### PR TITLE
Create actions to merge Multidev to/from Dev

### DIFF
--- a/php/Terminus/Collections/Environments.php
+++ b/php/Terminus/Collections/Environments.php
@@ -30,7 +30,6 @@ class Environments {
    * List Environment IDs, with Dev/Test/Live first
    *
    */
-
   public function ids() {
     $ids = array_keys($this->models);
 
@@ -42,11 +41,24 @@ class Environments {
     return $ids;
   }
 
+  /**
+   * Returns a list of all Multidev Environments
+   *
+   */
+  public function multidev() {
+    $environments = array_filter($this->all(), function($environment) {
+      return $environment->isMultidev();
+    });
+    return $environments;
+  }
+
   public function get($id) {
-    return array_key_exists($id, $this->models) ? $this->models[$id] : null;
+    $environment = array_key_exists($id, $this->models) ? $this->models[$id] : null;
+    return $environment;
   }
 
   public function all() {
-    return array_values($this->models);
+    $environments = array_values($this->models);
+    return $environments;
   }
 }

--- a/php/Terminus/Environment.php
+++ b/php/Terminus/Environment.php
@@ -301,10 +301,10 @@ class Environment {
   }
 
   /**
-   * Merge the Master Branch (Dev Environment) into this Multidev Branch (Environment)
+   * Merge code from the Dev Environment into this Multidev Environment
    *
    */
-  public function mergeFromMaster($options = array()) {
+  public function mergeFromDev($options = array()) {
     if (!$this->isMultidev()) {
       throw new Exception(sprintf("The %s environment is not a multidev environment", $this->id));
     }
@@ -323,10 +323,10 @@ class Environment {
   }
 
   /**
-   * Merge this Multidev Branch (Environment) into the Master Branch (Dev Environment)
+   * Merge code from this Multidev Environment into the Dev Environment
    *
    */
-  public function mergeToMaster($options = array()) {
+  public function mergeToDev($options = array()) {
     if (!$this->isMultidev()) {
       throw new Exception(sprintf("The %s environment is not a multidev environment", $this->id));
     }

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -698,6 +698,60 @@ class Site_Command extends Terminus_Command {
    }
 
    /**
+    * Merge a Multidev Environment into Dev Environment
+    *
+    * ## OPTIONS
+    *
+    * [--site=<site>]
+    * : Site to use
+    *
+    * [--env=<env>]
+    * : Name of multidev to environment to merge into Dev
+    *
+    * @subcommand merge-to-dev
+    */
+    public function merge_to_dev($args, $assoc_args) {
+      $site = SiteFactory::instance(Input::site($assoc_args));
+      $site->environmentsCollection->fetch();
+
+      $multidev_ids = array_map(function($env) { return $env->id; }, $site->environmentsCollection->multidev());
+      $multidev_id = Input::env($assoc_args, 'env', "Multidev environment to merge into Dev Environment", $multidev_ids);
+      $environment = $site->environmentsCollection->get($multidev_id);
+
+      $workflow = $environment->mergeToMaster();
+      $workflow->wait();
+
+      Terminus::success(sprintf('Merged the %s environment into Dev', $environment->id));
+    }
+
+    /**
+     * Merge the Dev Environment (Master) into a Multidev Environment
+     *
+     * ## OPTIONS
+     *
+     * [--site=<site>]
+     * : Site to use
+     *
+     * [--env=<env>]
+     * : Name of multidev to environment to merge Dev into
+     *
+     * @subcommand merge-from-dev
+     */
+     public function merge_from_dev($args, $assoc_args) {
+       $site = SiteFactory::instance(Input::site($assoc_args));
+       $site->environmentsCollection->fetch();
+
+       $multidev_ids = array_map(function($env) { return $env->id; }, $site->environmentsCollection->multidev());
+       $multidev_id = Input::env($assoc_args, 'env', "Multidev environment that the Dev Environment will be merged into", $multidev_ids);
+       $environment = $site->environmentsCollection->get($multidev_id);
+
+       $workflow = $environment->mergeFromMaster();
+       $workflow->wait();
+
+       Terminus::success(sprintf('Merged the Dev environment into the %s environment ', $environment->id));
+     }
+
+   /**
    * Delete a MultiDev environment
    *
    * ## OPTIONS

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -718,7 +718,7 @@ class Site_Command extends Terminus_Command {
       $multidev_id = Input::env($assoc_args, 'env', "Multidev environment to merge into Dev Environment", $multidev_ids);
       $environment = $site->environmentsCollection->get($multidev_id);
 
-      $workflow = $environment->mergeToMaster();
+      $workflow = $environment->mergeToDev();
       $workflow->wait();
 
       Terminus::success(sprintf('Merged the %s environment into Dev', $environment->id));
@@ -745,7 +745,7 @@ class Site_Command extends Terminus_Command {
        $multidev_id = Input::env($assoc_args, 'env', "Multidev environment that the Dev Environment will be merged into", $multidev_ids);
        $environment = $site->environmentsCollection->get($multidev_id);
 
-       $workflow = $environment->mergeFromMaster();
+       $workflow = $environment->mergeFromDev();
        $workflow->wait();
 
        Terminus::success(sprintf('Merged the Dev environment into the %s environment ', $environment->id));

--- a/tests/features/site_merge-from-dev.feature
+++ b/tests/features/site_merge-from-dev.feature
@@ -1,0 +1,10 @@
+Feature: site merge-from-dev
+
+  Scenario: Merge the Dev Environment into a Multidev Environment
+    @vcr site_merge-from-dev
+    Given I am authenticated
+    When I run "terminus site merge-from-dev --site=[[test_site_name]] --env=stuff"
+    Then I should get:
+    """
+    Merged the Dev environment into the stuff environment
+    """

--- a/tests/features/site_merge-to-dev.feature
+++ b/tests/features/site_merge-to-dev.feature
@@ -1,0 +1,10 @@
+Feature: site merge-to-dev
+
+  Scenario: Merge Multidev to dev environment
+    @vcr site_merge-to-dev
+    Given I am authenticated
+    When I run "terminus site merge-to-dev --site=[[test_site_name]] --env=stuff"
+    Then I should get:
+    """
+    Merged the stuff environment into Dev
+    """

--- a/tests/fixtures/site_merge-from-dev
+++ b/tests/fixtures/site_merge-from-dev
@@ -1,0 +1,144 @@
+
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Content-type: application/json
+        body: '{"email":"devuser@pantheon.io","password":"password1"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:12:02 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: d50548c0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Vary: Accept-Encoding
+        body: '{"session":"74d3797f-5ff0-432a-8fb8-388fcdb170e0:d50aa284-3af5-11e5-87c9-bc764e115846:ACXAGiGYTd8HZBN5OdgrL","expires_at":1441145522,"user_id":"74d3797f-5ff0-432a-8fb8-388fcdb170e0"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/74d3797f-5ff0-432a-8fb8-388fcdb170e0/sites'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:d50aa284-3af5-11e5-87c9-bc764e115846:ACXAGiGYTd8HZBN5OdgrL'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:12:03 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '1223'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: d603a5f0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"izfWXMC+dIJU6h1FYMoTlQ=="'
+            Vary: Accept-Encoding
+        body: '{"7f856d06-2242-4a72-aa63-5849d596eb70": {"information": {"created_by_user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "holder_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "name": "behat-test", "created": 1438707393, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "git://github.com/pantheon-systems/drops-7.git", "product_id": "8f4d5df2-c975-4e95-8c30-9615773d8b6a", "branch": "master"}, "owner": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "multidev": true, "last_code_push": {"timestamp": "2015-08-04T22:03:19", "user_uuid": null}, "preferred_zone": "onebox"}, "metadata": null}, "4fb7e186-a2a3-4d2f-8768-f0c77a733f0a": {"information": {"created_by_user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "holder_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "name": "testy", "created": 1438385883, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "git://github.com/pantheon-systems/drops-7.git", "product_id": "8f4d5df2-c975-4e95-8c30-9615773d8b6a", "branch": "master"}, "owner": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "last_code_push": {"timestamp": "2015-07-31T23:38:12", "user_uuid": null}, "preferred_zone": "onebox"}, "metadata": null}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/environments'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:d50aa284-3af5-11e5-87c9-bc764e115846:ACXAGiGYTd8HZBN5OdgrL'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:12:04 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: d6508d70-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"1TPKyH8Yo5V8Enjy4BrFYQ=="'
+            Vary: Accept-Encoding
+        body: '{"live": {"environment_created": 1438707394, "dns_zone": "onebox.pantheon.io", "randseed": "7RD8ULXX4EYUCYCYADB3SSPYL2T47O5T", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "dev": {"watchers": 1, "diffstat": {}, "on_server_development": true, "environment_created": 1438707393, "dns_zone": "onebox.pantheon.io", "randseed": "LH3VDXPHZKJRUCXWX5RVTFUU2S14ZW3F", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "31380a7312eba4dec46b5f8a107e7386eac02fd2", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "stuff": {"environment_created": 1438720898, "dns_zone": "onebox.pantheon.io", "randseed": "WDI9NK0OJ9E1DY1WBNFV5BQDWN7AOQRN", "target_ref": "refs/heads/stuff", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "31380a7312eba4dec46b5f8a107e7386eac02fd2", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "test": {"environment_created": 1438707393, "dns_zone": "onebox.pantheon.io", "randseed": "EYWBIE4WV6UP4LRJMOPPUDUH9UESAN55", "target_ref": "refs/tags/pantheon_test_2", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "f90ace276abbd540836e1e12c8f166320e9b8ee3", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}}'
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/environments/stuff/workflows'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:d50aa284-3af5-11e5-87c9-bc764e115846:ACXAGiGYTd8HZBN5OdgrL'
+            Content-type: application/json
+        body: '{"type":"merge_dev_into_cloud_development_environment","params":{"updatedb":false}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '202'
+            message: Accepted
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:12:05 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: d6978180-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Vary: Accept-Encoding
+        body: '{"environment_id": "stuff", "params": {"updatedb": false}, "role": "owner", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "task_ids": ["d69c2a8c-3af5-11e5-85d8-bc764e115846", "d69d2658-3af5-11e5-85d8-bc764e115846", "d6ab5a3e-3af5-11e5-85d8-bc764e115846", "d6ae35a6-3af5-11e5-85d8-bc764e115846"], "trace_id": "d6978180-3af5-11e5-b6a3-7fb233bbf6b7", "type": "merge_dev_into_cloud_development_environment", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "id": "d69b8f00-3af5-11e5-85d8-bc764e115846", "key": "1438725600", "waiting_for_task_id": "d69c2a8c-3af5-11e5-85d8-bc764e115846", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1438726324.65856, "reason": "", "environment": "stuff", "final_task_id": null, "result": null, "total_time": null, "active_description": "Merge code from master into \"stuff\"", "description": "Merge code from master into \"stuff\"", "step": 1, "number_of_tasks": 4, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=d6978180-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:07:04.658560Z&to_iso_date=now", "user": {"created_at": 1437160970, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "stuff", "fn_name": "trigger_task", "params": {"environment": "stuff", "task_type": "merge_code_from_environment", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "from_environment": "dev"}, "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "trace_id": "d6978180-3af5-11e5-b6a3-7fb233bbf6b7", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "workflow_id": "d69b8f00-3af5-11e5-85d8-bc764e115846", "id": "d69c2a8c-3af5-11e5-85d8-bc764e115846", "key": "1438725600", "responses": [], "created_at": 1438726324.662542, "queued_time": null, "run_time": null, "phase": "created", "allow_concurrent": false, "result": null, "total_time": null, "internal_reason": "", "build_url": null, "messages": {}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=d6978180-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:07:04.662542Z&to_iso_date=now", "type": "merge_code_from_environment"}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/workflows/d69b8f00-3af5-11e5-85d8-bc764e115846'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:d50aa284-3af5-11e5-87c9-bc764e115846:ACXAGiGYTd8HZBN5OdgrL'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:12:05 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: d76028b0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"sEO31T5zJsPO+CfDHeozgw=="'
+            Vary: Accept-Encoding
+        body: '{"environment_id": "stuff", "params": {"updatedb": false}, "role": "owner", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "task_ids": ["d69c2a8c-3af5-11e5-85d8-bc764e115846", "d69d2658-3af5-11e5-85d8-bc764e115846", "d6ab5a3e-3af5-11e5-85d8-bc764e115846", "d6ae35a6-3af5-11e5-85d8-bc764e115846"], "trace_id": "d6978180-3af5-11e5-b6a3-7fb233bbf6b7", "type": "merge_dev_into_cloud_development_environment", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "id": "d69b8f00-3af5-11e5-85d8-bc764e115846", "key": "7f856d06-2242-4a72-aa63-5849d596eb70", "waiting_for_task_id": "d69c2a8c-3af5-11e5-85d8-bc764e115846", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1438726324.65856, "reason": "", "environment": "stuff", "final_task_id": null, "result": "succeeded", "total_time": null, "active_description": "Merge code from master into \"stuff\"", "description": "Merge code from master into \"stuff\"", "step": 1, "number_of_tasks": 4, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=d6978180-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:07:04.658560Z&to_iso_date=now", "user": {"created_at": 1437160970, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "stuff", "fn_name": "trigger_task", "params": {"environment": "stuff", "task_type": "merge_code_from_environment", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "from_environment": "dev"}, "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "trace_id": "d6978180-3af5-11e5-b6a3-7fb233bbf6b7", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "workflow_id": "d69b8f00-3af5-11e5-85d8-bc764e115846", "id": "d69c2a8c-3af5-11e5-85d8-bc764e115846", "key": "1438725600", "responses": [], "created_at": 1438726324.662542, "queued_time": null, "run_time": null, "phase": "created", "allow_concurrent": false, "result": null, "total_time": null, "internal_reason": "", "build_url": null, "messages": {}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=d6978180-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:07:04.662542Z&to_iso_date=now", "type": "merge_code_from_environment"}}'

--- a/tests/fixtures/site_merge-to-dev
+++ b/tests/fixtures/site_merge-to-dev
@@ -1,0 +1,144 @@
+
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Content-type: application/json
+        body: '{"email":"devuser@pantheon.io","password":"password1"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:07:18 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 2c3d94e0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Vary: Accept-Encoding
+        body: '{"session":"74d3797f-5ff0-432a-8fb8-388fcdb170e0:2c4265f6-3af5-11e5-8afd-bc764e115846:oa841SYt1iIhIujzubMPC","expires_at":1441145238,"user_id":"74d3797f-5ff0-432a-8fb8-388fcdb170e0"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/74d3797f-5ff0-432a-8fb8-388fcdb170e0/sites'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:2c4265f6-3af5-11e5-8afd-bc764e115846:oa841SYt1iIhIujzubMPC'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:07:21 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '1223'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 2d83f790-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"izfWXMC+dIJU6h1FYMoTlQ=="'
+            Vary: Accept-Encoding
+        body: '{"7f856d06-2242-4a72-aa63-5849d596eb70": {"information": {"created_by_user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "holder_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "name": "behat-test", "created": 1438707393, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "git://github.com/pantheon-systems/drops-7.git", "product_id": "8f4d5df2-c975-4e95-8c30-9615773d8b6a", "branch": "master"}, "owner": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "multidev": true, "last_code_push": {"timestamp": "2015-08-04T22:03:19", "user_uuid": null}, "preferred_zone": "onebox"}, "metadata": null}, "4fb7e186-a2a3-4d2f-8768-f0c77a733f0a": {"information": {"created_by_user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "holder_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "name": "testy", "created": 1438385883, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "git://github.com/pantheon-systems/drops-7.git", "product_id": "8f4d5df2-c975-4e95-8c30-9615773d8b6a", "branch": "master"}, "owner": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "last_code_push": {"timestamp": "2015-07-31T23:38:12", "user_uuid": null}, "preferred_zone": "onebox"}, "metadata": null}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/environments'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:2c4265f6-3af5-11e5-8afd-bc764e115846:oa841SYt1iIhIujzubMPC'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:07:21 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 2dc434e0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"1TPKyH8Yo5V8Enjy4BrFYQ=="'
+            Vary: Accept-Encoding
+        body: '{"live": {"environment_created": 1438707394, "dns_zone": "onebox.pantheon.io", "randseed": "7RD8ULXX4EYUCYCYADB3SSPYL2T47O5T", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "dev": {"watchers": 1, "diffstat": {}, "on_server_development": true, "environment_created": 1438707393, "dns_zone": "onebox.pantheon.io", "randseed": "LH3VDXPHZKJRUCXWX5RVTFUU2S14ZW3F", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "31380a7312eba4dec46b5f8a107e7386eac02fd2", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "stuff": {"environment_created": 1438720898, "dns_zone": "onebox.pantheon.io", "randseed": "WDI9NK0OJ9E1DY1WBNFV5BQDWN7AOQRN", "target_ref": "refs/heads/stuff", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "31380a7312eba4dec46b5f8a107e7386eac02fd2", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}, "test": {"environment_created": 1438707393, "dns_zone": "onebox.pantheon.io", "randseed": "EYWBIE4WV6UP4LRJMOPPUDUH9UESAN55", "target_ref": "refs/tags/pantheon_test_2", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "f90ace276abbd540836e1e12c8f166320e9b8ee3", "styx_cluster": "styx-ben-onebox10.onebox.pantheon.io"}}'
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/environments/dev/workflows'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:2c4265f6-3af5-11e5-8afd-bc764e115846:oa841SYt1iIhIujzubMPC'
+            Content-type: application/json
+        body: '{"type":"merge_cloud_development_environment_into_dev","params":{"updatedb":false,"from_environment":"stuff"}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '202'
+            message: Accepted
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:07:22 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Vary: Accept-Encoding
+        body: '{"environment_id": "dev", "params": {"updatedb": false, "from_environment": "stuff"}, "role": "owner", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "task_ids": ["2e092316-3af5-11e5-8f9a-bc764e115846", "2e0a614a-3af5-11e5-8f9a-bc764e115846", "2e187b4a-3af5-11e5-8f9a-bc764e115846", "2e1aa1ae-3af5-11e5-8f9a-bc764e115846", "2e1be9ba-3af5-11e5-8f9a-bc764e115846", "2e2ab026-3af5-11e5-8f9a-bc764e115846", "2e2ce166-3af5-11e5-8f9a-bc764e115846"], "trace_id": "2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7", "type": "merge_cloud_development_environment_into_dev", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "id": "2e0833ac-3af5-11e5-8f9a-bc764e115846", "key": "1438725600", "waiting_for_task_id": "2e092316-3af5-11e5-8f9a-bc764e115846", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1438726041.835614, "reason": "", "environment": "dev", "final_task_id": null, "result": null, "total_time": null, "active_description": "Merge code into master", "description": "Merge code into master", "step": 1, "number_of_tasks": 7, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:02:21.835614Z&to_iso_date=now", "user": {"created_at": 1437160970, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "dev", "fn_name": "trigger_task", "params": {"environment": "dev", "task_type": "merge_code_from_environment", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "from_environment": "stuff"}, "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "trace_id": "2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "workflow_id": "2e0833ac-3af5-11e5-8f9a-bc764e115846", "id": "2e092316-3af5-11e5-8f9a-bc764e115846", "key": "1438725600", "responses": [], "created_at": 1438726041.841743, "queued_time": null, "run_time": null, "phase": "created", "allow_concurrent": false, "result": null, "total_time": null, "internal_reason": "", "build_url": null, "messages": {}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:02:21.841743Z&to_iso_date=now", "type": "merge_code_from_environment"}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/7f856d06-2242-4a72-aa63-5849d596eb70/workflows/2e0833ac-3af5-11e5-8f9a-bc764e115846'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/1.0.0 (php_version=5.5.24&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=74d3797f-5ff0-432a-8fb8-388fcdb170e0:2c4265f6-3af5-11e5-8afd-bc764e115846:oa841SYt1iIhIujzubMPC'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 04 Aug 2015 22:07:23 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 2ee8dec0-3af5-11e5-b6a3-7fb233bbf6b7
+            X-Frame-Options: deny
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"g+pObtMu62fqxn2Yc2iCtg=="'
+            Vary: Accept-Encoding
+        body: '{"environment_id": "dev", "params": {"updatedb": false, "from_environment": "stuff"}, "role": "owner", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "task_ids": ["2e092316-3af5-11e5-8f9a-bc764e115846", "2e0a614a-3af5-11e5-8f9a-bc764e115846", "2e187b4a-3af5-11e5-8f9a-bc764e115846", "2e1aa1ae-3af5-11e5-8f9a-bc764e115846", "2e1be9ba-3af5-11e5-8f9a-bc764e115846", "2e2ab026-3af5-11e5-8f9a-bc764e115846", "2e2ce166-3af5-11e5-8f9a-bc764e115846"], "trace_id": "2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7", "type": "merge_cloud_development_environment_into_dev", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "id": "2e0833ac-3af5-11e5-8f9a-bc764e115846", "key": "7f856d06-2242-4a72-aa63-5849d596eb70", "waiting_for_task_id": "2e092316-3af5-11e5-8f9a-bc764e115846", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1438726041.835614, "reason": "", "environment": "dev", "final_task_id": null, "result": "succeeded", "total_time": null, "active_description": "Merge code into master", "description": "Merge code into master", "step": 1, "number_of_tasks": 7, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:02:21.835614Z&to_iso_date=now", "user": {"created_at": 1437160970, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "dev", "fn_name": "trigger_task", "params": {"environment": "dev", "task_type": "merge_code_from_environment", "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "from_environment": "stuff"}, "site_id": "7f856d06-2242-4a72-aa63-5849d596eb70", "trace_id": "2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7", "user_id": "74d3797f-5ff0-432a-8fb8-388fcdb170e0", "workflow_id": "2e0833ac-3af5-11e5-8f9a-bc764e115846", "id": "2e092316-3af5-11e5-8f9a-bc764e115846", "key": "1438725600", "responses": [], "created_at": 1438726041.841743, "queued_time": null, "run_time": null, "phase": "created", "allow_concurrent": false, "result": null, "total_time": null, "internal_reason": "", "build_url": null, "messages": {}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=2e03fd00-3af5-11e5-b6a3-7fb233bbf6b7&from_iso_date=2015-08-04T22:02:21.841743Z&to_iso_date=now", "type": "merge_code_from_environment"}}'


### PR DESCRIPTION
This adds actions to the `site` command to manage merging between the Dev environment and Multidev environments.

To merge a multidev environment into the dev environment
`terminus site merge-to-dev --site=<site> --env=<multidev>`

To merge the dev environment into a multidev environment
`terminus site merge-from-dev --site=<site> --env=<multidev>`
