### PR TITLE
Just one type of exception provides response object.

### DIFF
--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -153,9 +153,14 @@ abstract class Terminus_Command {
       );
       $cache->put_data($cachekey, $data);
       return $data;
-    } catch( Exception $e ) {
+    } catch( Guzzle\Http\Exception\BadResponseException $e ) {
       $response = $e->getResponse();
       \Terminus::error("%s", $response->getBody(TRUE) );
+    } catch( Guzzle\Http\Exception\BadResponseException $e ) {
+      $request = $e->getRequest();
+      \Terminus::error("Request %s had failed: %s", (string)$request, $e->getMessage() );
+    } catch( Exception $e ) {
+      \Terminus::error("Unrecognised request failure: %s", $e->getMessage() );
     }
 
   }

--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -156,7 +156,7 @@ abstract class Terminus_Command {
     } catch( Guzzle\Http\Exception\BadResponseException $e ) {
       $response = $e->getResponse();
       \Terminus::error("%s", $response->getBody(TRUE) );
-    } catch( Guzzle\Http\Exception\BadResponseException $e ) {
+    } catch( Guzzle\Http\Exception\HttpException $e ) {
       $request = $e->getRequest();
       \Terminus::error("Request %s had failed: %s", (string)$request, $e->getMessage() );
     } catch( Exception $e ) {


### PR DESCRIPTION
Fix issue where an untyped exception was requested to hold response object.
If error happens earlier (i.e. `cURL` error) this is not true and process fail to cleanly abort.
