### PR TITLE
Fixed error that shows whenever Terminus::launch is run from Windows with spaces in dir path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ##Master
 ### Fixed
 - `site connection-info` Git, MySQL and Redis info now correct (#573)
+- No more errors when running Terminus in Windows from directories with spaces in the path. (#575)
 
 ##[0.8.1] - 2015-09-28
 ### Changed

--- a/php/class-terminus.php
+++ b/php/class-terminus.php
@@ -211,6 +211,9 @@ class Terminus {
    * @return int The command exit status
    */
   static function launch($command, $exit_on_error = true) {
+    if (Utils\is_windows()) {
+      $command = '"' . $command . '"';
+    }
     $r = proc_close(proc_open($command, array(STDIN, STDOUT, STDERR), $pipes));
 
     if($r && $exit_on_error)
@@ -242,18 +245,19 @@ class Terminus {
         $assoc_args[ $key ] = self::get_runner()->config[$key];
     }
 
-    $php_bin = self::get_php_binary();
+    $php_bin = '"' . self::get_php_binary() . '"' ;
 
     if(Terminus::is_test()) {
       $script_path = __DIR__.'/boot-fs.php';
     } else {
       $script_path = $GLOBALS['argv'][0];
     }
+    $script_path = '"' . $script_path . '"';
 
     $args = implode(' ', array_map('escapeshellarg', $args));
-    $assoc_args = \Terminus\Utils\assoc_args_to_str($assoc_args);
+    $assoc_args = Utils\assoc_args_to_str($assoc_args);
 
-    $full_command = "{$php_bin} {$script_path} {$command} {$args} {$assoc_args}";
+    $full_command = "$php_bin $script_path $command $args $assoc_args";
 
     return self::launch($full_command, $exit_on_error);
   }


### PR DESCRIPTION
Closes #544
