### PR TITLE
Adds better array display to pretty formatter

### DIFF
--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -98,7 +98,7 @@ class PrettyFormatter implements OutputFormatterInterface {
       $new = array();
       $record = (array)$record;
       foreach ($keys as $key) {
-        $new[$key] = isset($record[$key]) ? PrettyFormatter::flattenValue($record[$key]) : '';
+        $new[$key] = isset($record[$key]) ? PrettyFormatter::flattenValue($record[$key], $human_labels) : '';
       }
       $records[$i] = $new;
     }
@@ -164,10 +164,19 @@ class PrettyFormatter implements OutputFormatterInterface {
    * @param mixed $value
    * @return string
    */
-  private static function flattenValue($value) {
-    if (is_array($value) || is_object($value)) {
-      $value = join(', ', (array)$value);
+  private static function flattenValue($value, $human_labels = array()) {
+    if (is_scalar($value)) {
+      return $value;
     }
+
+    // Merge an array or object down. Doesn't look great past 2 levels of depth.
+    $is_assoc = is_array($value) && (bool)count(array_filter(array_keys($value), 'is_string'));
+    if ($is_assoc || is_object($value)) {
+      foreach ($value as $key => $val) {
+        $value[$key] = PrettyFormatter::getHumanLabel($key, $human_labels) . ': ' . PrettyFormatter::flattenValue($val, $human_labels);
+      }
+    }
+    $value = join(', ', (array)$value);
     return $value;
   }
 


### PR DESCRIPTION
Arrays and objects (especially nested ones) are hard to display in a human-readable format. This change improves that somewhat (currently second level arrays are just coerced to a string with a PHP notice). This changes this:

```
+---------------+---------------------------------------------------------------------------------------------+
| Key           | Value                                                                                       |
+---------------+---------------------------------------------------------------------------------------------+
| Id            | 4f503b5f-7f2a-4678-9599-bef049196584                                                        |
| Name          | rd-wordpress-test                                                                           |
| Label         |                                                                                             |
| Created       | 1426172351                                                                                  |
| Framework     | wordpress                                                                                   |
| Organization  |                                                                                             |
| Service Level | free                                                                                        |
| Upstream      | https://github.com/pantheon-systems/WordPress, e8fe8550-1ab9-4964-8838-2b9abdccf4bf, master |
| Php Version   | 55                                                                                          |
| Holder Type   | user                                                                                        |
| Holder Id     | 7d81b4c1-ca45-41ab-a175-1d238f9c25d5                                                        |
| Owner         | 7d81b4c1-ca45-41ab-a175-1d238f9c25d5                                                        |
| Membership    | 09f56b3d-e43f-4728-9589-c4c284f2fc60, Team, team                                            |
| Memberships   | Array                                                                                       |
+---------------+---------------------------------------------------------------------------------------------+
```

To this:

```
+---------------+----------------------------------------------------------------------------------------------------------------------+
| Key           | Value                                                                                                                |
+---------------+----------------------------------------------------------------------------------------------------------------------+
| Id            | 4f503b5f-7f2a-4678-9599-bef049196584                                                                                 |
| Name          | rd-wordpress-test                                                                                                    |
| Label         |                                                                                                                      |
| Created       | 1426172351                                                                                                           |
| Framework     | wordpress                                                                                                            |
| Organization  |                                                                                                                      |
| Service Level | free                                                                                                                 |
| Upstream      | Url: https://github.com/pantheon-systems/WordPress, Product Id: e8fe8550-1ab9-4964-8838-2b9abdccf4bf, Branch: master |
| Php Version   | 55                                                                                                                   |
| Holder Type   | user                                                                                                                 |
| Holder Id     | 7d81b4c1-ca45-41ab-a175-1d238f9c25d5                                                                                 |
| Owner         | 7d81b4c1-ca45-41ab-a175-1d238f9c25d5                                                                                 |
| Membership    | Id: 09f56b3d-e43f-4728-9589-c4c284f2fc60, Name: Team, Type: team                                                     |
| Memberships   | 09f56b3d-e43f-4728-9589-c4c284f2fc60: Id: 09f56b3d-e43f-4728-9589-c4c284f2fc60, Name: Team, Type: team               |
+---------------+----------------------------------------------------------------------------------------------------------------------+
```

Not amazing, but better.
