### PR TITLE
Fixed undefined property $function in sites cache

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 #Change Log
 All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+##MASTER
+###Fixed
+- Undefined property "framework" error when running SitesCache functions (#433)
+
 ##[0.7.1] - 2015-08-21
 ###Fixed
 - PHP 5.3 incompatibility


### PR DESCRIPTION
Closes #375 
The same logic to create identical arrays of site data was re-used three times in SitesCache, and each time the API didn't return a value for the framework attribute, this error would appear. I condensed the logic into a single private function and made it so that framework can never be unset without un-setting it manually.
