### PR TITLE
Use `getError()` for Guzzle CurlException

### DIFF
--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -161,7 +161,7 @@ abstract class Terminus_Command {
       \Terminus::error("%s", $response->getBody(TRUE) );
     } catch( Guzzle\Http\Exception\HttpException $e ) {
       $request = $e->getRequest();
-      \Terminus::error("Request %s had failed: %s", (string)$request, $e->getMessage() );
+      \Terminus::error("Request %s had failed: %s", array((string)$request, $e->getMessage()) );
     } catch( Exception $e ) {
       \Terminus::error("Unrecognised request failure: %s", $e->getMessage() );
     }


### PR DESCRIPTION
Issue #124

The `getResponse()` method is not a valid method for Guzzle's
CurlException class. `getError()` seems to be doing the trick,
though.

Further, the `getError()` method doesn't have a `getBody()` member
function. It just returns the error.

Signed-off-by: Elliot Voris elliot@voris.me
