### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ terminus
 
 Tab completion
 --------------
-Terminus also comes with a tab completion script for Bash. Just download [terminus-completion.bash](https://github.com/pantheon-systems/cli/blob/master/utils/terminus-completion.bash) and source it from ``~/.bash_profile`:
+Terminus also comes with a tab completion script for Bash. Just download [terminus-completion.bash](https://github.com/pantheon-systems/cli/blob/master/utils/terminus-completion.bash) and source it from `~/.bash_profile`:
 
 ```bash
 source /FULL/PATH/TO/terminus-completion.bash


### PR DESCRIPTION
Removed backtick on `~/.bash_profile` under tab completion.  Small documentation fix.
