### PR TITLE
Move SitesCache invocation out of Site model

### DIFF
--- a/php/Terminus/Site.php
+++ b/php/Terminus/Site.php
@@ -4,7 +4,6 @@ namespace Terminus;
 use Terminus\Request;
 use Terminus\Deploy;
 use \Terminus\SiteWorkflow;
-use Terminus\SitesCache;
 use \Terminus_Command;
 
 class Site {
@@ -47,18 +46,13 @@ class Site {
     return $this;
   }
 
-  public static function createFromName($sitename) {
-    $sites_cache = new SitesCache();
-    $site_id = $sites_cache->find($sitename);
+  public function fetch() {
+    $response = Terminus_Command::simple_request(sprintf('sites/%s?site_state=true', $this->id));
+    $this->attributes = $response['data'];
+    # backwards compatibility
+    $this->information = $this->attributes;
 
-    if ($site_id) {
-      $response = Terminus_Command::simple_request('sites/' . $site_id . '?site_state=true');
-      $site_data = $response['data'];
-      $site = new Site($site_data);
-      return $site;
-    } else {
-      throw new \Exception('We cannot access a site with this name');
-    }
+    return $this;
   }
 
   /**

--- a/php/Terminus/SitesCache.php
+++ b/php/Terminus/SitesCache.php
@@ -13,12 +13,20 @@ class SitesCache {
   protected $cache;
   protected $cachekey = 'sites';
 
+  /**
+   * Searches the SitesCache for an ID given a name
+   *
+   */
+  static function find($name, $options = array()) {
+    $instance = new SitesCache();
+    return $instance->_find($name, $options);
+  }
+
   public function __construct() {
     $this->cache = Terminus::get_cache();
   }
 
-  // Returns the UUID of the site
-  public function find($name, $options = array()) {
+  public function _find($name, $options = array()) {
     if (!isset($options['rebuild'])) {
       $options['rebuild'] = true;
     }

--- a/php/Terminus/SitesCache.php
+++ b/php/Terminus/SitesCache.php
@@ -26,7 +26,7 @@ class SitesCache {
     $this->cache = Terminus::get_cache();
   }
 
-  public function _find($name, $options = array()) {
+  private function _find($name, $options = array()) {
     if (!isset($options['rebuild'])) {
       $options['rebuild'] = true;
     }

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -13,6 +13,8 @@ use \Terminus\Loggers\Regular as Logger;
 use \Terminus\Helpers\Input;
 use \Terminus\Deploy;
 use \Terminus\SiteWorkflow;
+use Terminus\SitesCache;
+
 
 class Site_Command extends Terminus_Command {
 
@@ -288,7 +290,10 @@ class Site_Command extends Terminus_Command {
    */
   public function info($args, $assoc_args) {
     $sitename = Input::site($assoc_args);
-    $site = Site::createFromName($sitename);
+    $site_id = SitesCache::find($sitename);
+    $site = new Site($site_id);
+
+    $site->fetch();
 
     if (isset($assoc_args['field'])) {
       $field = $assoc_args['field'];


### PR DESCRIPTION
Make responsibilities a little clearer and the Site model a little more free-standing by removing any reliance on caching.

Question: what's the best way to shadow static methods with instance methods? Apparently PHP won't let them have the same name.
