### PR TITLE
Fix parsing of 'terminus site info' output in create-local.sh

### DIFF
--- a/scripts/create-local.sh
+++ b/scripts/create-local.sh
@@ -5,7 +5,7 @@ LOCAL_DIR="/srv/www/$1"; #should be an empty dir
 DB_NAME="pantheon_$( echo $1 | sed -r 's/-//g')"
 DBUSER="$( echo $1 | sed -r 's/-//g')"
 DBPASS="$( echo $1 | sed -r 's/-//g')"
-SITE_ID=$( $TERMINUS site info --site=$SITENAME --bash --nocache=1 | grep id | awk '{print $2}' )
+SITE_ID=$( $TERMINUS site info --site=$SITENAME --bash --nocache=1 | grep ^id | awk '{print $2}' )
 GIT_REMOTE="ssh://codeserver.dev.$SITE_ID@codeserver.dev.$SITE_ID.drush.in:2222/~/repository.git"
 echo "GIT_REMOTE=$GIT_REMOTE"
 


### PR DESCRIPTION
The output from 'terminus site info' includes a 'holder_id' as well as an 'id'. We are only interested in the 'id', but the existing logic greps for 'id', and thus picks up both lines, breaking the parsing later in the script. 
