### PR TITLE
For discussion: Added i18n

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "symfony/dom-crawler": "2.7.*",
     "symfony/css-selector": "2.7.*",
     "vlucas/phpdotenv": "2.0.*@stable",
-    "katzgrau/klogger": "dev-master"
+    "katzgrau/klogger": "dev-master",
+    "philasearch/i18n": "1.0.*"
   },
   "autoload": {
     "psr-0": { "Terminus": "php" },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2d91f6bdfd8d298914043e663f95d520",
+    "hash": "a0dccfd164a1865314cd35e96f69cc9e",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -447,6 +447,80 @@
                 "php"
             ],
             "time": "2015-09-19 14:15:08"
+        },
+        {
+            "name": "philasearch/i18n",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/philasearch/php-i18n.git",
+                "reference": "2f837517bdd8d4e6ba4fed9012669f6c6d3677bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/philasearch/php-i18n/zipball/2f837517bdd8d4e6ba4fed9012669f6c6d3677bc",
+                "reference": "2f837517bdd8d4e6ba4fed9012669f6c6d3677bc",
+                "shasum": ""
+            },
+            "require": {
+                "philasearch/io": "1.0.0",
+                "symfony/yaml": "2.5.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.1",
+                "phpunit/phpunit": "4.0.20"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Philasearch\\": "lib/Philasearch/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Thomas Muntaner",
+                    "email": "muntaner@philasearch.com"
+                }
+            ],
+            "description": "An i18n library for PHP",
+            "homepage": "https://github.com/philasearch/php-i18n",
+            "time": "2014-09-09 14:43:32"
+        },
+        {
+            "name": "philasearch/io",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/philasearch/php-io.git",
+                "reference": "c3605b449c53775019c6a84e79d329356106762f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/philasearch/php-io/zipball/c3605b449c53775019c6a84e79d329356106762f",
+                "reference": "c3605b449c53775019c6a84e79d329356106762f",
+                "shasum": ""
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.1",
+                "phpunit/phpunit": "4.0.20"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Philasearch\\": "lib/Philasearch/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Thomas Muntaner",
+                    "email": "muntaner@philasearch.com"
+                }
+            ],
+            "description": "An io library for PHP",
+            "homepage": "https://github.com/philasearch/php-io",
+            "time": "2014-09-09 14:25:02"
         },
         {
             "name": "psr/log",
@@ -1029,6 +1103,55 @@
                 "dump"
             ],
             "time": "2015-09-22 14:41:01"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.5.2",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "f868ecdbcc0276b6158dfbf08b9e98ce07f014e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f868ecdbcc0276b6158dfbf08b9e98ce07f014e1",
+                "reference": "f868ecdbcc0276b6158dfbf08b9e98ce07f014e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-07-09 09:05:48"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -2614,55 +2737,6 @@
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
             "time": "2015-09-06 08:36:38"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.7.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-09-14 14:14:09"
         },
         {
             "name": "theseer/fdomdocument",

--- a/i18n/en/auth.yml
+++ b/i18n/en/auth.yml
@@ -1,0 +1,8 @@
+login:
+  validating: 'Validating session token'
+  success: 'You are now logged in as :user'
+  failure: 'Login failed'
+  need_email: 'What is your email address?'
+  need_password: 'What is your password? (Your input will not be displayed.)'
+  invalid_email: 'The provided email address is invalid.'
+  saving_session: 'Saving your session data.'

--- a/i18n/en/auth.yml
+++ b/i18n/en/auth.yml
@@ -6,3 +6,9 @@ login:
   need_password: 'What is your password? (Your input will not be displayed.)'
   invalid_email: 'The provided email address is invalid.'
   saving_session: 'Saving your session data.'
+  invalid_token: 'The session token is not valid.'
+logout: 
+  success: 'Logging out of Pantheon'
+  invalid: 'You are not logged in.'
+whoami:
+  invalid: 'You are not logged in.'

--- a/i18n/en/cli.yml
+++ b/i18n/en/cli.yml
@@ -1,0 +1,17 @@
+info:
+  php_binary_path: 'PHP binary'
+  php_version: 'PHP version'
+  php_in: 'php.ini used'
+  global_config_path : 'Terminus global config'
+  project_config_path : 'Terminus project config'
+  wp_cli_dir_path: 'Terminus root dir'
+  wp_cli_version: 'Terminus version'
+console:
+  not_logged_in: 'Please log in using `terminus auth login`.'
+cache_clear:
+  success: 'Your Terminus cache has been cleared.'
+session_clear:
+  success: 'Your Terminus session has been cleared.'
+version:
+  version: 'Terminus version'
+  script: 'Terminus script'

--- a/i18n/en/instruments.yml
+++ b/i18n/en/instruments.yml
@@ -1,0 +1,3 @@
+all:
+  label: 'Label'
+  id: 'ID'

--- a/i18n/en/organizations.yml
+++ b/i18n/en/organizations.yml
@@ -1,0 +1,18 @@
+all:
+  name: 'Name'
+  id: 'ID'
+sites:
+  confirm_add: 'Are you sure you want to add :site to :org?'
+  invalid_add: ':site is already a member of :org.'
+  select_site: 'Please select a site.'
+  select_org: 'Please select an organization.'
+  invalid_remove: ':site is not a member of :org'
+  confirm_remove: 'Are you sure you want to remove :site from :org?'
+  name: 'Name'
+  id: 'ID'
+  service_level: 'Service Level'
+  framework: 'Framework'
+  created: 'Created At'
+  tags: 'Tags'
+  success: 'The operation has succeeded.'
+  failure: 'The operation has failed.'

--- a/i18n/en/sites.yml
+++ b/i18n/en/sites.yml
@@ -1,0 +1,3 @@
+create:
+  success: 'Site :site has been created'
+  failure: 'Failed to create site :site'

--- a/i18n/en/terminus.yml
+++ b/i18n/en/terminus.yml
@@ -1,0 +1,6 @@
+responseOutput:
+  success: 'The operation has succeeded'
+  failure: 'The operation was unsuccessful'
+workflowOutput:
+  success: ':reason'
+  error: ':reason'

--- a/i18n/jp/auth.yml
+++ b/i18n/jp/auth.yml
@@ -1,0 +1,8 @@
+login:
+  validating: 'セッショントークンを検証しています。'
+  success: ':user としてログインしています。'
+  failure: 'ログインに失敗しました。'
+  need_email: 'メールとは何ですか？'
+  need_password: 'パスワードは何ですか？（入力は表示されません。）'
+  invalid_email: '指定したメールが無効です。'
+  saving_session: 'セッションデータを保存しています。'

--- a/i18n/jp/auth.yml
+++ b/i18n/jp/auth.yml
@@ -1,8 +1,14 @@
 login:
   validating: 'セッショントークンを検証しています。'
-  success: ':user としてログインしています。'
+  success: '「:user」としてログインしています。'
   failure: 'ログインに失敗しました。'
   need_email: 'メールとは何ですか？'
   need_password: 'パスワードは何ですか？（入力は表示されません。）'
   invalid_email: '指定したメールが無効です。'
   saving_session: 'セッションデータを保存しています。'
+  invalid_token: 'セッショントークンは無効です。'
+logout:
+  success: 'パンシオンからログアウトしています。'
+  invalid: 'ログインしていません。'
+whoami:
+  invalid: 'ログインしていません。'

--- a/i18n/jp/cli.yml
+++ b/i18n/jp/cli.yml
@@ -1,0 +1,17 @@
+info:
+  php_binary_path: 'PHPバイナリ'
+  php_version: 'PHPのバージョン'
+  php_ini: '使っているphp.ini'
+  global_config_path : 'ターミナスのグローバルコンフィギュレーション・パス'
+  project_config_path : 'ターミナスのプロジェックトコンフィギュレーション・パス'
+  wp_cli_dir_path: 'ターミナスのクライアントのディレクトリ・パス'
+  wp_cli_version: 'ターミナスのバージョン'
+console:
+  not_logged_in: '`terminus auth login`とログインして下さい。'
+cache_clear:
+  success: 'ターミナスのキャッシュはクリアされました。'
+session_clear:
+  success: 'ターミナスのセッションはクリアされました。'
+version:
+  version: 'ターミナッスバージョン'
+  script: 'ターミナッススクリップト'

--- a/i18n/jp/instruments.yml
+++ b/i18n/jp/instruments.yml
@@ -1,0 +1,3 @@
+all:
+  label: '名'
+  id: 'ID'

--- a/i18n/jp/organizations.yml
+++ b/i18n/jp/organizations.yml
@@ -1,0 +1,18 @@
+all:
+  name: '名'
+  id: 'ID'
+sites:
+  confirm_add: '「:org」に「:site」を追加しますか？'
+  invalid_add: '「:site」はすでに「:org」のメンバーです。'
+  select_site: 'サイトを選択して下さい。'
+  select_org: '組織を選択して下さい。'
+  invalid_remove: '「:site」は、「:org」のメンバーではありません。'
+  confirm_remove: '「:org」から「:site」を削除してもよろしいですか？'
+  name: '名'
+  id: 'ID'
+  service_level: 'サービスレベル'
+  framework: 'フレームワーク'
+  created: '作成時間'
+  tags: 'タグ'
+  success: '操作が成功しました。'
+  failure: '操作が成功しませんでした。'

--- a/i18n/jp/sites.yml
+++ b/i18n/jp/sites.yml
@@ -1,0 +1,3 @@
+create:
+  success: 'サイト「:site」を作りました。'
+  failure: 'サイト「:site」を作る事が出来ませんでした。'

--- a/i18n/jp/terminus.yml
+++ b/i18n/jp/terminus.yml
@@ -1,0 +1,6 @@
+responseOutput:
+  success: '操作は成功しました。'
+  failure: '操作は成功しませんでした。'
+workflowOutput:
+  success: ':reason'
+  error: ':reason'

--- a/php/Terminus/Auth.php
+++ b/php/Terminus/Auth.php
@@ -1,17 +1,29 @@
 <?php
+
 namespace Terminus;
 
-use Terminus\Exceptions\TerminusException;
-use Terminus\FileCache;
-use Terminus;
 use Terminus\Session;
 
 class Auth {
 
-  public static function loggedIn() {
-    if (Session::instance()->getValue('session', false) === false) {
-      throw new TerminusException("Please login first with `terminus auth login`");
-    }
+  /**
+   * Returns current user
+   *
+   * @return [string] $user
+   */
+  public static function getUser() {
+    $user = Session::getValue('email');
+    return $user;
+  }
+
+  /**
+   * Detects whether the user is logged in
+   *
+   * @return [boolean] $logged_in True when user is logged in
+   */
+  public static function isLoggedIn() {
+    $logged_in = (boolean)Session::instance()->getValue('session', false);
+    return $logged_in;
   }
 
 }

--- a/php/Terminus/Dispatcher/Subcommand.php
+++ b/php/Terminus/Dispatcher/Subcommand.php
@@ -9,7 +9,7 @@ use Terminus\Exceptions\TerminusException;
 class Subcommand extends CompositeCommand {
 
   private $alias;
-
+  private $logger;
   private $when_invoked;
 
   function __construct( $parent, $name, $docparser, $when_invoked ) {
@@ -59,7 +59,7 @@ class Subcommand extends CompositeCommand {
     try {
       $response = \cli\prompt( $question, $default );
     } catch( \Exception $e ) {
-      \Terminus::line();
+      $this->logger->info($question);
       return false;
     }
 

--- a/php/Terminus/Exceptions/TerminusException.php
+++ b/php/Terminus/Exceptions/TerminusException.php
@@ -7,6 +7,7 @@
 
 namespace Terminus\Exceptions;
 
+use Terminus\Internationalizer as I18n;
 
 /**
  * Class TerminusException
@@ -18,16 +19,9 @@ class TerminusException extends \Exception {
    */
   private $replacements;
 
-  public function __construct($message = null, $replacements = array(), $code = 0)
-  {
-    $this->replacements = $replacements;
+  public function __construct($message = null, $replacements = array(), $code = 0) {
+    $i18n    = new I18n();
+    //$message = $i18n->get($message, $replacements);
     parent::__construct($message, $code);
-  }
-
-  /**
-   * @return array
-   */
-  public function getReplacements() {
-    return $this->replacements;
   }
 }

--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -6,6 +6,8 @@ use Terminus\Exceptions\TerminusException;
 use \Terminus\Models\User;
 use Terminus\Models\Collections\Sites;
 use \Terminus\Models\Collections\Upstreams;
+//TODO: Bring the inputter in here, replace I18n
+use Terminus\Internationalizer as I18n;
 
 /**
  * Helper class to handle inputs
@@ -60,6 +62,8 @@ class Input {
       $return_value = false
   ) {
     echo PHP_EOL;
+    $i18n = new I18n();
+    $text = $i18n->get($text);
     $index = \cli\Streams::menu($choices, $default, $text);
     if ($return_value) {
       return $choices[$index];
@@ -126,7 +130,8 @@ class Input {
       $orglist_with_id[$id] = sprintf("%s (%s)", $name, $id);
     }
 
-    $org = \Terminus::menu($orglist_with_id, false, "Choose organization");
+    $i18n = new I18n();
+    $org = \Terminus::menu($orglist_with_id, false, $i18n->get('select_org'));
     if($org == '-') {
       return $default;
     }

--- a/php/Terminus/Inputters/Inputter.php
+++ b/php/Terminus/Inputters/Inputter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Terminus\Inputters;
+
+use Terminus\Internationalizer as I18n;
+use Terminus\Outputters\Outputter;
+
+class Inputter {
+
+  /**
+   * @var Outputter
+   */
+  private $outputter;
+
+  /**
+   * Constructs inputter
+   *
+   * @param [Outputter] $outputter
+   * @return [Inputter] $this
+   */
+  public function __construct(Outputter $outputter) {
+    $this->outputter = $outputter;
+  }
+
+  /**
+   * Outputs a prompt and collects the result
+   *
+   * @param [string] $key     I18n key for output
+   * @param [array]  $context Replacements for variables in i18n string
+   * @return $response
+   */
+  public function promptForInput($key, $context = array()) {
+    $i18n = new I18n();
+    $this->outputter->getWriter()->write($i18n->get($key, $context));
+    if (strpos($key, 'password') === false) {
+      $response = $this->getInput();
+    } else {
+      $response = $this->getInputSilently();
+    } 
+    return $response;
+  }
+
+  /**
+   * Gets input from STDIN
+   *
+   * @return [string] $response
+   */
+  private function getInput() {
+    $line = readline();
+    $response = trim($line);
+    return $response;
+  }
+
+  /**
+   * Gets input from STDIN silently
+   * By: Troels Knak-Nielsen
+   * From: http://www.sitepoint.com/interactive-cli-password-prompt-in-php/
+   *
+   * @return $password
+   */
+  private function getInputSilently() {
+    if (preg_match('/^win/i', PHP_OS)) {
+      $vbscript = sys_get_temp_dir() . 'prompt_password.vbs';
+      file_put_contents(
+        $vbscript, 'wscript.echo(InputBox("'
+        . addslashes($prompt)
+        . '", "", "password here"))');
+      $command = "cscript //nologo " . escapeshellarg($vbscript);
+      $password = rtrim(shell_exec($command));
+      unlink($vbscript);
+      return $password;
+    } else {
+      $command = "/usr/bin/env bash -c 'echo OK'";
+      if (rtrim(shell_exec($command)) !== 'OK') {
+        trigger_error("Can't invoke bash");
+        return;
+      }
+      $command = "/usr/bin/env bash -c 'read -s -p \""
+        . addslashes($prompt)
+        . "\" mypassword && echo \$mypassword'";
+      $password = rtrim(shell_exec($command));
+      echo "\n";
+      return $password;
+    }
+  }
+
+}

--- a/php/Terminus/Internationalizer.php
+++ b/php/Terminus/Internationalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Terminus;
+
+use Philasearch\I18n\I18n as Lang;
+
+class Internationalizer {
+
+  private $internationalizer;
+  private $language;
+
+  /**
+   * Sets up object
+   *
+   * @return [Internationalizer] $this
+   */
+  public function __construct() {
+    $this->setInternationalizer();
+    $this->setLanguage();
+  }
+
+  /**
+   * Returns text in target language
+   *
+   * @param [string] $key          Name of key to retrieve
+   * @param [array]  $replacements List of variables to replace
+   * @return [string] $output
+   */
+  public function get($key, $replacements = array()) {
+    $string_name = $this->getRoute() . '.' . $key;
+    $output = $this->internationalizer->get(
+      $this->language,
+      $string_name,
+      $replacements
+    );
+    return $output;
+  }
+
+  /**
+   * Parses the route to find translated text
+   *
+   * @return [string] $route
+   */
+  private function getRoute() {
+    $backtrace = debug_backtrace();
+    $backtrace = array_reverse($backtrace);
+    $route     = '';
+    while ($route == '') {
+      $last_command = array_shift($backtrace);
+      if (strpos($last_command['class'], '_Command') != false) {
+        $route = strtolower(str_replace('_Command', '', $last_command['class']));
+        $route .= '.' . $last_command['function'];
+      }
+    }
+    return $route;
+  }
+
+  /**
+   * Instantiates the internationalizer
+   *
+   * @return [void]
+   */
+  private function setInternationalizer() {
+    $this->internationalizer = new Lang(TERMINUS_ROOT . '/i18n');
+  }
+
+  /**
+   * Sets the language to use
+   *
+   * @return [void]
+   */
+  private function setLanguage() {
+    if (!isset($_SERVER['TERMINUS_LANG'])) {
+      $this->language = 'en';
+    } else {
+      $this->language = $_SERVER['TERMINUS_LANG'];
+    }
+  }
+
+}

--- a/php/Terminus/Internationalizer.php
+++ b/php/Terminus/Internationalizer.php
@@ -33,6 +33,9 @@ class Internationalizer {
       $string_name,
       $replacements
     );
+    if ($output == '') {
+      return $key;
+    }
     return $output;
   }
 

--- a/php/Terminus/Outputters/BashFormatter.php
+++ b/php/Terminus/Outputters/BashFormatter.php
@@ -22,9 +22,10 @@ class BashFormatter implements OutputFormatterInterface {
    *
    * @param mixed $value
    *  The scalar value to format
+   * @param [string] $label Key for label to look up
    * @return string
    */
-  public function formatValue($value) {
+  public function formatValue($value, $label = '') {
     $value = BashFormatter::flattenValue($value);
     return $value . BashFormatter::ROW_SEPARATOR;
   }

--- a/php/Terminus/Outputters/BashFormatter.php
+++ b/php/Terminus/Outputters/BashFormatter.php
@@ -18,15 +18,13 @@ class BashFormatter implements OutputFormatterInterface {
   const VALUE_SEPARATOR = ',';
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
    * @param mixed $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
    * @return string
    */
-  public function formatValue($value, $human_label = '') {
+  public function formatValue($value) {
     $value = BashFormatter::flattenValue($value);
     return $value . BashFormatter::ROW_SEPARATOR;
   }
@@ -36,11 +34,9 @@ class BashFormatter implements OutputFormatterInterface {
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
+  public function formatRecord($record) {
     $out = '';
     foreach ((array)$record as $key => $value) {
       $value = BashFormatter::flattenValue($value);
@@ -54,12 +50,9 @@ class BashFormatter implements OutputFormatterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function formatValueList($values, $human_label = '') {
+  public function formatValueList($values) {
     $out = '';
     foreach ($values as $value) {
       $out .= $this->formatValue($value);
@@ -72,11 +65,9 @@ class BashFormatter implements OutputFormatterInterface {
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
+  public function formatRecordList($records) {
     $out = '';
     foreach ($records as $record) {
       foreach ((array)$record as $value) {

--- a/php/Terminus/Outputters/JSONFormatter.php
+++ b/php/Terminus/Outputters/JSONFormatter.php
@@ -29,15 +29,13 @@ class JSONFormatter implements OutputFormatterInterface {
   }
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
    * @param mixed $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
    * @return string
    */
-  public function formatValue($value, $human_label = '') {
+  public function formatValue($value) {
     return json_encode($value, $this->json_options);
   }
 
@@ -46,11 +44,9 @@ class JSONFormatter implements OutputFormatterInterface {
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
+  public function formatRecord($record) {
     return json_encode((array)$record, $this->json_options);
   }
 
@@ -59,12 +55,9 @@ class JSONFormatter implements OutputFormatterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function formatValueList($values, $human_label = '') {
+  public function formatValueList($values) {
     return json_encode((array)$values, $this->json_options);
   }
 
@@ -73,11 +66,9 @@ class JSONFormatter implements OutputFormatterInterface {
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
+  public function formatRecordList($records) {
     return json_encode((array)$records, $this->json_options);
   }
 

--- a/php/Terminus/Outputters/JSONFormatter.php
+++ b/php/Terminus/Outputters/JSONFormatter.php
@@ -33,9 +33,10 @@ class JSONFormatter implements OutputFormatterInterface {
    *
    * @param mixed $value
    *  The scalar value to format
+   * @param [string] $label Key for label to look up
    * @return string
    */
-  public function formatValue($value) {
+  public function formatValue($value, $label = '') {
     return json_encode($value, $this->json_options);
   }
 

--- a/php/Terminus/Outputters/OutputFormatterInterface.php
+++ b/php/Terminus/Outputters/OutputFormatterInterface.php
@@ -13,26 +13,22 @@ namespace Terminus\Outputters;
 interface OutputFormatterInterface {
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
    * @param mixed $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
    * @return string
    */
-  public function formatValue($value, $human_label = '');
+  public function formatValue($value);
 
   /**
    * Format a single record or object
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function formatRecord($record, $human_labels = array());
+  public function formatRecord($record);
 
 
   /**
@@ -40,23 +36,18 @@ interface OutputFormatterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function formatValueList($values, $human_label = '');
+  public function formatValueList($values);
 
   /**
    * Format a list of records of the same type.
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function formatRecordList($records, $human_labels = array());
+  public function formatRecordList($records);
 
   /**
    * Format any kind of value as a raw dump.

--- a/php/Terminus/Outputters/OutputFormatterInterface.php
+++ b/php/Terminus/Outputters/OutputFormatterInterface.php
@@ -17,9 +17,10 @@ interface OutputFormatterInterface {
    *
    * @param mixed $value
    *  The scalar value to format
+   * @param [string] $label Key for label to look up
    * @return string
    */
-  public function formatValue($value);
+  public function formatValue($value, $label);
 
   /**
    * Format a single record or object

--- a/php/Terminus/Outputters/Outputter.php
+++ b/php/Terminus/Outputters/Outputter.php
@@ -49,10 +49,13 @@ class Outputter implements OutputterInterface {
    *
    * @param mixed $value
    *  The scalar value to format
+   * @param [string] $label Key for I18n label
    * @return string
    */
-  public function outputValue($value) {
-    $this->getWriter()->write($this->getFormatter()->formatValue($value));
+  public function outputValue($value, $label = '') {
+    $value = $this->i18n->get($value);
+    $label = $this->i18n->get($label);
+    $this->getWriter()->write($this->getFormatter()->formatValue($value, $label));
   }
 
   /**

--- a/php/Terminus/Outputters/Outputter.php
+++ b/php/Terminus/Outputters/Outputter.php
@@ -37,16 +37,14 @@ class Outputter implements OutputterInterface {
 
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
    * @param mixed $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
    * @return string
    */
-  public function outputValue($value, $human_label = '') {
-    $this->getWriter()->write($this->getFormatter()->formatValue($value, $human_label));
+  public function outputValue($value) {
+    $this->getWriter()->write($this->getFormatter()->formatValue($value));
   }
 
   /**
@@ -54,12 +52,10 @@ class Outputter implements OutputterInterface {
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function outputRecord($record, $human_labels = array()) {
-    $this->getWriter()->write($this->getFormatter()->formatRecord($record, $human_labels));
+  public function outputRecord($record) {
+    $this->getWriter()->write($this->getFormatter()->formatRecord($record));
   }
 
   /**
@@ -67,13 +63,10 @@ class Outputter implements OutputterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function outputValueList($values, $human_label = '') {
-    $this->getWriter()->write($this->getFormatter()->formatRecord($values, $human_label));
+  public function outputValueList($values) {
+    $this->getWriter()->write($this->getFormatter()->formatRecord($values));
   }
 
   /**
@@ -81,12 +74,10 @@ class Outputter implements OutputterInterface {
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function outputRecordList($records, $human_labels = array()) {
-    $this->getWriter()->write($this->getFormatter()->formatRecordList($records, $human_labels));
+  public function outputRecordList($records) {
+    $this->getWriter()->write($this->getFormatter()->formatRecordList($records));
   }
 
   /**

--- a/php/Terminus/Outputters/OutputterInterface.php
+++ b/php/Terminus/Outputters/OutputterInterface.php
@@ -27,26 +27,22 @@ interface OutputterInterface {
   public function setFormatter(OutputFormatterInterface $formatter);
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
    * @param mixed $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
    * @return string
    */
-  public function outputValue($value, $human_label = '');
+  public function outputValue($value);
 
   /**
    * Format a single record or object
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function outputRecord($record, $human_labels = array());
+  public function outputRecord($record);
 
 
   /**
@@ -54,23 +50,18 @@ interface OutputterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function outputValueList($values, $human_label = '');
+  public function outputValueList($values);
 
   /**
    * Format a list of records of the same type.
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function outputRecordList($records, $human_labels = array());
+  public function outputRecordList($records);
 
   /**
    * Output any variable type as a raw dump.

--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -158,7 +158,7 @@ class PrettyFormatter implements OutputFormatterInterface {
   private static function getHumanLabel($key, $autolabel = true) {
     $i18n  = new I18n();
     $label = $i18n->get($key);
-    if ($label == '') {
+    if ($label == $key) {
       if (!$autolabel) {
         return false;
       }

--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -7,21 +7,27 @@
 
 namespace Terminus\Outputters;
 
+use Terminus\Internationalizer as I18n;
+
 
 class PrettyFormatter implements OutputFormatterInterface {
 
   /**
-   * Formats a single scalar value with an optional human label.
+   * Formats a single scalar value.
    *
-   * @param mixed $value
+   * @param [mixed] $value
    *  The scalar value to format
-   * @param string $human_label
-   *  The human readable label for the value
-   * @return string
+   * @return [string] $human_label
    */
-  public function formatValue($value, $human_label = '') {
+  public function formatValue($value) {
     $value = PrettyFormatter::flattenValue($value);
-    return $human_label ? "$human_label: $value" . PHP_EOL : $value;
+    $label = self::getHumanLabel($value, $autolabel = false);
+
+    $human_label = $value;
+    if ($label) {
+      $human_label = "$label: $value";
+    }
+    return $human_label;
   }
 
   /**
@@ -29,23 +35,22 @@ class PrettyFormatter implements OutputFormatterInterface {
    *
    * @param array|object $record
    *   A key/value array or object
-   * @param array $human_labels
-   *   A key/value array mapping the keys in the record to human labels
    * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
+  public function formatRecord($record) {
     // No output for empty records. This should be handled by the logger with a friendly message.
     if (empty($record)) {
       return '';
     }
 
     // Normalize the keys
+    $human_labels = array_keys($record);
     $rows = array();
 
     // Get the headers
     $record = (array)$record;
     foreach ((array)$record as $key => $value) {
-      $label = self::getHumanLabel($key, $human_labels);
+      $label = self::getHumanLabel($key);
       $rows[] = array($label, $value);
     }
 
@@ -57,13 +62,10 @@ class PrettyFormatter implements OutputFormatterInterface {
    *
    * @param array $values
    *  The values to format
-   * @param string $human_label
-   *  A human name for the entire list. If each value needs a separate label then
-   *  formatRecord should be used.
    * @return string
    */
-  public function formatValueList($values, $human_label = '') {
-    $this->formatValue(implode(', ', $values), $human_label);
+  public function formatValueList($values) {
+    $this->formatValue(implode(', ', $values));
   }
 
   /**
@@ -71,11 +73,9 @@ class PrettyFormatter implements OutputFormatterInterface {
    *
    * @param array $records
    *  A list of arrays or objects.
-   * @param array $human_labels
-   *  An array that maps the record keys to human names.
    * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
+  public function formatRecordList($records) {
     // No output for empty records. This should be handled by the logger with a friendly message.
     if (empty($records)) {
       return '';
@@ -98,13 +98,13 @@ class PrettyFormatter implements OutputFormatterInterface {
       $new = array();
       $record = (array)$record;
       foreach ($keys as $key) {
-        $new[$key] = isset($record[$key]) ? PrettyFormatter::flattenValue($record[$key], $human_labels) : '';
+        $new[$key] = isset($record[$key]) ? PrettyFormatter::flattenValue($record[$key]) : '';
       }
       $records[$i] = $new;
     }
     // Get the headers
     foreach ($keys as $key) {
-      $header[] = self::getHumanLabel($key, $human_labels);
+      $header[] = self::getHumanLabel($key);
     }
 
     return $this->formatTable($records, $header);
@@ -150,12 +150,20 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Get the human name for a key if available.
    *
-   * @param string $key
-   * @param array $human_labels
-   * @return string
+   * @param [string] $key
+   * @param [boolean] $autolabel If true, will return a label made from the key
+   * @return [string] $label
    */
-  private static function getHumanLabel($key, $human_labels) {
-    return isset($human_labels[$key]) ? $human_labels[$key] : ucwords(strtr($key, '_', ' '));
+  private static function getHumanLabel($key, $autolabel = true) {
+    $i18n  = new I18n();
+    $label = $i18n->get($key);
+    if ($label == '') {
+      if (!$autolabel) {
+        return false;
+      }
+      $label = ucwords(strtr($key, '_', ' '));
+    }
+    return $label;
   }
 
   /**
@@ -164,7 +172,7 @@ class PrettyFormatter implements OutputFormatterInterface {
    * @param mixed $value
    * @return string
    */
-  private static function flattenValue($value, $human_labels = array()) {
+  private static function flattenValue($value) {
     if (is_scalar($value)) {
       return $value;
     }
@@ -173,7 +181,7 @@ class PrettyFormatter implements OutputFormatterInterface {
     $is_assoc = is_array($value) && (bool)count(array_filter(array_keys($value), 'is_string'));
     if ($is_assoc || is_object($value)) {
       foreach ($value as $key => $val) {
-        $value[$key] = PrettyFormatter::getHumanLabel($key, $human_labels) . ': ' . PrettyFormatter::flattenValue($val, $human_labels);
+        $value[$key] = PrettyFormatter::getHumanLabel($key) . ': ' . PrettyFormatter::flattenValue($val);
       }
     }
     $value = join(', ', (array)$value);

--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -17,11 +17,12 @@ class PrettyFormatter implements OutputFormatterInterface {
    *
    * @param [mixed] $value
    *  The scalar value to format
+   * @param [string] $label Key for label to look up
    * @return [string] $human_label
    */
-  public function formatValue($value) {
+  public function formatValue($value, $label = '') {
     $value = PrettyFormatter::flattenValue($value);
-    $label = self::getHumanLabel($value, $autolabel = false);
+    $label = self::getHumanLabel($label, $autolabel = false);
 
     $human_label = $value;
     if ($label) {

--- a/php/Terminus/Request.php
+++ b/php/Terminus/Request.php
@@ -69,7 +69,11 @@ class Request {
         \Terminus::log('debug', $data['body']);
     }
 
-    $response = $request->send();
+    try {
+      $response = $request->send();
+    } catch(\Exception $e) {
+      return false;
+    }
 
     return $response;
   }

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -35,6 +35,7 @@ class Runner {
     $this->init_colorization();
     $this->init_logger();
     $this->init_outputter();
+    $this->init_inputter(Terminus::get_outputter());
   }
 
   public function __get($key) {
@@ -115,7 +116,32 @@ class Runner {
   }
 
   private function init_outputter() {
+    $formatter = $this->pick_formatter();
 
+    // Create an output service.
+    $outputter = new Terminus\Outputters\Outputter(
+      new Terminus\Outputters\StreamWriter('php://stdout'),
+      $formatter
+    );
+
+    Terminus::set_outputter($outputter);
+  }
+
+  private function init_inputter($outputter) {
+    // Create an input service.
+    $inputter = new Terminus\Inputters\Inputter(
+      $outputter
+    );
+
+    Terminus::set_inputter($inputter);
+  }
+
+  /**
+   * Checks the config and picks out the appropriate formatter
+   *
+   * @return [Formatter] $formatter
+   */
+  private function pick_formatter() {
     // Pick an output formatter
     if ($this->config['json']) {
       $formatter = new Terminus\Outputters\JSONFormatter();
@@ -126,15 +152,7 @@ class Runner {
     else {
       $formatter = new Terminus\Outputters\PrettyFormatter();
     }
-    // @TODO: Implement BASH output formatter
-
-    // Create an output service.
-    $this->outputter = new Terminus\Outputters\Outputter(
-      new Terminus\Outputters\StreamWriter('php://stdout'),
-      $formatter
-    );
-
-    Terminus::set_outputter($this->outputter);
+    return $formatter;
   }
 
   private function init_config() {

--- a/php/Terminus/Session.php
+++ b/php/Terminus/Session.php
@@ -56,7 +56,6 @@ class Session {
 
   public static function setData( $data ) {
     $cache = Terminus::get_cache();
-    Terminus::log('info', 'Saving session data');
     $cache->put_data('session', $data);
     $session = self::instance();
     $session->set('data',$data);

--- a/php/Terminus/SynopsisValidator.php
+++ b/php/Terminus/SynopsisValidator.php
@@ -42,7 +42,6 @@ class SynopsisValidator {
         return false;
       }
       $regex = "#^($token)$#s";
-      \Terminus::log('debug', "Positional match $regex");
 
       if (!preg_match($regex, $args[$i])) {
         return $args[$i];

--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -63,7 +63,7 @@ abstract class TerminusCommand {
     $options = null
   ) {
     if (!in_array($realm, array('login', 'user', 'public')) && !Auth::isLoggedIn()) {
-      $this->logger->error('Please log in using `terminus auth login`.');
+      \Terminus::get_logger()->error('not_logged_in');
     }
 
     try {

--- a/php/class-terminus-command.php
+++ b/php/class-terminus-command.php
@@ -62,8 +62,8 @@ abstract class TerminusCommand {
     $method = 'GET',
     $options = null
   ) {
-    if (!in_array($realm, array('login', 'user', 'public'))) {
-      Auth::loggedIn();
+    if (!in_array($realm, array('login', 'user', 'public')) && !Auth::isLoggedIn()) {
+      $this->logger->error('Please log in using `terminus auth login`.');
     }
 
     try {

--- a/php/class-terminus.php
+++ b/php/class-terminus.php
@@ -3,6 +3,7 @@
 use Terminus\Configurator;
 use Terminus\Dispatcher;
 use Terminus\FileCache;
+use Terminus\Internationalizer as I18n;
 use Terminus\Runner;
 use Terminus\Utils;
 
@@ -191,9 +192,11 @@ class Terminus {
   /**
    * Ask for confirmation before running a destructive operation.
    */
+  //TODO: Move this functionality to the inputter/input helper
   static function confirm($question, $assoc_args = array(), $params = array()) {
+      $i18n = new I18n();
       if(\Terminus::get_config('yes')) return true;
-      $question = vsprintf($question, $params);
+      $question = $i18n->get($question, $params);
       fwrite(STDOUT, $question . " [y/n] ");
 
       $answer = trim(fgets(STDIN));

--- a/php/class-terminus.php
+++ b/php/class-terminus.php
@@ -13,6 +13,7 @@ class Terminus {
   private static $configurator;
   private static $hooks = array();
   private static $hooks_passed = array();
+  private static $inputter;
   private static $logger;
   private static $outputter;
 
@@ -312,21 +313,31 @@ class Terminus {
   }
 
   /**
-   * @param $type
-   * @param $message
-   * @param array $context
+   * Set the inputter instance.
+   *
+   * @param [object] $inputter
+   * @return [void]
    */
-  static function log($type, $message, $context = array()) {
-    self::$logger->log($type, $message, $context);
+  static function set_inputter($inputter) {
+    self::$inputter = $inputter;
   }
 
   /**
-   * Set the logger instance.
+   * Set the outputter instance.
    *
    * @param LoggerInterface $logger
    */
   static function set_logger($logger) {
     self::$logger = $logger;
+  }
+
+  /**
+   * Retrieves the instantiated inputter
+   *
+   * @return [Inputter] $inputter
+   */
+  static function get_inputter() {
+    return self::$inputter;
   }
 
   /**

--- a/php/commands/auth.php
+++ b/php/commands/auth.php
@@ -3,8 +3,8 @@
  * Authenticate to Pantheon and store a local secret token.
  *
  */
-use Terminus\Exceptions\TerminusException;
-use Terminus\Request as Request;
+ use Terminus\Request as Request;
+ use Terminus\Auth;
  use Terminus\Utils;
  use Symfony\Component\DomCrawler\Crawler;
  use Guzzle\Parser\Cookie\CookieParser;
@@ -32,7 +32,7 @@ class Auth_Command extends TerminusCommand {
    * [--debug]
    * : dump call information when logging in.
    */
-  public function login( $args, $assoc_args ) {
+  public function login($args, $assoc_args) {
     # First try to login using a session token if provided
     if (isset($assoc_args['session'])) {
       $this->logger->info('validating');
@@ -92,35 +92,22 @@ class Auth_Command extends TerminusCommand {
    * Log yourself out and remove the secret session key.
    */
   public function logout() {
-    $this->log()->info( "Logging out of Pantheon." );
-    $this->cache->remove('session');
+    if (Auth::isLoggedIn()) {
+      $this->logger->info('success');
+      $this->cache->remove('session');
+    } else {
+      $this->logger->error('invalid');
+    }
   }
 
   /**
    * Find out what user you are logged in as.
    */
   public function whoami() {
-    if (Session::getValue('email')) {
-      $this->output()->outputValue(Session::getValue('email'), "You are authenticated as");
-    }
-    else {
-      $this->log()->warning( "You are not logged in." );
-    }
-  }
-
-  private function _checkSession() {
-    if ((!property_exists($this, "session")) || (!property_exists($this->session, "user_uuid"))) {
-      return false;
-    }
-    $results = $this->terminus_request("user", $this->session->user_uuid, "profile", "GET");
-    if ($results['info']['http_code'] >= 400){
-      $this->log()->error("Expired Session, please re-authenticate.");
-      $this->cache->remove('session');
-      Terminus::launch_self("auth", array("login"));
-      $this->whoami();
-      return true;
+    if (Auth::isLoggedIn()) {
+      $this->outputter->outputValue(Auth::getUser(), 'user');
     } else {
-      return (($results['info']['http_code'] <= 199 )||($results['info']['http_code'] >= 300 ))? false : true;
+      $this->logger->error('invalid');
     }
   }
 
@@ -166,19 +153,17 @@ class Auth_Command extends TerminusCommand {
    * @param $session_token string (required)
    * @return array
    */
-  private function doLoginFromSessionToken($session_token)
-  {
-
+  private function doLoginFromSessionToken($session_token) {
     $options = array(
-        'headers' => array('Content-type'=>'application/json'),
-        'cookies' => array('X-Pantheon-Session' => $session_token),
+      'headers' => array('Content-type' => 'application/json'),
+      'cookies' => array('X-Pantheon-Session' => $session_token),
     );
 
     # Temporarily disable the cache for this GET call
     $response = TerminusCommand::request('user', '', '', 'GET', $options);
 
     if ( !$response OR '200' != @$response['info']['http_code'] ) {
-      throw new TerminusException("Session token not valid");
+      $this->logger->error('invalid_token');
     }
 
     // Prepare credentials for storage.

--- a/php/commands/cli.php
+++ b/php/commands/cli.php
@@ -38,8 +38,7 @@ class CLI_Command extends TerminusCommand {
    * Print Terminus version.
    */
   function version() {
-    $labels = array('version' => 'Terminus version', 'script' => 'Terminus script');
-    $this->output()->outputRecord(array('version' => TERMINUS_VERSION, 'script' => TERMINUS_SCRIPT), $labels);
+    $this->outputter->outputRecord(array('version' => TERMINUS_VERSION, 'script' => TERMINUS_SCRIPT));
   }
 
   /**
@@ -64,17 +63,7 @@ class CLI_Command extends TerminusCommand {
       'wp_cli_dir_path' => TERMINUS_ROOT,
       'wp_cli_version' => TERMINUS_VERSION,
     );
-    $labels = array(
-      'php_binary_path' => 'PHP binary',
-      'php_version' => 'PHP version',
-      'php_ini' => 'php.ini used',
-      'global_config_path' => 'Terminus global config',
-      'project_config_path' => 'Terminus project config',
-      'wp_cli_dir_path' => 'Terminus root dir',
-      'wp_cli_version' => 'Terminus version',
-    );
-    $this->output()->outputRecord($info, $labels);
-
+    $this->outputter->outputRecord($info);
   }
 
   /**
@@ -118,6 +107,7 @@ class CLI_Command extends TerminusCommand {
   */
   function session_clear() {
     $this->cache->remove("session");
+    $this->logger->info('success');
   }
 
   /**
@@ -142,9 +132,11 @@ class CLI_Command extends TerminusCommand {
   public function cache_clear($args, $assoc_args) {
     if (isset($assoc_args['cache'])) {
       $this->cache->remove($assoc_args['cache']);
+      $args['cache'] = $assoc_args['cache'];
     } else {
       $this->cache->flush();
     }
+    $this->logger->info('success');
   }
 
   /**
@@ -158,7 +150,7 @@ class CLI_Command extends TerminusCommand {
   * @subcommand console
   */
   public function console($args, $assoc_args) {
-    $user = new User(new stdClass(), array());
+    $user = new User();
     if (isset($assoc_args['site'])) {
       $sitename = $assoc_args['site'];
       $site_id = $this->sitesCache->findID($sitename);

--- a/php/commands/organizations.php
+++ b/php/commands/organizations.php
@@ -76,7 +76,7 @@ class Organizations_Command extends TerminusCommand {
         if (isset($assoc_args['site'])) {
           if ($this->siteIsMember($memberships, $assoc_args['site'])) {
             throw new TerminusException(
-              '{site} is already a member of {org}',
+              'invalid_add',
               array(
                 'site' => $assoc_args['site'],
                 'org' => $org_info->profile->name
@@ -90,14 +90,14 @@ class Organizations_Command extends TerminusCommand {
             Input::menu(
               $this->getNonmemberSiteList($memberships),
               null,
-              'Choose site'
+              'select_site'
             )
           );
         }
         Terminus::confirm(
-          'Are you sure you want to add %s to %s ?',
+          'confirm_add',
           $assoc_args,
-          array($site->get('name'), $org_info->profile->name)
+          array('site' => $site->get('name'), 'org' => $org_info->profile->name)
         );
         $workflow = $org->site_memberships->addMember($site);
         $workflow->wait();
@@ -107,7 +107,7 @@ class Organizations_Command extends TerminusCommand {
         if (isset($assoc_args['site'])) {
           if (!$this->siteIsMember($memberships, $assoc_args['site'])) {
             throw new TerminusException(
-              '{site} is not a member of {org}',
+              'invalid_remove',
               array(
                 'site' => $assoc_args['site'],
                 'org' => $org_info->profile->name
@@ -121,15 +121,15 @@ class Organizations_Command extends TerminusCommand {
             Input::menu(
               $this->getMemberSiteList($memberships),
               null,
-              'Choose site'
+              'select_site'
             )
           );
         }
         $member = $org->site_memberships->get($site->get('id'));
         Terminus::confirm(
-          'Are you sure you want to remove %s from %s ?',
+          'confirm_remove',
           $assoc_args,
-          array($site->get('name'), $org_info->profile->name)
+          array('site' => $site->get('name'), 'org' => $org_info->profile->name)
         );
         $workflow = $member->removeMember();
         $workflow->wait();

--- a/php/commands/sites.php
+++ b/php/commands/sites.php
@@ -28,7 +28,6 @@ class Sites_Command extends TerminusCommand {
    */
   public function __construct() {
     parent::__construct();
-    Auth::loggedIn();
     $this->sites = new Sites();
   }
 

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -22,7 +22,7 @@ Feature: auth
     When I run "terminus auth whoami"
     Then I should get:
     """
-    You are authenticated as: [[username]]
+    user: [[username]]
     """
 
   Scenario: Logout

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -5,7 +5,7 @@ Feature: auth
     When I run "terminus auth login fake@email.com --password=BAD_PASSWORD"
     Then I should not get:
     """
-    Saving session data
+    Saving session your data.
     """
 
   Scenario: Login
@@ -13,7 +13,7 @@ Feature: auth
     When I run "terminus auth login [[username]] --password=[[password]]"
     Then I should get:
     """
-    Logging in as [[username]]
+    You are now logged in as [[username]]
     """
 
   Scenario: Check Which User I Am


### PR DESCRIPTION
I'm thinking we should break the output down between commands. Like, instead of an "output.yml" file, we'd have a file for each command (auth.yml, sites.yml, etc) I didn't do the work to add this to the logger or outputter yet - just clumsily stuck one output in for test to the auth login command. Try it with:

```
TERMINUS_LANG=jp terminus auth login
```
