### PR TITLE
Make setting owner action explicit.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,16 @@
 #Change Log
 All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+#Change Log
+All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
+
+## [Unreleased][unreleased]
+### Changed
+- `site owner` now just returns the owner id. The --set flag has been removed. Setting is now done by `site set-owner`. (#469)
+
+###Added
+- `site set owner --site=<site> --set=<owner>` sets the site owner to the given user id.
+
 ##[0.8.0] - 2015-09-15
 ###Added
 - Environment variable TERMINUS_LOG_DIR will save all logs to file in the given directory. (#487)

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -483,7 +483,7 @@ class Site extends TerminusModel {
     $new_owner = $this->user_memberships->get($owner);
     if ($new_owner == null) {
       Terminus::error(
-        'The new owner must first be a user. Try adding with `site team`'
+        'The new owner must first be a member of the team. Try adding with `site team`'
       );
     }
     $workflow = $this->workflows->create(

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -2,6 +2,7 @@
 
 namespace Terminus\Models;
 
+use \Terminus;
 use Terminus\Request;
 use Terminus\Deploy;
 use \TerminusCommand;
@@ -492,6 +493,9 @@ class Site extends TerminusModel {
       );
       return $workflow;
     }
+    Terminus::error(
+      'The owner cannot be changed on this site.'
+    );
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -480,22 +480,17 @@ class Site extends TerminusModel {
    * @return [stdClass] $data['data']
    */
   public function setOwner($owner = null) {
-    if ((boolean)$this->getFeature('change_management')) {
-      $new_owner = $this->user_memberships->get($owner);
-      if ($new_owner == null) {
-        Terminus::error(
-          'The new owner must first be a user. Try adding with `site team`'
-        );
-      }
-      $workflow = $this->workflows->create(
-        'promote_site_user_to_owner',
-        array('user_id' => $new_owner->get('id'))
+    $new_owner = $this->user_memberships->get($owner);
+    if ($new_owner == null) {
+      Terminus::error(
+        'The new owner must first be a user. Try adding with `site team`'
       );
-      return $workflow;
     }
-    Terminus::error(
-      'The owner cannot be changed on this site.'
+    $workflow = $this->workflows->create(
+      'promote_site_user_to_owner',
+      array('params' => array('user_id' => $new_owner->get('id')))
     );
+    return $workflow;
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -488,7 +488,11 @@ class Site extends TerminusModel {
     }
     $workflow = $this->workflows->create(
       'promote_site_user_to_owner',
-      array('params' => array('user_id' => $new_owner->get('id')))
+      array(
+        'params' => array(
+          'user_id' => $new_owner->get('id')
+        )
+      )
     );
     return $workflow;
   }

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -1379,27 +1379,38 @@ class Site_Command extends TerminusCommand {
   }
 
   /**
-  * Get or set owner
+  * Get the site owner
   *
   * ## OPTIONS
   *
   * [--site=<site>]
   * : Site to check
   *
-  * [--set=<value>]
-  * : new owner to set
-  *
   * @subcommand owner
   */
   public function owner($args, $assoc_args) {
     $site = $this->sites->get(Input::sitename($assoc_args));
-    if (!isset($assoc_args['set'])) {
-      Terminus::line($site->get('owner'));
-    } else {
-      $workflow = $site->setOwner($assoc_args['set']); 
-      $workflow->wait();
-      $this->workflowOutput($workflow);
-    }
+    $this->outputter->outputValue($site->get('owner'), 'Site Owner');
+  }
+
+  /**
+   * Set the site owner
+   *
+   * ## OPTIONS
+   *
+   * [--site=<site>]
+   * : Site to check
+   *
+   * [--set=<value>]
+   * : new owner to set
+   *
+   * @subcommand set-owner
+   */
+  public function set_owner($args, $assoc_args) {
+    $site = $this->sites->get(Input::sitename($assoc_args));
+    $workflow = $site->setOwner($assoc_args['set']);
+    $workflow->wait();
+    $this->workflowOutput($workflow);
   }
 
   /**


### PR DESCRIPTION
Resolves  #469

I've separated out these two commands but I wasn't able to set the owner on a site because none of the sites I tried had the 'change_management' feature. 

That situation was causing a php error so I put in a terminus failure at that point instead.

Not sure how to test this change.
