### PR TITLE
Changing upstream updates argument to be > 0 vs == 1. 

### DIFF
--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -1247,7 +1247,7 @@ class Site_Command extends Terminus_Command {
      if(isset($upstream->remote_url) && isset($upstream->behind)) {
        // The $upstream object returns a value of [behind] -> 1 if there is an
        // upstream update that has not been applied to Dev.
-       $data[$upstream->remote_url] = ($upstream->behind == 1 ? "Updates Available":"Up-to-date");
+       $data[$upstream->remote_url] = ($upstream->behind > 0 ? "Updates Available":"Up-to-date");
 
        $this->_constructTableForResponse($data, array('Upstream','Status') );
        if (!isset($upstream) OR empty($upstream->update_log)) Terminus::success("No updates to show");


### PR DESCRIPTION
The returned int value is actually the # of updates the site is behind, rather than a 0|1 False|True. You'll want to triple check this to make sure I didn't miss something. I was seeing my upstreams returning a "No updates" value but showing that there were 2 updates available. Debugging the behind value showed an returning int value of 2.
