### PR TITLE
Fix for PHP Catchable fatal error:  Object of class Terminus\Session could not be converted to string

### DIFF
--- a/php/commands/auth.php
+++ b/php/commands/auth.php
@@ -156,7 +156,7 @@ class Auth_Command extends Terminus_Command {
     $response = Request::send($endpoint, "GET", array(
       'allow_redirects'=>true,
       'cookies'=>
-        array('X-Pantheon-Session'=>$this->session)
+        array('X-Pantheon-Session'=>$this->session->get())
       )
     );
 


### PR DESCRIPTION
Command: `terminus auth getUUIDFromSession`
