### PR TITLE
Backup file#493

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 #Change Log
 All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## [Unreleased][unreleased]
+### Changed
+- `site backup get` flag `--to-directory` is now `--to` and accepts either a directory or a file name (#493)
+
 ##[0.8.0] - 2015-09-15
 ###Added
 - Environment variable TERMINUS_LOG_DIR will save all logs to file in the given directory. (#487)

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -526,7 +526,7 @@ class Site_Command extends TerminusCommand {
         return $url->url;
         break;
     case 'load':
-      $assoc_args['to-directory'] = '/tmp';
+      $assoc_args['to'] = '/tmp';
       $assoc_args['element'] = 'database';
       if (isset($assoc_args['database'])) {
         $database = $assoc_args['database'];

--- a/php/commands/site.php
+++ b/php/commands/site.php
@@ -423,8 +423,8 @@ class Site_Command extends TerminusCommand {
     * [--element=<code|files|db|all>]
     * : Element to download or create. *all* only used for 'create'
     *
-    * [--to-directory=<directory>]
-    * : Absolute path of directory to download the file
+    * [--to=<directory|file>]
+    * : Absolute path of a directory or filename to save the downloaded backup to
     *
     * [--latest]
     * : If set the latest backup will be selected automatically
@@ -508,10 +508,13 @@ class Site_Command extends TerminusCommand {
 
         $url = $site->environments->get($env)->backupUrl($bucket, $element);
 
-        if (isset($assoc_args['to-directory'])) {
+        if (isset($assoc_args['to'])) {
+          $target = $assoc_args['to'];
+          if (is_dir($target)) {
+            $filename = \Terminus\Utils\get_filename_from_url($url->url);
+            $target = sprintf('%s/%s', $target, $filename);
+          }
           Terminus::line('Downloading ... please wait ...');
-          $filename = \Terminus\Utils\get_filename_from_url($url->url);
-          $target = sprintf('%s/%s', $assoc_args['to-directory'], $filename);
           if (TerminusCommand::download($url->url, $target)) {
             Terminus::success('Downloaded %s', $target);
             return $target;
@@ -519,7 +522,7 @@ class Site_Command extends TerminusCommand {
             Terminus::error('Could not download file');
           }
         }
-        Terminus::success($url->url);
+        $this->outputter->outputValue($url->url, 'Backup URL');
         return $url->url;
         break;
     case 'load':

--- a/scripts/create-local.sh
+++ b/scripts/create-local.sh
@@ -15,8 +15,8 @@ fi
 
 cd $LOCAL_DIR
 
-$TERMINUS site backup get --site=$SITENAME --element=files --env='dev' --to-directory=$LOCAL_DIR --latest || exit 1
-$TERMINUS site backup get --site=$SITENAME --element=db --env='dev' --to-directory=$LOCAL_DIR --latest || exit 1
+$TERMINUS site backup get --site=$SITENAME --element=files --env='dev' --to=$LOCAL_DIR --latest || exit 1
+$TERMINUS site backup get --site=$SITENAME --element=db --env='dev' --to=$LOCAL_DIR --latest || exit 1
 
 DB=$( ls . | grep "database.*gz" )
 FILES=$( ls . | grep "files.*gz" )


### PR DESCRIPTION
... allowing a filename to be specified or a directory.

Fixes #493

There are a few different ways to handle this. We could add another flag for '--to-file' but I opted to change `---to-directory` to `--to` and allow the user to specify a directory OR a file with that flag. It acts much the same way the target does in `mv` or `cp`. This simplifies the signature and does not allow for the ambiguous situation where a user adds both flags. It could lead to other ambiguity though so if the consensus is to make these separate flags, I'll do it that way instead.
