### PR TITLE
Fixed logout

### DIFF
--- a/php/commands/auth.php
+++ b/php/commands/auth.php
@@ -89,7 +89,7 @@ class Auth_Command extends Terminus_Command {
    */
   public function logout() {
     Terminus::line( "Logging out of Pantheon." );
-    Terminus::launch_self("cli",array('cache-clear'));
+    $this->cache->flush();
   }
 
   /**


### PR DESCRIPTION
Formerly, logout was using the cache_clear command which flushes the cache with a flag which explicitly excludes the session from clearing, thereby making logout impossible.
