### PR TITLE
Issue #84: Don't run invalid_positionals() on the `help` command

### DIFF
--- a/php/Terminus/Dispatcher/Subcommand.php
+++ b/php/Terminus/Dispatcher/Subcommand.php
@@ -177,9 +177,11 @@ class Subcommand extends CompositeCommand {
       exit(1);
     }
 
-    $invalid = $validator->invalid_positionals($args);
-    if($invalid) {
-      \Terminus::error("Invalid positional value: $invalid");
+    if ( $this->name != 'help') {
+      $invalid = $validator->invalid_positionals($args);
+      if($invalid) {
+        \Terminus::error("Invalid positional value: $invalid");
+      }
     }
 
     $unknown_positionals = $validator->unknown_positionals($args);


### PR DESCRIPTION
The positional arguments for the `help` command, apparently, don't
validate the same way that the other commands do. As a result,
invalid_positionals() will return the argument as invalid every
time.

Maybe it seems a little harsh to completely ignore validation? I'm
sure there's a better way to make this happen, and to validate the
positional arguments. But, here's a stab at it, at least.

Signed-off-by: Elliot Voris elliot@voris.me
