### PR TITLE
Noting that connection mode can't be changed on test/live

### DIFF
--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -207,6 +207,9 @@ class Site_Command extends Terminus_Command {
       $action = 'set';
     }
     $env = Input::env($assoc_args, 'env');
+    if (($env == 'test' || $env == 'live') && $action == 'set') {
+      Terminus::error("Connection mode cannot be set in Test or Live environments");
+    }
     $data = $headers = array();
     switch($action) {
       case 'show':


### PR DESCRIPTION
Test and Live environments can't be connected with through Sftp
or Git by the user. So, we'll tell them that a command trying to
set the mode on either of those environments is uselss and futile.

Signed-off-by: Elliot J. Voris elliot@voris.me
