### PR TITLE
Better guard $site->info() calls.

### DIFF
--- a/php/Terminus/Site.php
+++ b/php/Terminus/Site.php
@@ -121,10 +121,12 @@ class Site {
    */
   public function info($key = null) {
     $info = $this->information;
-    if ($key AND property_exists($info, $key)) {
-      return $info->$key;
+    if ($key) {
+      return property_exists($info, $key) ? $info->$key : null;
     }
-    return $this->information;
+    else {
+      return $info;
+    }
   }
 
   /**


### PR DESCRIPTION
Don't return the full site object if `$site->info('somekey')` is looking for `somekey` that does not exist.
