### PR TITLE
terminus wp: Send “Running wp…” to STDERR

### DIFF
--- a/php/commands/wp.php
+++ b/php/commands/wp.php
@@ -69,7 +69,7 @@ class WPCLI_Command extends CommandWithSSH {
         $flags .= "--$k ";
       }
     }
-    fputs( STDERR, vsprintf( "Running wp %s %s on %s-%s\n", array($command,$flags,$site->getName(),$environment) ) );
+    fputs( STDERR, vsprintf( "Running wp %s on %s-%s\n", array(trim("$command $flags"),$site->getName(),$environment) ) );
     $this->send_command($server, 'wp', $args, $assoc_args );
 
   }

--- a/php/commands/wp.php
+++ b/php/commands/wp.php
@@ -69,7 +69,7 @@ class WPCLI_Command extends CommandWithSSH {
         $flags .= "--$k ";
       }
     }
-    Terminus::line( "Running wp %s %s on %s-%s", array($command,$flags,$site->getName(),$environment));
+    fputs( STDERR, vsprintf( "Running wp %s %s on %s-%s\n", array($command,$flags,$site->getName(),$environment) ) );
     $this->send_command($server, 'wp', $args, $assoc_args );
 
   }


### PR DESCRIPTION
The informational (verbose) message about what command is running gets in the way of scripts capturing the output. For instance:

``` bash
version=$(terminus wp core version --site=example)
echo $version
# => Running wp core version on example-dev 4.2.2
```

The informational message should be sent to `STDERR` instead.

As an aside, the `Terminus\Loggers\Regular` class should expose a public method for writing to `STDERR`.
