### PR TITLE
Switched Terminus logger for katzgrau/KLogger

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "74bb6998cf1233236067c1f1c1a9c29e",
+    "hash": "46032f1a07f1f7bb2ffafb20728d9948",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -399,6 +399,44 @@
             "time": "2015-07-14 17:31:05"
         },
         {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        },
+        {
             "name": "psy/psysh",
             "version": "v0.5.2",
             "source": {
@@ -566,16 +604,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e"
+                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
-                "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "shasum": ""
             },
             "require": {
@@ -619,7 +657,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-28 15:18:12"
+            "time": "2015-09-03 11:40:38"
         },
         {
             "name": "symfony/css-selector",
@@ -729,16 +767,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
+                "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/b58c916f1db03a611b72dd702564f30ad8fe83fa",
+                "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa",
                 "shasum": ""
             },
             "require": {
@@ -783,20 +821,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-18 19:21:56"
+            "time": "2015-08-24 07:13:45"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4"
+                "reference": "fff4b0c362640a0ab7355e2647b3d461608e9065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/ae0f363277485094edc04c9f3cbe595b183b78e4",
-                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/fff4b0c362640a0ab7355e2647b3d461608e9065",
+                "reference": "fff4b0c362640a0ab7355e2647b3d461608e9065",
                 "shasum": ""
             },
             "require": {
@@ -832,7 +870,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-08-26 17:56:37"
         },
         {
             "name": "symfony/process",
@@ -840,12 +878,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3"
+                "reference": "f7b3f73f70a7f8f49a1c838dc3debbf054732d8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/48aeb0e48600321c272955132d7606ab0a49adb3",
-                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/f7b3f73f70a7f8f49a1c838dc3debbf054732d8e",
+                "reference": "f7b3f73f70a7f8f49a1c838dc3debbf054732d8e",
                 "shasum": ""
             },
             "require": {
@@ -881,20 +919,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-01 11:25:50"
+            "time": "2015-08-27 06:45:45"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "e8903ebba5eb019f5886ffce739ea9e3b7519579"
+                "reference": "b39221998ff5fc26ba63f96d2b833dfddc233d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e8903ebba5eb019f5886ffce739ea9e3b7519579",
-                "reference": "e8903ebba5eb019f5886ffce739ea9e3b7519579",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b39221998ff5fc26ba63f96d2b833dfddc233d57",
+                "reference": "b39221998ff5fc26ba63f96d2b833dfddc233d57",
                 "shasum": ""
             },
             "require": {
@@ -940,7 +978,57 @@
                 "debug",
                 "dump"
             ],
-            "time": "2015-07-28 15:18:12"
+            "time": "2015-08-31 12:28:11"
+        },
+        {
+            "name": "tesladethray/klogger",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TeslaDethray/KLogger.git",
+                "reference": "46cdd92a9b4a8443120cc955bf831450cb274813"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TeslaDethray/KLogger/zipball/46cdd92a9b4a8443120cc955bf831450cb274813",
+                "reference": "46cdd92a9b4a8443120cc955bf831450cb274813",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "psr/log": "1.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.0.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Katzgrau\\KLogger\\": "src/"
+                },
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kenny Katzgrau",
+                    "email": "katzgrau@gmail.com"
+                },
+                {
+                    "name": "Dan Horrigan",
+                    "email": "dan@dhorrigan.com"
+                }
+            ],
+            "description": "A Simple Logging Class",
+            "keywords": [
+                "logging"
+            ],
+            "time": "2014-03-20 02:36:36"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -992,20 +1080,24 @@
     "packages-dev": [
         {
             "name": "beberlei/assert",
-            "version": "v2.3",
+            "version": "v2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/beberlei/assert.git",
-                "reference": "160eba4d1fbe692e42b3cf8a20b92ab23e3a8759"
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/beberlei/assert/zipball/160eba4d1fbe692e42b3cf8a20b92ab23e3a8759",
-                "reference": "160eba4d1fbe692e42b3cf8a20b92ab23e3a8759",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*"
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
             },
             "type": "library",
             "extra": {
@@ -1037,7 +1129,7 @@
                 "assertion",
                 "validation"
             ],
-            "time": "2014-12-18 19:12:40"
+            "time": "2015-08-21 16:50:17"
         },
         {
             "name": "behat/behat",
@@ -1402,16 +1494,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2d7c03c0e4e080901b8f33b2897b0577be18a13c"
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2d7c03c0e4e080901b8f33b2897b0577be18a13c",
-                "reference": "2d7c03c0e4e080901b8f33b2897b0577be18a13c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
                 "shasum": ""
             },
             "require": {
@@ -1460,7 +1552,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-04 03:42:39"
+            "time": "2015-09-14 06:51:16"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1593,16 +1685,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.6",
+            "version": "1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b"
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
                 "shasum": ""
             },
             "require": {
@@ -1638,20 +1730,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-08-16 08:51:00"
+            "time": "2015-09-15 10:49:45"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.4",
+            "version": "4.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "55bf1d6092b0e13a1f26bd5eaffeef3d8ad85ea7"
+                "reference": "dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/55bf1d6092b0e13a1f26bd5eaffeef3d8ad85ea7",
-                "reference": "55bf1d6092b0e13a1f26bd5eaffeef3d8ad85ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa",
+                "reference": "dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa",
                 "shasum": ""
             },
             "require": {
@@ -1710,24 +1802,24 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-15 04:21:23"
+            "time": "2015-09-14 06:57:22"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.6",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42"
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
-                "reference": "18dfbcb81d05e2296c0bcddd4db96cade75e6f42",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "doctrine/instantiator": "^1.0.2",
                 "php": ">=5.3.3",
                 "phpunit/php-text-template": "~1.2",
                 "sebastian/exporter": "~1.2"
@@ -1766,7 +1858,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-07-10 06:54:24"
+            "time": "2015-08-19 09:14:08"
         },
         {
             "name": "sebastian/comparator",
@@ -2231,16 +2323,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666"
+                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/c1a26c729508f73560c1a4f767f60b8ab6b4a666",
-                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
+                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
                 "shasum": ""
             },
             "require": {
@@ -2301,20 +2393,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2015-06-24 03:16:23"
+            "time": "2015-09-09 00:18:50"
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9"
+                "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
-                "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
+                "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
                 "shasum": ""
             },
             "require": {
@@ -2351,20 +2443,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-08-27 06:45:45"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "851e3ffe8a366b1590bdaf3df2c1395f2d27d8a6"
+                "reference": "c0a3a97b9450d77cd8eff81c5825efb3624c255b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/851e3ffe8a366b1590bdaf3df2c1395f2d27d8a6",
-                "reference": "851e3ffe8a366b1590bdaf3df2c1395f2d27d8a6",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/c0a3a97b9450d77cd8eff81c5825efb3624c255b",
+                "reference": "c0a3a97b9450d77cd8eff81c5825efb3624c255b",
                 "shasum": ""
             },
             "require": {
@@ -2411,20 +2503,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-28 14:07:07"
+            "time": "2015-08-24 07:16:32"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
+                "reference": "f079e9933799929584200b9a926f72f29e291654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
-                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
+                "reference": "f079e9933799929584200b9a926f72f29e291654",
                 "shasum": ""
             },
             "require": {
@@ -2460,20 +2552,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-08-27 07:03:44"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "c8dc34cc936152c609cdd722af317e4239d10dd6"
+                "reference": "485877661835e188cd78345c6d4eef1290d17571"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/c8dc34cc936152c609cdd722af317e4239d10dd6",
-                "reference": "c8dc34cc936152c609cdd722af317e4239d10dd6",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/485877661835e188cd78345c6d4eef1290d17571",
+                "reference": "485877661835e188cd78345c6d4eef1290d17571",
                 "shasum": ""
             },
             "require": {
@@ -2485,7 +2577,7 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~2.7",
-                "symfony/intl": "~2.3",
+                "symfony/intl": "~2.4",
                 "symfony/phpunit-bridge": "~2.7",
                 "symfony/yaml": "~2.2"
             },
@@ -2521,20 +2613,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-09 16:07:40"
+            "time": "2015-09-06 08:36:38"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.3",
+            "version": "v2.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "71340e996171474a53f3d29111d046be4ad8a0ff"
+                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/71340e996171474a53f3d29111d046be4ad8a0ff",
-                "reference": "71340e996171474a53f3d29111d046be4ad8a0ff",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/2dc7b06c065df96cc686c66da2705e5e18aef661",
+                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661",
                 "shasum": ""
             },
             "require": {
@@ -2570,7 +2662,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-07-28 14:07:07"
+            "time": "2015-08-24 07:13:45"
         },
         {
             "name": "theseer/fdomdocument",

--- a/php/Terminus/Dispatcher/RootCommand.php
+++ b/php/Terminus/Dispatcher/RootCommand.php
@@ -11,49 +11,48 @@ class RootCommand extends CompositeCommand {
 
   function __construct() {
     $this->parent = false;
-
     $this->name = 'terminus';
-
     $this->shortdesc = 'Manage Pantheon through the command-line.';
   }
 
   function get_longdesc() {
     $binding = array();
 
-    foreach ( \Terminus::get_configurator()->get_spec() as $key => $details ) {
-      if ( false === $details['runtime'] )
+    foreach (\Terminus::get_configurator()->get_spec() as $key => $details) {
+      if (
+        ($details['runtime'] === false)
+        || isset($details['deprecated'])
+        || (isset($details['hidden']))
+      ) {
         continue;
-
-      if ( isset( $details['deprecated'] ) )
-        continue;
-
-      if ( isset( $details['hidden'] ) )
-        continue;
-
-      if ( true === $details['runtime'] )
-        $synopsis = "--[no-]$key";
-      else
+      } if ($details['runtime']) {
+        $synopsis = "--[no-]$key"; 
+      } else {
         $synopsis = "--$key" . $details['runtime'];
+      }
 
       $binding['parameters'][] = array(
         'synopsis' => $synopsis,
-        'desc' => $details['desc']
-      );
+        'desc'     => $details['desc']
+     );
     }
 
-    return Utils\mustache_render( 'man-params.mustache', $binding );
+    if ((boolean)\Terminus::get_config('json')) {
+      return $binding;
+    }
+    return Utils\mustache_render('man-params.mustache', $binding);
   }
 
-  function find_subcommand( &$args ) {
-    $command = array_shift( $args );
+  function find_subcommand(&$args) {
+    $command = array_shift($args);
 
-    Utils\load_command( $command );
+    Utils\load_command($command);
 
-    if ( !isset( $this->subcommands[ $command ] ) ) {
+    if (!isset($this->subcommands[$command])) {
       return false;
     }
 
-    return $this->subcommands[ $command ];
+    return $this->subcommands[$command];
   }
 
   function get_subcommands() {

--- a/php/Terminus/JLogger.php
+++ b/php/Terminus/JLogger.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Terminus;
+
+use DateTime;
+use RuntimeException;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+/**
+ * Finally, a light, permissions-checking logging class.
+ *
+ * Originally written for use with wpSearch
+ *
+ * Usage:
+ * $log = new Katzgrau\KLogger\Logger('/var/log/', Psr\Log\LogLevel::INFO);
+ * $log->info('Returned a million search results'); //Prints to the log file
+ * $log->error('Oh dear.'); //Prints to the log file
+ * $log->debug('x = 5'); //Prints nothing due to current severity threshhold
+ *
+ * @author  Kenny Katzgrau <katzgrau@gmail.com>
+ * @since   July 26, 2008
+ * @link    https://github.com/katzgrau/KLogger
+ * @version 1.0.1
+ */
+
+/**
+ * Class documentation
+ */
+//Todo: Replace this with Katzgrau/KLogger after stderr PR is merged. This class is a stopgap.
+class JLogger extends AbstractLogger
+{
+    /**
+     * KLogger options
+     *  Anything options not considered 'core' to the logging library should be
+     *  settable view the third parameter in the constructor
+     *
+     *  Core options include the log file path and the log threshold
+     *
+     * @var array
+     */
+    private $options = array (
+        'extension'      => 'txt',
+        'dateFormat'     => 'Y-m-d G:i:s.u',
+        'filename'       => false,
+        'flushFrequency' => false,
+        'prefix'         => 'log_',
+        'logFormat'      => false,
+        'appendContext'  => true,
+    );
+
+    /**
+     * Path to the log file
+     * @var string
+     */
+    private $logFilePath;
+
+    /**
+     * Current minimum logging threshold
+     * @var integer
+     */
+    private $logLevelThreshold = LogLevel::DEBUG;
+
+    /**
+     * The number of lines logged in this instance's lifetime
+     * @var int
+     */
+    private $logLineCount = 0;
+
+    /**
+     * Log Levels
+     * @var array
+     */
+    private $logLevels = array(
+        LogLevel::EMERGENCY => 0,
+        LogLevel::ALERT     => 1,
+        LogLevel::CRITICAL  => 2,
+        LogLevel::ERROR     => 3,
+        LogLevel::WARNING   => 4,
+        LogLevel::NOTICE    => 5,
+        LogLevel::INFO      => 6,
+        LogLevel::DEBUG     => 7
+    );
+
+    /**
+     * This holds the file handle for this instance's log file
+     * @var resource
+     */
+    private $fileHandle;
+
+    /**
+     * This holds the last line logged to the logger
+     *  Used for unit tests
+     * @var string
+     */
+    private $lastLine = '';
+
+    /**
+     * Octal notation for default permissions of the log file
+     * @var integer
+     */
+    private $defaultPermissions = 0777;
+
+    /**
+     * Class constructor
+     *
+     * @param string $logDirectory      File path to the logging directory
+     * @param string $logLevelThreshold The LogLevel Threshold
+     * @param array  $options
+     *
+     * @internal param string $logFilePrefix The prefix for the log file name
+     * @internal param string $logFileExt The extension for the log file
+     */
+    public function __construct($logDirectory, $logLevelThreshold = LogLevel::DEBUG, array $options = array())
+    {
+        $this->logLevelThreshold = $logLevelThreshold;
+        $this->options = array_merge($this->options, $options);
+
+        $logDirectory = rtrim($logDirectory, DIRECTORY_SEPARATOR);
+        if ( ! file_exists($logDirectory)) {
+            mkdir($logDirectory, $this->defaultPermissions, true);
+        }
+
+        if(strpos($logDirectory, 'php://') === 0) {
+            $this->setLogToStdOut($logDirectory);
+            $this->setFileHandle('w+');
+        } else {
+            $this->setLogFilePath($logDirectory);
+            if(file_exists($this->logFilePath) && !is_writable($this->logFilePath)) {
+                throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
+            }
+            $this->setFileHandle('a');
+        }
+
+        if ( ! $this->fileHandle) {
+            throw new RuntimeException('The file could not be opened. Check permissions.');
+        }
+    }
+
+    /**
+     * @param string $stdOutPath
+     */
+    public function setLogToStdOut($stdOutPath) {
+        $this->logFilePath = $stdOutPath;
+    }
+
+    /**
+     * @param string $logDirectory
+     */
+    public function setLogFilePath($logDirectory) {
+        if ($this->options['filename']) {
+            if (strpos($this->options['filename'], '.log') !== false || strpos($this->options['filename'], '.txt') !== false) {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'];
+            }
+            else {
+                $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['filename'].'.'.$this->options['extension'];
+            }
+        } else {
+            $this->logFilePath = $logDirectory.DIRECTORY_SEPARATOR.$this->options['prefix'].date('Y-m-d').'.'.$this->options['extension'];
+        }
+    }
+
+    /**
+     * @param $writeMode
+     *
+     * @internal param resource $fileHandle
+     */
+    public function setFileHandle($writeMode) {
+        $this->fileHandle = fopen($this->logFilePath, $writeMode);
+    }
+
+
+    /**
+     * Class destructor
+     */
+    public function __destruct()
+    {
+        if ($this->fileHandle) {
+            fclose($this->fileHandle);
+        }
+    }
+
+    /**
+     * Sets the date format used by all instances of KLogger
+     *
+     * @param string $dateFormat Valid format string for date()
+     */
+    public function setDateFormat($dateFormat)
+    {
+        $this->options['dateFormat'] = $dateFormat;
+    }
+
+    /**
+     * Sets the Log Level Threshold
+     *
+     * @param string $logLevelThreshold The log level threshold
+     */
+    public function setLogLevelThreshold($logLevelThreshold)
+    {
+        $this->logLevelThreshold = $logLevelThreshold;
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     * @return null
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if ($this->logLevels[$this->logLevelThreshold] < $this->logLevels[$level]) {
+            return;
+        }
+        $message = $this->formatMessage($level, $message, $context);
+        $this->write($message);
+    }
+
+    /**
+     * Writes a line to the log without prepending a status or timestamp
+     *
+     * @param string $message Line to write to the log
+     * @return void
+     */
+    public function write($message)
+    {
+        if (null !== $this->fileHandle) {
+            if (fwrite($this->fileHandle, $message) === false) {
+                throw new RuntimeException('The file could not be written to. Check that appropriate permissions have been set.');
+            } else {
+                $this->lastLine = trim($message);
+                $this->logLineCount++;
+
+                if ($this->options['flushFrequency'] && $this->logLineCount % $this->options['flushFrequency'] === 0) {
+                    fflush($this->fileHandle);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the file path that the log is currently writing to
+     *
+     * @return string
+     */
+    public function getLogFilePath()
+    {
+        return $this->logFilePath;
+    }
+
+    /**
+     * Get the last line logged to the log file
+     *
+     * @return string
+     */
+    public function getLastLogLine()
+    {
+        return $this->lastLine;
+    }
+
+    /**
+     * Formats the message for logging.
+     *
+     * @param  string $level   The Log Level of the message
+     * @param  string $message The message to log
+     * @param  array  $context The context
+     * @return string
+     */
+    private function formatMessage($level, $message, $context)
+    {
+        if ($this->options['logFormat']) {
+            $parts = array(
+                'date'          => $this->getTimestamp(),
+                'level'         => strtoupper($level),
+                'level-padding' => str_repeat(' ', 9 - strlen($level)),
+                'priority'      => $this->logLevels[$level],
+                'message'       => $message,
+                'context'       => json_encode($context),
+            );
+            $message = $this->options['logFormat'];
+            foreach ($parts as $part => $value) {
+                $message = str_replace('{'.$part.'}', $value, $message);
+            }
+
+        } else {
+            $message = "[{$this->getTimestamp()}] [{$level}] {$message}";
+        }
+
+        if ($this->options['appendContext'] && ! empty($context)) {
+            $message .= PHP_EOL.$this->indent($this->contextToString($context));
+        }
+
+        return $message.PHP_EOL;
+
+    }
+
+    /**
+     * Gets the correctly formatted Date/Time for the log entry.
+     *
+     * PHP DateTime is dump, and you have to resort to trickery to get microseconds
+     * to work correctly, so here it is.
+     *
+     * @return string
+     */
+    private function getTimestamp()
+    {
+        $originalTime = microtime(true);
+        $micro = sprintf("%06d", ($originalTime - floor($originalTime)) * 1000000);
+        $date = new DateTime(date('Y-m-d H:i:s.'.$micro, $originalTime));
+
+        return $date->format($this->options['dateFormat']);
+    }
+
+    /**
+     * Takes the given context and coverts it to a string.
+     *
+     * @param  array $context The Context
+     * @return string
+     */
+    private function contextToString($context)
+    {
+        $export = '';
+        foreach ($context as $key => $value) {
+            $export .= "{$key}: ";
+            $export .= preg_replace(array(
+                '/=>\s+([a-zA-Z])/im',
+                '/array\(\s+\)/im',
+                '/^  |\G  /m'
+            ), array(
+                '=> $1',
+                'array()',
+                '    '
+            ), str_replace('array (', 'array(', var_export($value, true)));
+            $export .= PHP_EOL;
+        }
+        return str_replace(array('\\\\', '\\\''), array('\\', '\''), rtrim($export));
+    }
+
+    /**
+     * Indents the given string with the given indent.
+     *
+     * @param  string $string The string to indent
+     * @param  string $indent What to use as the indent.
+     * @return string
+     */
+    private function indent($string, $indent = '    ')
+    {
+        return $indent.str_replace("\n", "\n".$indent, $string);
+    }
+}

--- a/php/Terminus/KLogger.php
+++ b/php/Terminus/KLogger.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Terminus;
+
+use Terminus\JLogger as Logger;
+use Psr\Log\LogLevel;
+
+//TODO: Change this classname to Logger once the old logger is fully replaced
+class KLogger extends Logger {
+  protected $parent;
+
+  /**
+   * Class constructor. Feeds in output destination from env vars
+   *
+   * @param [array]  $options           Options for operation of logger
+   *        [array] config Configuration options from Runner
+   * @param [string] $logDirectory      File path to the logging directory
+   * @param [string] $logLevelThreshold The LogLevel Threshold
+   * @return [KLogger] $this
+   */
+  public function __construct(
+    array $options = array(),
+    $logDirectory = 'php://stderr',
+    $logLevelThreshold = LogLevel::INFO
+  ) {
+    $config = $options['config'];
+    unset($options['config']);
+
+    if (isset($_SERVER['TERMINUS_LOG_DIR'])) {
+      $logDirectory = $_SERVER['TERMINUS_LOG_DIR'];
+    } elseif ($config['silent']) {
+      $logDirectory = ini_get('error_log');
+    }
+
+    if ($config['debug']) {
+      $logLevelThreshold = LogLevel::DEBUG;
+    }
+
+    if (!isset($options['logFormat'])) {
+      if ($config['json'] != null) {
+        $options['logFormat'] = 'json';
+      }
+      if ($config['bash'] != null) {
+        $options['logFormat'] = 'bash';
+      }
+    }
+
+    parent::__construct($logDirectory, $logLevelThreshold, $options);
+    $this->parent = $this->extractParent();
+  }
+
+  /**
+    * Logs with an arbitrary level.
+    *
+    * @param [mixed]  $level
+    * @param [string] $message
+    * @param [array]  $context
+    * @return [void]
+    */
+  public function log($level, $message, array $context = array()) {
+    $parent = $this->parent;
+    if ($parent->logLevels[$parent->logLevelThreshold] < $parent->logLevels[$level]) {
+      return;
+    }
+    if ($parent->options['logFormat'] == 'json') {
+      $message = $this->formatJsonMessages($level, $message, $context);
+    } elseif ($parent->options['logFormat'] == 'bash') {
+      $message = $this->formatBashMessages($level, $message, $context);
+    } else {
+      $message = $this->formatMessages($level, $message, $context);
+    }
+    $this->write($message);
+  }
+
+  /**
+   * Sets the output handle to php://std___
+   *
+   * @return [void]
+   */
+  public function setBufferHandle() {
+    $handle_name = strtoupper(substr($this->getLogFilePath(), 6));
+    $this->fileHandle = constant($handle_name);
+  }
+
+  /**
+   * Extracts private data from the parent class
+   *
+   * @return [stdClass] $parent
+   */
+  private function extractParent() {
+    $array  = (array)$this;
+    array_shift($array);
+    $parent = new \stdClass();
+    foreach ($array as $key => $value) {
+      //All these keys begin with a null. We need to cut them off so they can be used.
+      $property_name = substr(str_replace('Katzgrau\KLogger\Logger', '', $key), 2);
+      $parent->$property_name = $value;
+    }
+    return $parent;
+  }
+
+  /**
+    * Formats the message for bash-type logging.
+    *
+    * @param  [string] $level   The Log Level of the message
+    * @param  [string] $message The message to log
+    * @param  [array]  $context The context
+    * @return [string] $message
+    */
+  private function formatBashMessages($level, $message, $context) {
+    $parts   = $this->getMessageParts($level, $message, $context);
+    $message = '';
+    foreach ($parts as $key => $value) {
+      $message .= "$key\t$value\n";
+    }
+    return $message;
+  }
+
+  /**
+    * Formats the message for JSON-type logging.
+    *
+    * @param  [string] $level   The Log Level of the message
+    * @param  [string] $message The message to log
+    * @param  [array]  $context The context
+    * @return [string] $message
+    */
+  private function formatJsonMessages($level, $message, $context) {
+    $parts   = $this->getMessageParts($level, $message, $context);
+    $message = json_encode($parts) . "\n";
+    return $message;
+  }
+
+  /**
+    * Formats the message for logging.
+    *
+    * @param  [string] $level   The Log Level of the message
+    * @param  [string] $message The message to log
+    * @param  [array]  $context The context
+    * @return [string] $message
+    */
+  private function formatMessages($level, $message, $context) {
+    $parent = $this->parent;
+    if ($parent->options['logFormat']) {
+      $parts   = $this->getMessageParts($level, $message, $context);
+      $message = $parent->options['logFormat'];
+      foreach ($parts as $part => $value) {
+        $message = str_replace('{'.$part.'}', $value, $message);
+      }
+    } else {
+      $message = "[{$this->getTimestamp()}] [{$level}] {$message}";
+    }
+    if ($parent->options['appendContext'] && ! empty($context)) {
+      $message .= PHP_EOL . $this->indent($this->contextToString($context));
+    }
+
+    return $message . PHP_EOL;
+  }
+
+  /**
+    * Collects and formats the log message parts
+    *
+    * @param  [string] $level   The Log Level of the message
+    * @param  [string] $message The message to log
+    * @param  [array]  $context The context
+    * @return [string] $parts
+    */
+  private function getMessageParts($level, $message, $context) {
+    $parts = array(
+      'date'          => $this->getTimestamp(),
+      'level'         => strtoupper($level),
+      //'priority'      => $this->logLevels[$level],
+      'message'       => $message,
+      //'context'       => json_encode($context),
+    );
+    return $parts;
+  }
+
+  /**
+   * Gets the correctly formatted Date/Time for the log entry.
+   *
+   * @return [string] $date
+   */
+  private function getTimestamp() {
+    $date_format = 'Y-m-d H:i:s';
+    if (isset($this->options['dateFormat'])) {
+      $date_format = $this->options['dateFormat'];
+    }
+    $date = date($date_format);
+    return $date;
+  }
+
+}

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -5,74 +5,80 @@ namespace Terminus;
 use Terminus;
 use Terminus\Utils;
 use Terminus\Dispatcher;
+use Terminus\KLogger;
 
 class Runner {
+  public $config;
+  public $extra_config;
 
-  private $global_config_path, $project_config_path;
-
-  public $config, $extra_config;
-
-  private $arguments, $assoc_args;
-
+  private $arguments;
+  private $assoc_args;
   private $_early_invoke = array();
+  private $global_config_path;
+  private $project_config_path;
 
-  public function __get( $key ) {
-    if ( '_' === $key[0] )
+  public function __construct() {
+    $this->init_config();
+    $this->init_colorization();
+    $this->init_logger();
+    $this->init_outputter();
+  }
+
+  public function __get($key) {
+    if ('_' === $key[0])
       return null;
 
     return $this->$key;
   }
 
-  public function find_command_to_run( $args ) {
+  public function find_command_to_run($args) {
     $command = \Terminus::get_root_command();
 
     $cmd_path = array();
-
-
-    while ( !empty( $args ) && $command->can_have_subcommands() ) {
+    while (!empty($args) && $command->can_have_subcommands()) {
       $cmd_path[] = $args[0];
-      $full_name = implode( ' ', $cmd_path );
+      $full_name  = implode(' ', $cmd_path);
 
-      $subcommand = $command->find_subcommand( $args );
+      $subcommand = $command->find_subcommand($args);
 
-      if ( !$subcommand ) {
+      if (!$subcommand) {
         return sprintf(
           "'%s' is not a registered command. See 'terminus help'.",
           $full_name
-        );
+       );
       }
 
       $command = $subcommand;
     }
 
-    return array( $command, $args, $cmd_path );
+    return array($command, $args, $cmd_path);
   }
 
-  public function run_command( $args, $assoc_args = array() ) {
-    $r = $this->find_command_to_run( $args );
-    if ( is_string( $r ) ) {
-      Terminus::error( $r );
+  public function run_command($args, $assoc_args = array()) {
+    $r = $this->find_command_to_run($args);
+    if (is_string($r)) {
+      Terminus::error($r);
     }
 
-    list( $command, $final_args, $cmd_path ) = $r;
+    list($command, $final_args, $cmd_path) = $r;
 
-    $name = implode( ' ', $cmd_path );
+    $name = implode(' ', $cmd_path);
 
-    if ( isset( $this->extra_config[ $name ] ) ) {
+    if (isset($this->extra_config[ $name ])) {
       $extra_args = $this->extra_config[ $name ];
     } else {
       $extra_args = array();
     }
 
     try {
-      $command->invoke( $final_args, $assoc_args, $extra_args );
-    } catch ( Terminus\Iterators\Exception $e ) {
-      Terminus::error( $e->getMessage() );
+      $command->invoke($final_args, $assoc_args, $extra_args);
+    } catch (Terminus\Iterators\Exception $e) {
+      Terminus::error($e->getMessage());
     }
   }
 
   private function _run_command() {
-    $this->run_command( $this->arguments, $this->assoc_args );
+    $this->run_command($this->arguments, $this->assoc_args);
   }
 
   public function in_color() {
@@ -80,7 +86,7 @@ class Runner {
   }
 
   private function init_colorization() {
-    if ( 'auto' === $this->config['colorize'] ) {
+    if ($this->config['colorize'] == 'auto') {
       $this->colorize = !\cli\Shell::isPiped();
     } else {
       $this->colorize = $this->config['colorize'];
@@ -88,12 +94,17 @@ class Runner {
   }
 
   private function init_logger() {
-    if ( $this->config['silent'] )
-      $logger = new \Terminus\Loggers\Quiet;
-    else
-      $logger = new \Terminus\Loggers\Regular( $this->in_color() );
+    $logger = new KLogger(array('config' => $this->config));
+    Terminus::set_logger($logger);
+  }
 
-    Terminus::set_logger( $logger );
+  private function init_outputter() {
+    if ($this->config['silent']) {
+      $outputter = new \Terminus\Loggers\Quiet;
+    } else {
+      $outputter = new \Terminus\Loggers\Regular($this->in_color());
+    }
+    Terminus::set_outputter($outputter);
   }
 
   private function init_config() {
@@ -101,59 +112,54 @@ class Runner {
 
     // Runtime config and args
     {
-      list( $args, $assoc_args, $runtime_config ) = $configurator->parse_args(
-        array_slice( $GLOBALS['argv'], 1 ) );
+      list($args, $assoc_args, $runtime_config) = $configurator->parse_args(
+        array_slice($GLOBALS['argv'], 1));
 
 
       $this->arguments = $args;
       $this->assoc_args = $assoc_args;
 
-      $configurator->merge_array( $runtime_config );
+      $configurator->merge_array($runtime_config);
     }
 
-    list( $this->config, $this->extra_config ) = $configurator->to_array();
+    list($this->config, $this->extra_config) = $configurator->to_array();
   }
 
   public function run() {
-    $this->init_config();
-    $this->init_colorization();
-    $this->init_logger();
-
-    if ( Terminus::is_test() )
+    if (Terminus::is_test())
       return true;
 
-    if ( empty( $this->arguments ) )
+    if (empty($this->arguments))
       $this->arguments[] = 'help';
 
     // Load bundled commands early, so that they're forced to use the same
     // APIs as non-bundled commands.
-    Utils\load_command( $this->arguments[0] );
+    Utils\load_command($this->arguments[0]);
 
-    if ( isset( $this->config['require'] ) ) {
-      foreach ( $this->config['require'] as $path ) {
-        Utils\load_file( $path );
+    if (isset($this->config['require'])) {
+      foreach ($this->config['require'] as $path) {
+        Utils\load_file($path);
       }
     }
 
     // Show synopsis if it's a composite command.
-    $r = $this->find_command_to_run( $this->arguments );
-    if ( is_array( $r ) ) {
-      list( $command ) = $r;
+    $r = $this->find_command_to_run($this->arguments);
+    if (is_array($r)) {
+      list($command) = $r;
 
-      if ( $command->can_have_subcommands() ) {
+      if ($command->can_have_subcommands()) {
         $command->show_usage();
         exit;
       }
     }
 
     // First try at showing man page
-    if ( 'help' === $this->arguments[0] && ( isset( $this->arguments[1] ) ) ) {
+    if ('help' === $this->arguments[0] && (isset($this->arguments[1]))) {
       $this->_run_command();
     }
 
     # Run the stinkin command!
     $this->_run_command();
-
   }
 
 }

--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -5,6 +5,7 @@ use \Terminus\Endpoint;
 use \Terminus\Request;
 use \Terminus\Session;
 use \Terminus\Loggers\Regular as Logger;
+use Terminus\KLogger;
 use Terminus\Models\Collections\Sites;
 
 /**
@@ -17,6 +18,8 @@ abstract class TerminusCommand {
 
   protected static $blacklist = array('password');
   protected $func;
+  protected $logger;
+  protected $outputter;
 
   /**
    * Instantiates object, sets cache and session
@@ -25,8 +28,10 @@ abstract class TerminusCommand {
    */
   public function __construct() {
     //Load commonly used data from cache
-    $this->cache   = Terminus::get_cache();
-    $this->session = Session::instance();
+    $this->cache     = Terminus::get_cache();
+    $this->logger    = Terminus::get_logger();
+    $this->outputter = Terminus::get_outputter();
+    $this->session   = Session::instance();
   }
 
   /**

--- a/php/class-terminus.php
+++ b/php/class-terminus.php
@@ -9,8 +9,10 @@ use \Terminus\FileCache;
  */
 class Terminus {
   private static $configurator;
+  private static $hooks = array();
+  private static $hooks_passed = array();
   private static $logger;
-  private static $hooks = array(), $hooks_passed = array();
+  private static $outputter;
 
   /**
    * Set the logger instance.
@@ -46,8 +48,8 @@ class Terminus {
     try {
       static $runner;
 
-      if(!$runner) {
-        $runner = new Terminus\Runner;
+      if(!isset($runner) || !$runner) {
+        $runner = new Terminus\Runner();
       }
 
       return $runner;
@@ -123,6 +125,7 @@ class Terminus {
 
   /**
    * Prompt the user for input
+   * TODO: Remove this when all old logger calls have been replaced with calls directly to logger class
    *
    * @param string $message
    */
@@ -139,6 +142,7 @@ class Terminus {
 
   /**
    * Display a message in the CLI and end with a newline
+   * TODO: Create and use outputter for this
    *
    * @param string $message
    */
@@ -151,6 +155,7 @@ class Terminus {
 
   /**
    * Log an informational message.
+   * TODO: Remove this when all old logger calls have been replaced with calls directly to logger class
    *
    * @param string $message
    */
@@ -163,6 +168,7 @@ class Terminus {
 
   /**
    * Display a success in the CLI and end with a newline
+   * TODO: Create and use outputter for this
    *
    * @param string $message
    */
@@ -170,11 +176,12 @@ class Terminus {
     if(!empty($params)) {
       $message = vsprintf($message, $params);
     }
-    self::$logger->success($message);
+    self::$outputter->success($message);
   }
 
   /**
    * Display a warning in the CLI and end with a newline
+   * TODO: Remove this when all old logger calls have been replaced with calls directly to logger class
    *
    * @param string $message
    */
@@ -187,6 +194,24 @@ class Terminus {
 
   /**
    * Display an error in the CLI and end with a newline
+   * TODO: Create and use outputter for this
+   *
+   * @param string $message
+   */
+  static function failure($message, $params = array()) {
+    if(!empty($params)) {
+      $message = vsprintf($message, $params);
+    }
+    if(! isset(self::get_runner()->assoc_args[ 'completions' ])) {
+      self::$outputter->error(self::error_to_string($message));
+    }
+
+    exit(1);
+  }
+
+  /**
+   * Display an error in the CLI and end with a newline
+   * TODO: Remove this when all old logger calls have been replaced with calls directly to logger class
    *
    * @param string $message
    */
@@ -203,6 +228,7 @@ class Terminus {
 
   /**
    * Ask for confirmation before running a destructive operation.
+   * TODO: Create and use outputter for this
    */
   static function confirm($question, $assoc_args = array(), $params = array()) {
       if(\Terminus::get_config('yes')) return true;
@@ -260,6 +286,7 @@ class Terminus {
 
   /**
    * Display a value, in various formats
+   * TODO: Create and use outputter for this
    *
    * @param mixed $value
    * @param array $assoc_args
@@ -414,4 +441,33 @@ class Terminus {
     $is_test = (boolean)getenv("CLI_TEST_MODE");
     return $is_test;
   }
+
+  /**
+   * Set the outputter instance.
+   *
+   * @param [object] $outputter
+   * @return [void]
+   */
+  static function set_outputter($outputter) {
+    self::$outputter = $outputter;
+  }
+
+  /**
+   * Retrieves the instantiated logger
+   *
+   * @return [KLogger] $logger
+   */
+  public function get_logger() {
+    return self::$logger;
+  }
+
+  /**
+   * Retrieves the instantiated outputter
+   *
+   * @return [Logger] $outputter
+   */
+  public function get_outputter() {
+    return self::$outputter;
+  }
+
 }

--- a/php/commands/help.php
+++ b/php/commands/help.php
@@ -20,127 +20,151 @@ class Help_Command extends TerminusCommand {
    *
    * @synopsis [<command>...]
    */
-  function __invoke( $args, $assoc_args ) {
-    $command = self::find_subcommand( $args );
+  function __invoke($args, $assoc_args) {
+    $command = self::find_subcommand($args);
 
-    if ( $command ) {
-      self::show_help( $command );
+    if ($command) {
+      self::show_help($command);
       exit;
     }
 
     // WordPress is already loaded, so there's no chance we'll find the command
-    if ( function_exists( 'add_filter' ) ) {
-      \Terminus::error( sprintf( "'%s' is not a registered command.", $args[0] ) );
+    if (function_exists('add_filter')) {
+      \Terminus::error(sprintf("'%s' is not a registered command.", $args[0]));
     }
   }
 
-  private static function find_subcommand( $args ) {
+  private static function find_subcommand($args) {
     $command = \Terminus::get_root_command();
 
-    while ( !empty( $args ) && $command && $command->can_have_subcommands() ) {
-      $command = $command->find_subcommand( $args );
+    while (!empty($args) && $command && $command->can_have_subcommands()) {
+      $command = $command->find_subcommand($args);
     }
 
     return $command;
   }
 
-  private static function show_help( $command ) {
+  private static function show_help($command) {
 
-    $out = self::get_initial_markdown( $command );
+    $out = self::get_initial_markdown($command);
     $longdesc = $command->get_longdesc();
-    if ( $longdesc ) {
-      $out .= wordwrap( $longdesc, 79 ) . "\n";
+    if ($longdesc) {
+      if (is_array($longdesc)) {
+        $flag_list = array_pop($longdesc);
+        $flags     = array();
+        foreach ($flag_list as $desc) {
+          $flags[$desc['synopsis']] = $desc['desc'];
+        }
+        $out['parameters'] = $flags;
+        $out = json_encode($out);
+      } else {
+        $out .= wordwrap($longdesc, 79) . "\n";
+      }
     }
 
     // section headers
-    $out = preg_replace( '/^## ([A-Z ]+)/m', Terminus::colorize( '%9\1%n' ), $out );
+    $out = preg_replace('/^## ([A-Z]+)/m', Terminus::colorize('%9\1%n'), $out);
 
     // definition lists
-    $out = preg_replace_callback( '/([^\n]+)\n: (.+?)(\n\n|$)/s', array( __CLASS__, 'rewrap_param_desc' ), $out );
+    $out = preg_replace_callback('/([^\n]+)\n: (.+?)(\n\n|$)/s', array(__CLASS__, 'rewrap_param_desc'), $out);
 
-    $out = str_replace( "\t", '  ', $out );
+    $out = str_replace("\t", '  ', $out);
 
-    self::pass_through_pager( $out );
+    self::pass_through_pager($out);
   }
 
-  private static function rewrap_param_desc( $matches ) {
+  private static function rewrap_param_desc($matches) {
     $param = $matches[1];
-    $desc = self::indent( "\t\t", wordwrap( $matches[2] ) );
+    $desc = self::indent("\t\t", wordwrap($matches[2]));
     return "\t$param\n$desc\n\n";
   }
 
-  private static function indent( $whitespace, $text ) {
-    $lines = explode( "\n", $text );
-    foreach ( $lines as &$line ) {
+  private static function indent($whitespace, $text) {
+    $lines = explode("\n", $text);
+    foreach ($lines as &$line) {
       $line = $whitespace . $line;
     }
-    return implode( $lines, "\n" );
+    return implode($lines, "\n");
   }
 
-  private static function pass_through_pager( $out ) {
-    if ( Utils\is_windows() ) {
-      // no paging for Windows cmd.exe; sorry
-      echo $out;
+  private static function pass_through_pager($out) {
+
+    if (
+      Utils\is_windows()
+      || ((boolean)Terminus::get_config('bash')) 
+      || ((boolean)Terminus::get_config('json'))
+    ) {
+      // No paging for Windows cmd.exe; sorry
+      Terminus::print_value($out);
       return 0;
     }
 
     // convert string to file handle
-    $fd = fopen( "php://temp", "r+" );
-    fputs( $fd, $out );
-    rewind( $fd );
+    $fd = fopen("php://temp", "r+");
+    fputs($fd, $out);
+    rewind($fd);
 
     $descriptorspec = array(
       0 => $fd,
       1 => STDOUT,
       2 => STDERR
-    );
+   );
 
-    return proc_close( proc_open( 'less -r', $descriptorspec, $pipes ) );
+    return proc_close(proc_open('less -r', $descriptorspec, $pipes));
   }
 
-  private static function get_initial_markdown( $command ) {
-    $name = implode( ' ', Dispatcher\get_path( $command ) );
+  private static function get_initial_markdown($command) {
+    $name = implode(' ', Dispatcher\get_path($command));
 
     $binding = array(
       'name' => $name,
       'shortdesc' => $command->get_shortdesc(),
-    );
+   );
 
-    $binding['synopsis'] = wordwrap( "$name " . $command->get_synopsis(), 79 );
+    $binding['synopsis'] = wordwrap("$name " . $command->get_synopsis(), 79);
 
-    if ( $command->can_have_subcommands() ) {
-      $binding['has-subcommands']['subcommands'] = self::render_subcommands( $command );
+    if ($command->can_have_subcommands()) {
+      $binding['has-subcommands']['subcommands'] = self::render_subcommands($command);
     }
 
-    return Utils\mustache_render( 'man.mustache', $binding );
+    if ((boolean)Terminus::get_config('json')) {
+      $rendered_help = $binding;
+    } else {
+      $rendered_help = Utils\mustache_render('man.mustache', $binding);  
+    }
+    return $rendered_help;
   }
 
-  private static function render_subcommands( $command ) {
+  private static function render_subcommands($command) {
     $subcommands = array();
-    foreach ( $command->get_subcommands() as $subcommand ) {
-      $subcommands[ $subcommand->get_name() ] = $subcommand->get_shortdesc();
+    foreach ($command->get_subcommands() as $subcommand) {
+      $subcommands[$subcommand->get_name()] = $subcommand->get_shortdesc();
     }
 
-    $max_len = self::get_max_len( array_keys( $subcommands ) );
+    if ((boolean)Terminus::get_config('json')) {
+      return $subcommands;
+    }
 
+    $max_len = self::get_max_len(array_keys($subcommands));
     $lines = array();
-    foreach ( $subcommands as $name => $desc ) {
-      $lines[] = str_pad( $name, $max_len ) . "\t\t\t" . $desc;
+    foreach ($subcommands as $name => $desc) {
+      $lines[] = str_pad($name, $max_len) . "\t\t\t" . $desc;
     }
 
     return $lines;
   }
 
-  private static function get_max_len( $strings ) {
+  private static function get_max_len($strings) {
     $max_len = 0;
-    foreach ( $strings as $str ) {
-      $len = strlen( $str );
-      if ( $len > $max_len )
+    foreach ($strings as $str) {
+      $len = strlen($str);
+      if ($len > $max_len)
         $max_len = $len;
     }
 
     return $max_len;
   }
+
 }
 
-Terminus::add_command( 'help', 'Help_Command' );
+Terminus::add_command('help', 'Help_Command');


### PR DESCRIPTION
Closes #208 
Closes #260 
![image](https://cloud.githubusercontent.com/assets/868204/9827759/805cd28a-589a-11e5-8934-9ca7b41e898d.png)

I found a logger which elegantly extends PSR's logger, and even had the same function names. It accepts an output destination, which effectively silences the logs whenever they are unwanted. What I've done here is:
-Exchanged the Terminus Logger for katzgrau's KLogger.
-Renamed the old logger to outputter and switched the things it still needs to handle output on to use the outputter instead
-Made properties in TerminusCommand for both logger and outputter, which is how they'd be called in the future.

If accepted, in the future:
-Get rid of TerminusCommand::logtype('message', array()) and use $this->logger->type('message') and $this->outputter->success/failure('message'), eliminating the redundant vsprintf commands in TerminusCommand.
-Create an outputter to replace the other outputting calls
