### PR TITLE
Fixed Environment#createBackups

### DIFF
--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -361,6 +361,10 @@ class Environment extends TerminusModel {
       'files'      => isset($args['files']),
       'ttl'        => $ttl
     );
+
+    $options  = array('environment' => $this->get('id'), 'params' => $params);
+    $workflow = $this->site->workflows->create('do_export', $options);
+    return $workflow;
   }
 
   /**

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -572,12 +572,9 @@ class Site_Command extends TerminusCommand {
         if (!array_key_exists('element',$assoc_args)) {
           $assoc_args['element'] = Input::menu(array('code', 'db', 'files', 'all'), 'all', 'Select element');
         }
-        $result = $site->environments->get($env)->createBackup($assoc_args);
-        if ($result) {
-          Terminus::success('Created backup');
-        } else {
-          Terminus::error('Could not create backup.');
-        }
+        $workflow = $site->environments->get($env)->createBackup($assoc_args);
+        $workflow->wait();
+        $this->workflowOutput($workflow);
         break;
       case 'list':
       default:


### PR DESCRIPTION
A portion of Environment#createBackups went missing last week, and is now restored. I'm not sure how we can go about testing this functionality with Behat/PHP-VCR, due to the latter's inability to repeat requests. (Therefore cannot A-B test.) I built the functionality to check it for the QA script, but using it would mean that CI would need access to a valid account to run. If anybody has an idea, it'd be most welcome.
