### PR TITLE
Change Operation log_output to value outputter (not logger)

### DIFF
--- a/php/Terminus/Commands/WorkflowsCommand.php
+++ b/php/Terminus/Commands/WorkflowsCommand.php
@@ -124,11 +124,11 @@ class WorkflowsCommand extends TerminusCommand {
               $operation->description(),
               $operation->get('log_output')
             );
-            $this->log()->info($log_msg);
+            $this->output()->outputValue($log_msg);
           }
         }
       } else {
-        $this->log()->info('Workflow has no operations');
+        $this->output()->outputValue('Workflow has no operations');
       }
     } else {
       $this->output()->outputRecord($workflow_data);

--- a/php/Terminus/Models/WorkflowOperation.php
+++ b/php/Terminus/Models/WorkflowOperation.php
@@ -36,7 +36,7 @@ class WorkflowOperation extends TerminusModel {
    */
   public function description() {
     $description = sprintf(
-      "Operation: %s finished in %ss",
+      "Operation: %s finished in %s",
       $this->get('description'),
       $this->duration()
     );


### PR DESCRIPTION
Removes confusing timestamps and arguably does the right thing because the `operation->get('log_output')` is an attribute of the operation that we're presenting to the user.

Also fixes an issue with the duration being `8ss` by removing the second s.
