### PR TITLE
Fix misspelled word, "enviroments", in help documentation

### DIFF
--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -963,7 +963,7 @@ class Site_Command extends TerminusCommand {
   }
 
   /**
-   * List enviroments for a site
+   * List environments for a site
    *
    * ## OPTIONS
    *


### PR DESCRIPTION
In the current version of Terminus (0.7.1 as of this writing), there's a misspelling in the help documentation of the description for the **terminus help site environments** command.

You can see this typo by running the following command:

`$ terminus help site`

The output will show the following information (edited for brevity):

```
NAME

  terminus site

DESCRIPTION

  actions on an individual site

SYNOPSIS

  terminus site <command>

SUBCOMMANDS

  attributes            Get or set site attributes
  ...
  environments          List enviroments for a site
```

This pull request fixes the misspelling of the word "enviroments" — _note the missing letter 'n'._
