### PR TITLE
Change Packagist name to pantheon-systems/cli.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "terminus/terminus",
+  "name": "pantheon-systems/cli",
   "description": "A command line interface for Pantheon",
-  "keywords": [ "cli", "pantheon" ],
+  "keywords": [ "cli", "pantheon", "terminus", "drupal", "wordpress" ],
   "homepage": "http://getpantheon.com",
   "license": "MIT",
   "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ab736eb9d4b6c840f3bfc854a20aaa57",
+    "hash": "7afe71866222e71104072d543d9f7bcb",
+    "content-hash": "bb590aa882cbaf25fab9c94518fcb53a",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",


### PR DESCRIPTION
Currently, Terminus is called "terminus/terminus" in its composer.json, and therefore is terminus/terminus in Composer.

Traditionally, the Packagist name should mirror the GitHub repository name, so pantheon-systems/cli is a better choice than "terminus/terminus".

Not changing this will result in lasting, minor confusion.  Changing this may result in serious short-term consternation for existing users. I'm guessing that Terminus is not widely installed via Composer at the moment, so it might be a good time to fix this.
