### PR TITLE
Dashboard command did not check for --yes in config

### DIFF
--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -235,17 +235,18 @@ class Site_Command extends Terminus_Command {
   }
 
   /**
-   * Open the Pantheon site dashboard a browser
+   * Open the Pantheon site dashboard in a browser
    *
    * ## OPTIONS
    *
    * [--site=<site>]
    * : site dashboard to open
    *
+   * @subcommand dashboard
   */
   public function dashboard($args, $assoc_args) {
     $site = SiteFactory::instance(Input::site($assoc_args));
-    Terminus::confirm("Do you want to open your dashboard link in a web browser?");
+    Terminus::confirm("Do you want to open your dashboard link in a web browser?", Terminus::get_config());
     $command = sprintf("open 'https://dashboard.getpantheon.com/sites/%s'", $site->getId());
     exec($command);
   }


### PR DESCRIPTION
As pointed out in Issue #108, when running `terminus site dashboard`
with the --yes flag, the command still asked for confirmation.

The call to `Terminus::confirm` takes an optional call for the
current configuration. `get_config()` is used elsewhere to specify
JSON, Bash, Yes, etc. Here, however, it looks like that was
overlooked at some point.

Signed-off-by: Elliot Voris elliot@voris.me
