### PR TITLE
Removing single-quotes chmod mode

### DIFF
--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -216,7 +216,7 @@ class Sites_Command extends Terminus_Command {
     $h = fopen($location, 'w+');
     fwrite($h, $content);
     fclose($h);
-    chmod($location, '0777');
+    chmod($location, 0777);
     Logger::coloredOutput("%2%K$message%n");
 
     if ($json) {


### PR DESCRIPTION
Issue #126 

The `terminus sites aliases` command left me with `-r----x--t` for
my alias file permissions. Trying to update them would yell at me
about not having write-permissions.

Removing the single-quotes from around "0777" in the `chmod`
command has made the operation work right on my Linux machine.

Signed-off-by: Elliot Voris elliot@voris.me
