### PR TITLE
Improve `sites list` output to be proper list of hashes

### DIFF
--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -58,12 +58,11 @@ class Sites_Command extends Terminus_Command {
         'framework' => $cached_site['framework'],
         'memberships' => array_map(function($membership) {
           return $membership['name'];
-        }, $cached_site['memberships'])
+        }, array_values($cached_site['memberships']))
       );
-    }, $cached_sites);
+    }, array_values($cached_sites));
 
     $this->handleDisplay($rows);
-    return $rows;
   }
 
 


### PR DESCRIPTION
``` json
// before ...

{
    "site-team1": {
        "name": "site-team1",
        "id": "362fb473-719e-4188-a30e-d2672e83f65b",
        "service_level": "free",
        "framework": "unknown",
        "memberships": {
            "74d3797f-5ff0-432a-8fb8-388fcdb170e0": "Team"
        }
    }
}

// after ...

[
    {
        "name": "site-team1",
        "id": "362fb473-719e-4188-a30e-d2672e83f65b",
        "service_level": "free",
        "framework": "unknown",
        "memberships": [
            "Team"
        ]
    }
]
```

Progress towards #67.
