### PR TITLE
site hostname should not cache

### DIFF
--- a/php/Terminus/Environment.php
+++ b/php/Terminus/Environment.php
@@ -176,7 +176,10 @@ class Environment {
    * list hotnames for environment
    */
   public function hostnames() {
+    $current_nocache = \Terminus::get_config('nocache');
+    \Terminus::set_config('nocache',true);
     $response = \Terminus_Command::request("sites", $this->site->getId(), 'environments/' . $this->name . '/hostnames', 'GET');
+    \Terminus::set_config('nocache',$current_nocache);
     return $response['data'];
   }
 


### PR DESCRIPTION
Hi!

Ok, I've been down three different rabbit holes on this one. :) I think though I have it figured out. 

**Steps to reproduce:**

```
$ terminus site hostnames list --site=some-site-of-yours --env=dev
$ terminus site hostnames list --site=some-other-site-of-yours --env=dev
```

**Expected output:**
The hostname for each site requested

**Actual Output:**
The hostname for the first requested site, duplicated

**Example:**

```
$ php terminus site hostnames list --site=empty --env=dev --nocache
+-----------------------+-------------+--------------------------------------+
| Domain                | Environment | Site                                 |
+-----------------------+-------------+--------------------------------------+
| dev-empty.pantheon.io | dev         | eab44ac4-feec-46b2-9d7d-1d05000fbe17 |
+-----------------------+-------------+--------------------------------------+

$ terminus site hostnames list --site=cli-test-1 --env=dev
+-----------------------+-------------+--------------------------------------+
| Domain                | Environment | Site                                 |
+-----------------------+-------------+--------------------------------------+
| dev-empty.pantheon.io | dev         | eab44ac4-feec-46b2-9d7d-1d05000fbe17 |
+-----------------------+-------------+--------------------------------------+

```

In the example above, 'empty' is a valid site name in my account. I can specify any valid site name and it will return the result for 'empty', until I either create a new site, or use the `--nocache` flag.

Suggested fix:
I've patched Environment to turn off caching before it makes the request and then turn it back on. This works and works fine. However, a better solution in the long run may be to cache each hostname in separate files instead of just one file per user.  That means we've got to worry about invalidating them on change or delete, so it may not be the best solution. Anyhow, this one works. :)

Cheers!
=C=
