### PR TITLE
Changed PrettyFormatter#flattenValue so that it no longer formats key names when flattening values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 #Change Log
 All notable changes to this project starting with the 0.6.0 release will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+##Master
+### Fixed
+- `sites list` no longer capitalizes membership UUIDs. (#642)
+
 ##[0.9.1] - 2015-10-27
 ### Fixed
 - `site backups get` will now find and retrieve backups properly. (#632)

--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -173,7 +173,7 @@ class PrettyFormatter implements OutputFormatterInterface {
     $is_assoc = is_array($value) && (bool)count(array_filter(array_keys($value), 'is_string'));
     if ($is_assoc || is_object($value)) {
       foreach ($value as $key => $val) {
-        $value[$key] = PrettyFormatter::getHumanLabel($key, $human_labels) . ': ' . PrettyFormatter::flattenValue($val, $human_labels);
+        $value[$key] = $key . ': ' . PrettyFormatter::flattenValue($val, $human_labels);
       }
     }
     $value = join(', ', (array)$value);


### PR DESCRIPTION
Closes #639 
