### PR TITLE
Updated .travis.yml to reflect changes in upcoming 1.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
+  - 5.5
+  - 5.6
 
 sudo: false
 
@@ -36,7 +36,7 @@ env:
 
 before_script:
   - ./scripts/prepare.sh
-  - ./scripts/build.sh
+  - if [ $(git branch | sed -n -e 's/^\* \(.*\)/\1/p') == "master" ]; then ./scripts/build.sh; fi
 
 script:
   - ./scripts/test.sh ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 
 ### Changed
 - Cached sites lists are now keyed to UUID, preventing a previously logged-in user's list from interfering with the currently logged-in user. (#652)
+- Terminus now requires version 5.5.0 or greater. (#661)
 
 ### Fixed
 - Automatic version check disabled for testing. (#643)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 ------------
 
 **Requirements:**
-- PHP version 5.3.2 or later
+- PHP version 5.5.0 or later
 - [PHP-CLI](http://www.php-cli.com/)
 - [PHP-CURL](http://php.net/manual/en/curl.setup.php)
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "bin/terminus.bat", "bin/terminus"
   ],
   "require": {
-    "php": ">=5.3.2",
+    "php": ">=5.5.0",
     "guzzle/guzzle": "3.9.*@stable",
     "jlogsdon/cli": "~0.9.4",
     "mustache/mustache": "~2.4",

--- a/php/boot-fs.php
+++ b/php/boot-fs.php
@@ -3,15 +3,18 @@
 /**
  * This file needs to parse without error in PHP < 5.3
  */
+
 if (PHP_SAPI != 'cli') {
   echo "Only CLI access.\n";
   die(-1);
 }
 
-if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+$min_version = '5.5.0';
+
+if (version_compare(PHP_VERSION, $min_version, '<')) {
   printf(
     "Error: Terminus requires PHP %s or newer. You are running version %s.\n",
-    '5.3.0',
+    $min_version,
     PHP_VERSION
   );
   die(-1);


### PR DESCRIPTION
Removed 5.3 and 5.4, added 5.5 and 5.6. Removed build.sh run to drastically cut down on test time.
