### PR TITLE
Renames clear-caches to clear-cache

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 #Change Log
 All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## [Unreleased][unreleased]
+### Changed
+- `site clear-caches` is now `site clear-cache` (#353)
+
 ##[0.8.0] - 2015-09-15
 ###Added
 - Environment variable TERMINUS_LOG_DIR will save all logs to file in the given directory. (#487)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 
 ## [Unreleased][unreleased]
 ### Changed
+- `site owner` now just returns the owner id. The --set flag has been removed. Setting is now done by `site set-owner`. (#469)
 - `site clear-caches` is now `site clear-cache` (#353)
 
 ##[0.8.0] - 2015-09-15

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -53,11 +53,11 @@ class Site_Command extends TerminusCommand {
    * : Environment to clear
    *
    * ## EXAMPLES
-   *  terminus site clear-caches --site=test
+   *  terminus site clear-cache --site=test
    *
-   * @subcommand clear-caches
+   * @subcommand clear-cache
    */
-  public function clear_caches($args, $assoc_args) {
+  public function clear_cache($args, $assoc_args) {
     $site = $this->sites->get(Input::sitename($assoc_args));
     $env_id = Input::env($assoc_args, 'env');
     $workflow = $site->workflows->create(

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -249,7 +249,7 @@ class FeatureContext extends BehatContext {
    * @return [void]
    */
   public function iClearTheCaches($env, $site) {
-    $this->iRun("terminus site clear-caches --site=$site --env=$env");
+    $this->iRun("terminus site clear-cache --site=$site --env=$env");
   }
 
   /**

--- a/tests/features/site_clear-cache.feature
+++ b/tests/features/site_clear-cache.feature
@@ -1,10 +1,10 @@
-Feature: site clear-caches
+Feature: site clear-cache
 
   Scenario: Clear Caches on a Site
-    @vcr site_clear-caches
+    @vcr site_clear-cache
     Given I am authenticated
     And a site named "[[test_site_name]]"
-    When I run "terminus site clear-caches --site=[[test_site_name]] --env=dev"
+    When I run "terminus site clear-cache --site=[[test_site_name]] --env=dev"
     Then I should get "."
     Then I should get:
     """

--- a/tests/fixtures/site_clear-cache
+++ b/tests/fixtures/site_clear-cache
@@ -34,6 +34,7 @@
         headers:
             Host: onebox
             Accept: null
+
             User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
             Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:

--- a/tests/qa_features/qa.feature
+++ b/tests/qa_features/qa.feature
@@ -164,7 +164,7 @@ Feature: Daily Terminus QA Report
     """
 
   Scenario: Clear caches on live
-    @clear-caches
+    @clear-cache
     Given I am authenticated
     And a site named "[[test_site_name]]"
     When I clear the caches on the "live" environment of "[[test_site_name]]"


### PR DESCRIPTION
Resolves #353 

Do we have a policy when we rename or remove commands? Should we deprecate the old one? Add a warning?
