### PR TITLE
Allow `sites create` command to be passed `--org=None`; Fix Imports on Create

### DIFF
--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -7,6 +7,8 @@ use \Terminus\Products;
 
 class Input {
 
+  public static $NULL_INPUTS = array('', 'false', 'None', 'Null', '0');
+
   static public function environment($existing, $default, $message) {
 
     if (!$message) {
@@ -75,8 +77,10 @@ class Input {
     if (isset($args[$key]) AND array_key_exists($args[$key], $flip)) {
       // if we have a valid name provided and we need the id
       return $flip[$args[$key]];
-    } elseif(isset($args[$key]) AND  array_key_exists($args[$key],$orglist)) {
+    } elseif(isset($args[$key]) AND array_key_exists($args[$key], $orglist)) {
       return $args[$key];
+    } elseif(isset($args[$key]) AND in_array($args[$key], self::$NULL_INPUTS)) {
+      return $default;
     }
 
     $orglist = Input::orglist();

--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -149,32 +149,27 @@ class Sites_Command extends Terminus_Command {
   * : Url of archive to import
   *
   * [--name=<name>]
+  * : (deprecated) use --site instead
+  *
+  * [--site=<site>]
   * : Name of the site to create (machine-readable)
   *
   * [--label=<label>]
   * : Label for the site
   *
   * [--org=<org>]
-  * : UUID of organization to add this site to
+  * : UUID of organization to add this site to; or "None"
   *
   * @subcommand create-from-import
   */
   public function import($args, $assoc_args) {
     $url = Input::string($assoc_args, 'url', "Url of archive to import");
-    $label = Input::string($assoc_args, 'label', "Human readable label for the site");
-    $slug = Utils\sanitize_name( $label );
-    $name = Input::string($assoc_args, 'name', "Machine name of the site; used as part of the default URL [ if left blank will be $slug]");
-    $name = $name ? $name : $slug;
-    $organization = Terminus::menu(Input::orglist(), false, "Choose organization");
     if (!$url) {
       Terminus::error("Please enter a url.");
     }
-    Terminus::launch_self('sites', array('create'), array(
-      'label' => $label,
-      'name'  => $name,
-      'org'   => $organization,
-    ));
-    Terminus::launch_self('site', array('import'), array('url'=>$url, 'site'=>$name, 'nocache' => True));
+    $assoc_args['import'] = url;
+
+    $self->create($args, $assoc_args);
   }
 
   /**

--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -113,9 +113,12 @@ class Sites_Command extends Terminus_Command {
     if ($orgid = Input::orgid($assoc_args,'org', false)) {
       $data['organization_id'] = $orgid;
     }
-    $product = Input::product($assoc_args,'product');
-    $data['deploy_product'] = array('product_id' => $product['id']);
-    Terminus::line(sprintf("Creating new %s installation ... ", $product['longname']));
+    if (!isset($assoc_args['import'])) {
+      $product = Input::product($assoc_args,'product');
+      $data['deploy_product'] = array('product_id' => $product['id']);
+      Terminus::line(sprintf("Creating new %s installation ... ", $product['longname']));
+    }
+
     $params = array( 'body' => json_encode($data) , 'headers'=>array('Content-type'=>'application/json') );
 
     // run the workflow
@@ -124,16 +127,23 @@ class Sites_Command extends Terminus_Command {
     $workflow->setParams($data);
     $workflow->start();
     $workflow->refresh();
+
     $details = $workflow->status();
+    $site_id = $details->waiting_for_task->site_id;
+
     if ($details->result !== 'failed' AND $details->result !== 'aborted') {
-      Terminus\Loggers\Regular::coloredOutput('%G'.vsprintf('New "site" %s now building with "UUID" %s', array($details->waiting_for_task->params->site_name, $details->waiting_for_task->params->site_id)));
+      Terminus\Loggers\Regular::coloredOutput('%G'.vsprintf('New "site" %s now building with "UUID" %s', array($data['site_name'], $site_id)));
     }
     $workflow->wait();
     Terminus::success("Pow! You created a new site!");
     $this->cache->flush(null,'session');
 
     if (isset($assoc_args['import'])) {
-      Terminus::launch_self('site', array('import'), array('url'=>$assoc_args['import'], 'site'=>$data['name'], 'nocache' => True));
+      Terminus::launch_self('site', array('import'), array(
+        'url' => $assoc_args['import'],
+        'site' => $data['site_name'],
+        'nocache' => True
+      ));
     }
 
     return true;
@@ -169,7 +179,7 @@ class Sites_Command extends Terminus_Command {
     }
     $assoc_args['import'] = url;
 
-    $self->create($args, $assoc_args);
+    Terminus::launch_self('sites', array('create'), $assoc_args);
   }
 
   /**

--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -90,7 +90,7 @@ class Sites_Command extends Terminus_Command {
    * : Label for the site
    *
    * [--org=<org>]
-   * : UUID of organization to add this site to
+   * : UUID of organization to add this site to; or "None"
    *
    * [--import=<url>]
    * : A url to import a valid archive from


### PR DESCRIPTION
Includes:
- On `sites create`: can now pass `--org=None` or `--org=0` (or a couple other null-ish options) in order to avoid selecting an Org
-  On `sites create`: Allows skipping of product selection when importing an Archive on create (imports will automatically detect a framework)
-  On `sites create` and `sites import`: Simplified and fixed Create+Import, which also happened to be broken because it was passing `$data['name']`instead of `$data['site_name']` to the import function

This fixes #200
