### PR TITLE
Fixed object-as-array error

### DIFF
--- a/php/Terminus/SiteWorkflow.php
+++ b/php/Terminus/SiteWorkflow.php
@@ -53,9 +53,11 @@ class SiteWorkflow {
     if (!\Terminus\utils\result_is_multiobj($response['data'])) {
       $response['data'] = array($response['data']);
     }
-    $this->status = $response['data'][0];
-    $this->id = $response['data'][0]->id;
-    $this->result = $response['data'][0]->result;
+    if(is_array($response['data'])) {
+      $this->status = $response['data'][0];
+      $this->id = $response['data'][0]->id;
+      $this->result = $response['data'][0]->result;
+    }
     return $this;
   }
 
@@ -65,9 +67,11 @@ class SiteWorkflow {
     if (!\Terminus\utils\result_is_multiobj($response['data'])) {
       $response['data'] = array( $response['data'] );
     }
-    $this->status = $response['data'][0];
-    $this->id = $response['data'][0]->id;
-    $this->result = $response['data'][0]->result;
+    if(is_array($response['data'])) {
+      $this->status = $response['data'][0];
+      $this->id = $response['data'][0]->id;
+      $this->result = $response['data'][0]->result;
+    }
   }
 
   /**


### PR DESCRIPTION
When adding multidev environments, I have been getting this error:

```
{tesladethray@Rosie:~/Pantheon/cli} terminus site create-env --site=saras-qa-test --env=multidev6 --from-env=dev
PHP Fatal error:  Cannot use object of type stdClass as array in /Users/tesladethray/pantheon/cli/php/Terminus/SiteWorkflow.php on line 56
PHP Stack trace:
PHP   1. {main}() /Users/tesladethray/pantheon/cli/php/boot-fs.php:0
PHP   2. include() /Users/tesladethray/pantheon/cli/php/boot-fs.php:22
PHP   3. Terminus\Runner->run() /Users/tesladethray/pantheon/cli/php/terminus.php:41
PHP   4. Terminus\Runner->_run_command() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:155
PHP   5. Terminus\Runner->run_command() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:75
PHP   6. Terminus\Dispatcher\Subcommand->invoke() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:68
PHP   7. call_user_func:{/Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227
PHP   8. Terminus\Dispatcher\CommandFactory::Terminus\Dispatcher\{closure}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227
PHP   9. call_user_func:{/Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35
PHP  10. Site_Command->create_env() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35
PHP  11. Terminus\Site->createEnvironment() /Users/tesladethray/pantheon/cli/php/commands/site.php:652
PHP  12. Terminus\SiteWorkflow->start() /Users/tesladethray/pantheon/cli/php/Terminus/Site.php:342

Fatal error: Cannot use object of type stdClass as array in /Users/tesladethray/pantheon/cli/php/Terminus/SiteWorkflow.php on line 56

Call Stack:
    0.0004     229176   1. {main}() /Users/tesladethray/pantheon/cli/php/boot-fs.php:0
    0.0007     243880   2. include('/Users/tesladethray/pantheon/cli/php/terminus.php') /Users/tesladethray/pantheon/cli/php/boot-fs.php:22
    0.0068    1197480   3. Terminus\Runner->run() /Users/tesladethray/pantheon/cli/php/terminus.php:41
    0.0138    1801936   4. Terminus\Runner->_run_command() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:155
    0.0138    1802088   5. Terminus\Runner->run_command() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:75
    0.0138    1803576   6. Terminus\Dispatcher\Subcommand->invoke() /Users/tesladethray/pantheon/cli/php/Terminus/Runner.php:68
    0.0152    1863936   7. call_user_func:{/Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227
    0.0153    1864000   8. Terminus\Dispatcher\CommandFactory::Terminus\Dispatcher\{closure}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/Subcommand.php:227
    0.0307    2517176   9. call_user_func:{/Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35}() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35
    0.0307    2517352  10. Site_Command->create_env() /Users/tesladethray/pantheon/cli/php/Terminus/Dispatcher/CommandFactory.php:35
    1.0672    4601728  11. Terminus\Site->createEnvironment() /Users/tesladethray/pantheon/cli/php/commands/site.php:652
    1.0677    4637176  12. Terminus\SiteWorkflow->start() /Users/tesladethray/pantheon/cli/php/Terminus/Site.php:342
```

This might not be the right solution - the data that causes the error looks more like a request than a response, so it'd be worth investigating into why it's being passed the wrong thing now when it wasn't before. That being said, this solution works and un-blocks several steps of the QA report project. Thoughts?
