### PR TITLE
Collection#fetch and Model#fetch has options arg, rather than $paged

### DIFF
--- a/php/Terminus/Models/Collections/OrganizationSiteMemberships.php
+++ b/php/Terminus/Models/Collections/OrganizationSiteMemberships.php
@@ -81,11 +81,15 @@ class OrganizationSiteMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [OrganizationSiteMemberships] $this
    */
-  public function fetch($paged = false) {
-    parent::fetch(true);
+  public function fetch($options = array()) {
+    if (!isset($options['paged'])) {
+      $options['paged'] = true;
+    }
+
+    parent::fetch($options);
     return $this;
   }
 

--- a/php/Terminus/Models/Collections/SiteOrganizationMemberships.php
+++ b/php/Terminus/Models/Collections/SiteOrganizationMemberships.php
@@ -26,11 +26,15 @@ class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [TerminusModel] $this
    */
-  public function fetch($paged = false) {
-    parent::fetch(true);
+  public function fetch($options = array()) {
+    if (!isset($options['paged'])) {
+      $options['paged'] = true;
+    }
+
+    parent::fetch($options);
     return $this;
   }
 

--- a/php/Terminus/Models/Collections/SiteUserMemberships.php
+++ b/php/Terminus/Models/Collections/SiteUserMemberships.php
@@ -25,11 +25,14 @@ class SiteUserMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [SiteUserMemberships] $this
    */
-  public function fetch($paged = false) {
-    parent::fetch(true);
+  public function fetch($options = array()) {
+    if (!isset($options['paged'])) {
+      $options['paged'] = true;
+    }
+    parent::fetch($options);
     return $this;
   }
 

--- a/php/Terminus/Models/Collections/Sites.php
+++ b/php/Terminus/Models/Collections/Sites.php
@@ -110,10 +110,10 @@ class Sites extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [Sites] $this
    */
-  public function fetch($paged = false) {
+  public function fetch($options = array()) {
     if (empty($this->models)) {
       $cache = $this->sites_cache->all();
       if (count($cache) === 0) {

--- a/php/Terminus/Models/Collections/TerminusCollection.php
+++ b/php/Terminus/Models/Collections/TerminusCollection.php
@@ -34,11 +34,11 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [TerminusCollection] $this
    */
-  public function fetch($paged = false) {
-    $results = $this->getCollectionData($paged);
+  public function fetch($options = array()) {
+    $results = $this->getCollectionData($options);
     $data    = $this->objectify($results['data']);
 
     foreach (get_object_vars($data) as $id => $model_data) {
@@ -128,18 +128,23 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Retrieves collection data from the API
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [array] $results
    */
-  protected function getCollectionData($paged = false) {
+  protected function getCollectionData($options = array()) {
     $function_name = 'simpleRequest';
-    if ($paged) {
+    if (isset($options['paged']) && $options['paged']) {
       $function_name = 'pagedRequest';
     }
 
+    $fetch_args = array();
+    if (isset($options['fetch_args'])) {
+      $fetch_args = $options['fetch_args'];
+    }
     $options = array_merge(
       array('options' => array('method' => 'get')),
-      $this->getFetchArgs()
+      $this->getFetchArgs(),
+      $fetch_args
     );
     $results = TerminusCommand::$function_name(
       $this->getFetchUrl(),

--- a/php/Terminus/Models/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Models/Collections/UserOrganizationMemberships.php
@@ -24,11 +24,15 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [UserOrganizationMemberships] $this
    */
-  public function fetch($paged = false) {
-    parent::fetch(true);
+  public function fetch($options = array()) {
+    if (!isset($options['paged'])) {
+      $options['paged'] = true;
+    }
+
+    parent::fetch($options);
     return $this;
   }
 

--- a/php/Terminus/Models/Collections/Workflows.php
+++ b/php/Terminus/Models/Collections/Workflows.php
@@ -48,17 +48,6 @@ class Workflows extends TerminusCollection {
   }
 
   /**
-   * Fetches model data from API and instantiates its model instances
-   *
-   * @param [boolean] $paged True to use paginated API requests
-   * @return [Workflows] $this
-   */
-  public function fetch($paged = false) {
-    parent::fetch(true);
-    return $this;
-  }
-
-  /**
    * Give the URL for collection data fetching
    *
    * @return [string] $url URL to use in fetch query

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -243,10 +243,10 @@ class Site extends TerminusModel {
   /**
    * Fetches this object from Pantheon
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [Site] $this
    */
-  public function fetch($paged = true) {
+  public function fetch($options = array()) {
     $response         = TerminusCommand::simpleRequest(
       sprintf('sites/%s?site_state=true', $this->get('id'))
     );

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -52,18 +52,24 @@ abstract class TerminusModel {
   /**
    * Fetches this object from Pantheon
    *
-   * @param [boolean] $paged True to use paginated API requests
+   * @param [array] $options params to pass to url request
    * @return [TerminusModel] $this
    */
-  public function fetch($paged = false) {
-    $function_name = 'simpleRequest';
-    if ($paged) {
-      $function_name = 'pagedRequest';
+  public function fetch($options = array()) {
+    $fetch_args = array();
+    if (isset($options['fetch_args'])) {
+      $fetch_args = $options['fetch_args'];
     }
 
-    $results = TerminusCommand::$function_name(
+    $options = array_merge(
+      array('options' => array('method' => 'get')),
+      $this->getFetchArgs(),
+      $fetch_args
+    );
+
+    $results = TerminusCommand::simpleRequest(
       $this->getFetchUrl(),
-      $this->getFetchArgs()
+      $options
     );
 
     $this->attributes = $results['data'];


### PR DESCRIPTION
Allows more flexibility if we need to disable paging on a particular `fetch()` (like in #687) or if additional customized fetch args need to be passed into the url being fetched from (e.g. if multiple hydrators are needed as in the spec for operations in which workflows can be fetched vanilla, or with operations, or with operations_with_logs).
