### PR TITLE
Allow a `--print` flag for dashboard URL

### DIFF
--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -89,7 +89,7 @@ class Input {
       return $args[$key];
     }
 
-    return self::menu($choices, $default='dev', "Select $label", true);
+    return self::menu($choices, $default='dev', $label, true);
 
   }
 

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -261,7 +261,7 @@ class Site_Command extends Terminus_Command {
     }
     $site = SiteFactory::instance(Input::site($assoc_args));
     $env = Input::optional( 'env', $assoc_args );
-    $env = $env ? sprintf ( "#%s", $env ) : null;
+    $env = $env ? sprintf( "#%s", $env ) : null;
     $url = sprintf("https://dashboard.getpantheon.com/sites/%s%s", $site->getId(), $env);
     if ( isset($assoc_args['print']) ) {
       Logger::coloredOutput("%GDashboard URL:%n " . $url);

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -260,7 +260,8 @@ class Site_Command extends Terminus_Command {
         $cmd = "start"; break;
     }
     $site = SiteFactory::instance(Input::site($assoc_args));
-    $env = @$assoc_args['env'] ? sprintf("#%s", $assoc_args['env']) : null;
+    $env = Input::optional( 'env', $assoc_args );
+    $env = $env ? sprintf ( "#%s", $env ) : null;
     $url = sprintf("https://dashboard.getpantheon.com/sites/%s%s", $site->getId(), $env);
     if ( isset($assoc_args['print']) ) {
       Logger::coloredOutput("%GDashboard URL:%n " . $url);

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -243,19 +243,26 @@ class Site_Command extends Terminus_Command {
    * : site dashboard to open
    *
    * [--print]
-   * : don't try to open the link, just print it to the console (useful
-   * if you're not using Mac OS X)
+   * : don't try to open the link, just print it to the console
    *
    * @subcommand dashboard
   */
   public function dashboard($args, $assoc_args) {
+    switch ( php_uname('s') ) {
+      case "Linux":
+        $cmd = "xdg-open"; break;
+      case "Darwin":
+        $cmd = "open"; break;
+      case "Windows NT":
+        $cmd = "start"; break;
+    }
     $site = SiteFactory::instance(Input::site($assoc_args));
     if ( isset($assoc_args['print']) ) {
       Logger::coloredOutput("%GDashboard URL:%n " . sprintf('https://dashboard.getpantheon.com/sites/%s', $site->getId()));
     }
     else {
       Terminus::confirm("Do you want to open your dashboard link in a web browser?", Terminus::get_config());
-      $command = sprintf("open 'https://dashboard.getpantheon.com/sites/%s'", $site->getId());
+      $command = sprintf("%s https://dashboard.getpantheon.com/sites/%s", $cmd, $site->getId());
       exec($command);
     }
   }

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -242,8 +242,11 @@ class Site_Command extends Terminus_Command {
    * [--site=<site>]
    * : site dashboard to open
    *
+   * [--env=<env>]
+   * : site environment to display in the dashboard
+   *
    * [--print]
-   * : don't try to open the link, just print it to the console
+   * : don't try to open the link, just print it
    *
    * @subcommand dashboard
   */
@@ -257,12 +260,14 @@ class Site_Command extends Terminus_Command {
         $cmd = "start"; break;
     }
     $site = SiteFactory::instance(Input::site($assoc_args));
+    $env = @$assoc_args['env'] ? sprintf("#%s", $assoc_args['env']) : null;
+    $url = sprintf("https://dashboard.getpantheon.com/sites/%s%s", $site->getId(), $env);
     if ( isset($assoc_args['print']) ) {
-      Logger::coloredOutput("%GDashboard URL:%n " . sprintf('https://dashboard.getpantheon.com/sites/%s', $site->getId()));
+      Logger::coloredOutput("%GDashboard URL:%n " . $url);
     }
     else {
       Terminus::confirm("Do you want to open your dashboard link in a web browser?", Terminus::get_config());
-      $command = sprintf("%s https://dashboard.getpantheon.com/sites/%s", $cmd, $site->getId());
+      $command = sprintf("%s %s", $cmd, $url);
       exec($command);
     }
   }

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -242,13 +242,22 @@ class Site_Command extends Terminus_Command {
    * [--site=<site>]
    * : site dashboard to open
    *
+   * [--print]
+   * : don't try to open the link, just print it to the console (useful
+   * if you're not using Mac OS X)
+   *
    * @subcommand dashboard
   */
   public function dashboard($args, $assoc_args) {
     $site = SiteFactory::instance(Input::site($assoc_args));
-    Terminus::confirm("Do you want to open your dashboard link in a web browser?", Terminus::get_config());
-    $command = sprintf("open 'https://dashboard.getpantheon.com/sites/%s'", $site->getId());
-    exec($command);
+    if ( isset($assoc_args['print']) ) {
+      Logger::coloredOutput("%GDashboard URL:%n " . sprintf('https://dashboard.getpantheon.com/sites/%s', $site->getId()));
+    }
+    else {
+      Terminus::confirm("Do you want to open your dashboard link in a web browser?", Terminus::get_config());
+      $command = sprintf("open 'https://dashboard.getpantheon.com/sites/%s'", $site->getId());
+      exec($command);
+    }
   }
 
   /**


### PR DESCRIPTION
Issue #111:

In case the Terminus is being run in a Linux environment, the command
`open http://example.com` will fail.

The `--print` flag will allow the URL to simply be printed to STDOUT
and the user then can copy/paste or do whatever s/he pleases.

Signed-off-by: Elliot Voris elliot@voris.me
