### PR TITLE
Alter PHP docblocks to use syntax understood by IDEs

### DIFF
--- a/docs/Auth.md
+++ b/docs/Auth.md
@@ -4,9 +4,6 @@
 ##### Description:
     Object constructor. Sets the logger class property.
 
-##### Return:
-    [Auth] $this
-
 ---
 
 ### ensureLogin
@@ -14,7 +11,7 @@
     Ensures the user is logged in or errs.
 
 ##### Return:
-    [boolean] Always true
+    [bool] Always true
 
 ---
 
@@ -23,7 +20,7 @@
     Checks to see if the current user is logged in
 
 ##### Return:
-    [boolean] $is_logged_in True if the user is logged in
+    [bool] True if the user is logged in
 
 ---
 
@@ -35,7 +32,7 @@
     [string] $token Machine token to initiate login with
 
 ##### Return:
-    [boolean] True if login succeeded
+    [bool] True if login succeeded
 
 ---
 
@@ -47,7 +44,7 @@
     [string] $token Session token to initiate login with
 
 ##### Return:
-    [boolean] True if login succeeded
+    [bool] True if login succeeded
 
 ---
 
@@ -60,7 +57,7 @@
     [string] $password Password for the account
 
 ##### Return:
-    [boolean] True if login succeeded
+    [bool] True if login succeeded
 
 ---
 

--- a/docs/Models/Backup.md
+++ b/docs/Models/Backup.md
@@ -5,16 +5,16 @@
     Determines whether the backup has been completed or not
 
 ##### Return:
-    [boolean]] $is_finished
+    [bool] True if backup is completed.
 
 ---
 
 ### getBucket
 ##### Description:
-    Retruns the bucket name for this backup
+    Returns the bucket name for this backup
 
 ##### Return:
-    [string] $bucket
+    [string]
 
 ---
 
@@ -23,25 +23,25 @@
     Returns the date the backup was completed
 
 ##### Return:
-    [string] $date Y-m-d H:i:s completion time or "Pending"
+    [string] Y-m-d H:i:s completion time or "Pending"
 
 ---
 
 ### getElement
 ##### Description:
-    Retruns the element type of the backup
+    Returns the element type of the backup
 
 ##### Return:
-    [string] $type code, database, files, or null
+    [string] code, database, files, or null
 
 ---
 
 ### getInitiator
 ##### Description:
-    Retruns the type of initiator of the backup
+    Returns the type of initiator of the backup
 
 ##### Return:
-    [string] $initiator Either "manual" or "automated"
+    [string] Either "manual" or "automated"
 
 ---
 
@@ -50,7 +50,7 @@
     Returns the size of the backup in MB
 
 ##### Return:
-    [string] $size_string
+    [string] A number (int or float) followed by 'MB'.
 
 ---
 
@@ -59,7 +59,7 @@
     Gets the URL of a backup
 
 ##### Return:
-    [string] $response['data']->url
+    [string]
 
 ---
 

--- a/docs/Models/Collections/Backups.md
+++ b/docs/Models/Collections/Backups.md
@@ -5,7 +5,7 @@
     Cancels an environment's regular backup schedule
 
 ##### Return:
-    [boolean] True if operation was successful
+    [bool] True if operation was successful
 
 ---
 
@@ -14,37 +14,38 @@
     Creates a backup
 
 ##### Parameters:
-    [array] $arg_params Array of args to dictate backup choices
-    -[string]  type     Sort of operation to conduct (e.g. backup)
-    -[integer] keep-for Days to keep the backup for
-    -[string]  element  Which aspect of the arg to back up
+    [array] $arg_params Array of args to dictate backup choices,
+    -which may have the following keys:
+    -- type: string: Sort of operation to conduct (e.g. backup)
+    -- keep-for: int: Days to keep the backup for
+    -- element: string: Which aspect of the arg to back up
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
 ### getBackupByFileName
 ##### Description:
-    Lists all backups
+    Fetches backup for a specified filename
 
 ##### Parameters:
     [string] $filename Name of the file name to filter by
 
 ##### Return:
-    [array] $backup
+    [Backup]
 
 ---
 
 ### getBackupsByElement
 ##### Description:
-    Lists all backups
+    Lists all backups for a specific element.
 
 ##### Parameters:
     [string] $element Name of the element type to filter by
 
 ##### Return:
-    [array] $backups
+    [Backup[]]
 
 ---
 
@@ -54,8 +55,8 @@
 
 ##### Return:
     [array] $schedule Elements as follows:
-    -[string]  daily_backup_time
-    -[string]  weekly_backup_day
+    -- daily_backup_time: string
+    -- weekly_backup_day: string
 
 ---
 
@@ -67,7 +68,7 @@
     [string] $element Element requested (i.e. code, db, or files)
 
 ##### Return:
-    [array] $backups An array of stdClass objects representing backups
+    [Backup[]] An array of Backup objects
 
 ---
 
@@ -76,10 +77,10 @@
     Sets an environment's regular backup schedule
 
 ##### Parameters:
-    [integer] $day_number A numerical of a day of the week
+    [int] $day_number A numerical of a day of the week
 
 ##### Return:
-    [boolean] True if operation was successful
+    [bool] True if operation was successful
 
 ---
 

--- a/docs/Models/Collections/Bindings.md
+++ b/docs/Models/Collections/Bindings.md
@@ -8,7 +8,7 @@
     [string] $type e.g. "appserver", "db server", etc
 
 ##### Return:
-    [array] $bindings
+    [Bindings[]]
 
 ---
 

--- a/docs/Models/Collections/Bindings.md
+++ b/docs/Models/Collections/Bindings.md
@@ -8,7 +8,7 @@
     [string] $type e.g. "appserver", "db server", etc
 
 ##### Return:
-    [Bindings[]]
+    [Binding[]]
 
 ---
 

--- a/docs/Models/Collections/Environments.md
+++ b/docs/Models/Collections/Environments.md
@@ -9,7 +9,7 @@
     [Environment] $from_env  Environment to clone from
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -18,7 +18,7 @@
     List Environment IDs, with Dev/Test/Live first
 
 ##### Return:
-    [array] $ids
+    [string[]] $ids
 
 ---
 
@@ -27,7 +27,7 @@
     Returns a list of all multidev environments on the collection-owning Site
 
 ##### Return:
-    [array] $environment An array of all Environment objects
+    [Environment[]]
 
 ---
 

--- a/docs/Models/Collections/OrganizationSiteMemberships.md
+++ b/docs/Models/Collections/OrganizationSiteMemberships.md
@@ -8,7 +8,7 @@
     [Site] $site Site object of site to add to this organization
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -20,7 +20,7 @@
     [string] $id UUID or name of desired site membership instance
 
 ##### Return:
-    [Site] $model
+    [Site]
 
 ---
 
@@ -30,9 +30,6 @@
 
 ##### Parameters:
     [array] $options params to pass to url request
-
-##### Return:
-    [OrganizationSiteMemberships] $this
 
 ---
 

--- a/docs/Models/Collections/OrganizationSiteMemberships.md
+++ b/docs/Models/Collections/OrganizationSiteMemberships.md
@@ -31,5 +31,8 @@
 ##### Parameters:
     [array] $options params to pass to url request
 
+##### Return:
+    [OrganizationSiteMemberships]
+
 ---
 

--- a/docs/Models/Collections/OrganizationUserMemberships.md
+++ b/docs/Models/Collections/OrganizationUserMemberships.md
@@ -20,7 +20,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [OrganizationUserMemberships] $this
+    [OrganizationUserMemberships]
 
 ---
 

--- a/docs/Models/Collections/SiteOrganizationMemberships.md
+++ b/docs/Models/Collections/SiteOrganizationMemberships.md
@@ -9,7 +9,7 @@
     [string] $role Role for supporting organization to take
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -21,7 +21,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [TerminusModel] $this
+    [SiteOrganizationMemberships]
 
 ---
 
@@ -33,7 +33,7 @@
     [string] $name A name to search for
 
 ##### Return:
-    [SiteOrganizationMembership] $orgs[$name]
+    [SiteOrganizationMembership|null]
 
 ---
 

--- a/docs/Models/Collections/SiteUserMemberships.md
+++ b/docs/Models/Collections/SiteUserMemberships.md
@@ -9,7 +9,7 @@
     [string] $role  Role to assign to the new user
 
 ##### Return:
-    [workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -21,7 +21,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [SiteUserMemberships] $this
+    [SiteUserMemberships]
 
 ---
 
@@ -33,7 +33,7 @@
     [string] $id UUID or email of desired user
 
 ##### Return:
-    [SiteUserMembership] $membership
+    [SiteUserMembership]
 
 ---
 

--- a/docs/Models/Collections/Sites.md
+++ b/docs/Models/Collections/Sites.md
@@ -8,7 +8,7 @@
     [array] $options To be set to $this->key
 
 ##### Return:
-    [Sites] $this
+    [Sites]
 
 ---
 
@@ -17,11 +17,12 @@
     Creates a new site
 
 ##### Parameters:
-    [array] $options Information to run workflow
-    -[string] label
-    -[string] name
-    -[string] organization_id
-    -[string] upstream_id
+    [string[]] $options Information to run workflow, with the following
+    -keys:
+    -- label
+    -- name
+    -- organization_id
+    -- upstream_id
 
 ##### Return:
     [Workflow]
@@ -34,9 +35,10 @@
 
 ##### Parameters:
     [string] $site_id UUID of site to add to cache
+    [string] $org_id  UUID of org to which new site belongs
 
 ##### Return:
-    [Site] $site The newly created site object
+    [Site] The newly created site object
 
 ---
 
@@ -60,7 +62,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [Sites] $this
+    [Sites]
 
 ---
 
@@ -73,7 +75,7 @@
     [string] $org Organization which has tagged sites
 
 ##### Return:
-    [array] $sites A filtered list of sites
+    [Site[]]
 
 ---
 
@@ -85,7 +87,7 @@
     [string] $id UUID or name of desired site
 
 ##### Return:
-    [Site] $site
+    [Site]
 
 ---
 

--- a/docs/Models/Collections/TerminusCollection.md
+++ b/docs/Models/Collections/TerminusCollection.md
@@ -7,9 +7,6 @@
 ##### Parameters:
     [array] $options To be set to $this->key
 
-##### Return:
-    [TerminusCollection] $this
-
 ---
 
 ### all
@@ -17,7 +14,7 @@
     Retrieves all models
 
 ##### Return:
-    [array] $models
+    [TerminusModel[]]
 
 ---
 
@@ -50,7 +47,20 @@
     List Model IDs
 
 ##### Return:
-    [array] $ids Array of all model IDs
+    [string[]] Array of all model IDs
+
+---
+
+### add
+##### Description:
+    Adds a model to this collection
+
+##### Parameters:
+    [\stdClass] $model_data Data to feed into attributes of new model
+    [array]     $options    Data to make properties of the new model
+
+##### Return:
+    [TerminusModel]
 
 ---
 
@@ -63,11 +73,11 @@
     [array]  $filters Attributes to match during filtration
     -e.g. array('category' => 'other')
     [string] $key     Name of attribute to make array keys
-    [mixed]  $value   Name(s) of attribute to make array values
+    [string|array]  $value   Name(s) of attribute to make array values
 
 ##### Return:
-    [array] $member_list Array rendered as requested
-    -[mixed] $this->attribute->$key = $this->attribute->$value
+    [array] Array rendered as requested
+    -$this->attribute->$key = $this->attribute->$value
 
 ---
 
@@ -81,8 +91,8 @@
     [string] $value Name of attribute to make array values
 
 ##### Return:
-    [array] $member_list Array rendered as requested
-    -[mixed] $this->attribute->$key = $this->attribute->$value
+    [array] Array rendered as requested
+    -$this->attribute->$key = $this->attribute->$value
 
 ---
 

--- a/docs/Models/Collections/TerminusCollection.md
+++ b/docs/Models/Collections/TerminusCollection.md
@@ -56,8 +56,8 @@
     Adds a model to this collection
 
 ##### Parameters:
-    [\stdClass] $model_data Data to feed into attributes of new model
-    [array]     $options    Data to make properties of the new model
+    [object] $model_data Data to feed into attributes of new model
+    [array]  $options    Data to make properties of the new model
 
 ##### Return:
     [TerminusModel]
@@ -70,10 +70,10 @@
     values are the attribute $value, filtered by the given array
 
 ##### Parameters:
-    [array]  $filters Attributes to match during filtration
+    [array]        $filters Attributes to match during filtration
     -e.g. array('category' => 'other')
-    [string] $key     Name of attribute to make array keys
-    [string|array]  $value   Name(s) of attribute to make array values
+    [string]       $key     Name of attribute to make array keys
+    [string|array] $value   Name(s) of attribute to make array values
 
 ##### Return:
     [array] Array rendered as requested

--- a/docs/Models/Collections/Upstreams.md
+++ b/docs/Models/Collections/Upstreams.md
@@ -17,8 +17,8 @@
     Adds a model to this collection
 
 ##### Parameters:
-    [\stdClass] $model_data Data to feed into attributes of new model
-    [array]     $options    Data to make properties of the new model
+    [object] $model_data Data to feed into attributes of new model
+    [array]  $options    Data to make properties of the new model
 
 ##### Return:
     [void]

--- a/docs/Models/Collections/Upstreams.md
+++ b/docs/Models/Collections/Upstreams.md
@@ -8,7 +8,20 @@
     [string] $id_or_name UUID or name
 
 ##### Return:
-    [Upstream] $member
+    [Upstream]
+
+---
+
+### add
+##### Description:
+    Adds a model to this collection
+
+##### Parameters:
+    [\stdClass] $model_data Data to feed into attributes of new model
+    [array]     $options    Data to make properties of the new model
+
+##### Return:
+    [void]
 
 ---
 

--- a/docs/Models/Collections/UserOrganizationMemberships.md
+++ b/docs/Models/Collections/UserOrganizationMemberships.md
@@ -7,9 +7,6 @@
 ##### Parameters:
     [array] $options Options to set as $this->key
 
-##### Return:
-    [TerminusModel] $this
-
 ---
 
 ### fetch
@@ -20,7 +17,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [UserOrganizationMemberships] $this
+    [UserOrganizationMemberships]
 
 ---
 

--- a/docs/Models/Collections/Workflows.md
+++ b/docs/Models/Collections/Workflows.md
@@ -23,6 +23,9 @@
 ##### Parameters:
     [array] $options Additional information for the request
 
+##### Return:
+    [void]
+
 ---
 
 ### allFinished
@@ -75,8 +78,8 @@
     Adds a model to this collection
 
 ##### Parameters:
-    [\stdClass] $model_data Data to feed into attributes of new model
-    [array]     $options    Data to make properties of the new model
+    [object] $model_data Data to feed into attributes of new model
+    [array]  $options    Data to make properties of the new model
 
 ##### Return:
     [Workflow]  The newly-added model

--- a/docs/Models/Collections/Workflows.md
+++ b/docs/Models/Collections/Workflows.md
@@ -6,12 +6,13 @@
 
 ##### Parameters:
     [string] $type    Type of workflow to create
-    [array]  $options Additional information for the request
-    -[string] environment UUID of environment running workflow
-    -[array]  params      Parameters for the request
+    [array]  $options Additional information for the request, with the
+    -following possible keys:
+    -- environment: string
+    -- params: associative array of parameters for the request
 
 ##### Return:
-    [TerminusModel] $model
+    [Workflow] $model
 
 ---
 
@@ -22,21 +23,6 @@
 ##### Parameters:
     [array] $options Additional information for the request
 
-##### Return:
-    [Workflows] $this
-
----
-
-### fetchWithOperationsAndLogs
-##### Description:
-    Fetches workflow data hydrated with operations and logs
-
-##### Parameters:
-    [array] $options Additional information for the request
-
-##### Return:
-    [Workflows] $this
-
 ---
 
 ### allFinished
@@ -44,7 +30,7 @@
     Returns all existing workflows that have finished
 
 ##### Return:
-    [Array<Workflows>] $workflows
+    [Workflow[]]
 
 ---
 
@@ -53,16 +39,47 @@
     Returns all existing workflows that contain logs
 
 ##### Return:
-    [Array<Workflows>] $workflows
+    [Workflow[]]
+
+---
+
+### lastFinishedAt
+##### Description:
+    Get timestamp of most recently finished workflow
+
+##### Return:
+    [int|null] Timestamp
+
+---
+
+### lastCreatedAt
+##### Description:
+    Get timestamp of most recently created Workflow
+
+##### Return:
+    [int|null] Timestamp
 
 ---
 
 ### findLatestWithLogs
 ##### Description:
-    Get most-recent workflow from existingcollection that has logs
+    Get most-recent workflow from existing collection that has logs
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow|null]
+
+---
+
+### add
+##### Description:
+    Adds a model to this collection
+
+##### Parameters:
+    [\stdClass] $model_data Data to feed into attributes of new model
+    [array]     $options    Data to make properties of the new model
+
+##### Return:
+    [Workflow]  The newly-added model
 
 ---
 

--- a/docs/Models/Environment.md
+++ b/docs/Models/Environment.md
@@ -5,11 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [stdClass] $attributes Attributes of this model
-    [array]    $options    Options to set as $this->key
-
-##### Return:
-    [TerminusModel] $this
+    [\stdClass] $attributes Attributes of this model
+    [array]     $options    Options to set as $this->key
 
 ---
 
@@ -21,7 +18,7 @@
     [string] $hostname Hostname to add to environment
 
 ##### Return:
-    [array] $response['data']
+    [array] Response data
 
 ---
 
@@ -33,19 +30,19 @@
     [string] $value Connection mode, "git" or "sftp"
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow|string]
 
 ---
 
 ### cloneDatabase
 ##### Description:
-    Clones files from this environment to another
+    Clones database from this environment to another
 
 ##### Parameters:
     [string] $to_env Environment to clone into
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -57,7 +54,7 @@
     [string] $to_env Environment to clone into
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -70,7 +67,7 @@
     -on server changes
 
 ##### Return:
-    [array] $data['data']
+    [array] Response data
 
 ---
 
@@ -79,7 +76,7 @@
     Gives connection info for this environment
 
 ##### Return:
-    [array] $info
+    [array]
 
 ---
 
@@ -91,7 +88,7 @@
     [string] $env_name Name of environment to create
 
 ##### Return:
-    [array] $response['data']
+    [array] Response data
 
 ---
 
@@ -103,7 +100,7 @@
     [string] $hostname Hostname to remove from environment
 
 ##### Return:
-    [array] $response['data']
+    [array] Response data
 
 ---
 
@@ -115,7 +112,7 @@
     [array] $params Parameters for the deploy workflow
 
 ##### Return:
-    [Workflow] workflow response
+    [Workflow]
 
 ---
 
@@ -124,7 +121,7 @@
     Gets diff from multidev environment
 
 ##### Return:
-    [array] $data['data']
+    [array]
 
 ---
 
@@ -133,7 +130,7 @@
     Generate environment URL
 
 ##### Return:
-    [string] $host
+    [string]
 
 ---
 
@@ -142,16 +139,16 @@
     Returns the connection mode of this environment
 
 ##### Return:
-    [string] $connection_mode
+    [string] 'git' or 'sftp'
 
 ---
 
 ### getHostnames
 ##### Description:
-    List hotnames for environment
+    List hostnames for environment
 
 ##### Return:
-    [array] $response['data']
+    [array]
 
 ---
 
@@ -160,7 +157,7 @@
     Returns the environment's name
 
 ##### Return:
-    [string] $name
+    [string]
 
 ---
 
@@ -183,7 +180,7 @@
     clones test content.)
 
 ##### Return:
-    [Workflow] $workflow In-progress workflow
+    [Workflow] In-progress workflow
 
 ---
 
@@ -192,7 +189,7 @@
     Have the environment's bindings have been initialized?
 
 ##### Return:
-    [boolean] $has_commits True if environment has been instantiated
+    [bool] True if environment has been instantiated
 
 ---
 
@@ -201,7 +198,7 @@
     Is this branch a multidev environment?
 
 ##### Return:
-    [boolean] True if ths environment is a multidev environment
+    [bool] True if ths environment is a multidev environment
 
 ---
 
@@ -213,7 +210,7 @@
     [array] $options Parameters to override defaults
 
 ##### Return:
-    [Workflow] $workflow;
+    [Workflow]
 
 ---
 
@@ -222,7 +219,7 @@
     Get Info on an environment lock
 
 ##### Return:
-    [string] $lock
+    [string]
 
 ---
 
@@ -231,7 +228,7 @@
     Get the code log (commits)
 
 ##### Return:
-    [array] $response['data']
+    [array]
 
 ---
 
@@ -243,7 +240,7 @@
     [array] $options Parameters to override defaults
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -255,7 +252,7 @@
     [array] $options Parameters to override defaults
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -264,7 +261,7 @@
     Disable HTTP Basic Access authentication on the web environment
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -273,7 +270,7 @@
     "Wake" a site
 
 ##### Return:
-    [array] $return_data
+    [array]
 
 ---
 
@@ -282,7 +279,7 @@
     Deletes all content (files and database) from the Environment
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -294,7 +291,7 @@
     [Workflow] $workflow String work flow "slot"
 
 ##### Return:
-    [array] $response['data']
+    [array]
 
 ---
 

--- a/docs/Models/Environment.md
+++ b/docs/Models/Environment.md
@@ -5,8 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [\stdClass] $attributes Attributes of this model
-    [array]     $options    Options to set as $this->key
+    [object] $attributes Attributes of this model
+    [array]  $options    Options to set as $this->key
 
 ---
 

--- a/docs/Models/Organization.md
+++ b/docs/Models/Organization.md
@@ -5,11 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [stdClass] $attributes Attributes of this model
-    [array]    $options    Options to set as $this->key
-
-##### Return:
-    [Organization] $this
+    [\stdClass] $attributes Attributes of this model
+    [array]     $options    Options to set as $this->key
 
 ---
 
@@ -18,7 +15,7 @@
     Retrieves organization sites
 
 ##### Return:
-    [array] $sites An array of OrganizationSiteMember objects
+    [OrganizationSiteMembership[]]
 
 ---
 
@@ -27,7 +24,7 @@
     Retrieves organization users
 
 ##### Return:
-    [array] $users An array of OrganizationUserMember objects
+    [OrganizationUserMembership[]]
 
 ---
 

--- a/docs/Models/Organization.md
+++ b/docs/Models/Organization.md
@@ -5,8 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [\stdClass] $attributes Attributes of this model
-    [array]     $options    Options to set as $this->key
+    [object] $attributes Attributes of this model
+    [array]  $options    Options to set as $this->key
 
 ---
 

--- a/docs/Models/OrganizationSiteMembership.md
+++ b/docs/Models/OrganizationSiteMembership.md
@@ -2,10 +2,10 @@
 
 ### removeMember
 ##### Description:
-    Adds a site to this organization
+    Removes a site from this organization
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 

--- a/docs/Models/OrganizationUserMembership.md
+++ b/docs/Models/OrganizationUserMembership.md
@@ -2,10 +2,10 @@
 
 ### removeMember
 ##### Description:
-    Adds a site to this organization
+    Removes a user from this organization
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 

--- a/docs/Models/Site.md
+++ b/docs/Models/Site.md
@@ -5,11 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [stdClass] $attributes Attributes of this model
-    [array]    $options    Options to set as $this->key
-
-##### Return:
-    [Site] $this
+    [\stdClass] $attributes Attributes of this model
+    [array]     $options    Options to set as $this->key
 
 ---
 
@@ -21,7 +18,7 @@
     [string] $uuid UUID of new payment instrument
 
 ##### Return:
-    [Workflow] $workflow Workflow object for the request
+    [Workflow]
 
 ---
 
@@ -30,11 +27,11 @@
     Adds a tag to the site
 
 ##### Parameters:
-    [string] $tag Tag to apply
-    [string] $org Organization to add the tag associateion to
+    [string] $tag Name of tag to apply
+    [string] $org Organization to add the tag association to
 
 ##### Return:
-    [array] $response
+    [array]
 
 ---
 
@@ -44,11 +41,11 @@
 
 ##### Parameters:
     [string]  $env_id   Environment name
-    [boolean] $updatedb True to run update.php
-    [boolean] $xoption  True to automatically resolve merge conflicts
+    [bool]    $updatedb True to run update.php
+    [bool]    $xoption  True to automatically resolve merge conflicts
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -57,7 +54,7 @@
     Returns an array of attributes
 
 ##### Return:
-    [stdClass] $atts['data']
+    [\stdClass]
 
 ---
 
@@ -69,7 +66,7 @@
     [string] $type Which sort of binding to retrieve
 
 ##### Return:
-    [array] $this->bindings
+    [array]
 
 ---
 
@@ -81,7 +78,7 @@
     [string] $branch Name of new branch
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -90,7 +87,7 @@
     Deletes site
 
 ##### Return:
-    [array] $response
+    [array]
 
 ---
 
@@ -102,7 +99,7 @@
     [string] $branch Name of branch to remove
 
 ##### Return:
-    [void]
+    [Workflow]
 
 ---
 
@@ -112,10 +109,10 @@
 
 ##### Parameters:
     [string]  $env           Name of environment to remove
-    [boolean] $delete_branch True to delete branch
+    [bool]    $delete_branch True to delete branch
 
 ##### Return:
-    [void]
+    [Workflow]
 
 ---
 
@@ -136,7 +133,7 @@
     [array] $options params to pass to url request
 
 ##### Return:
-    [Site] $this
+    [Site]
 
 ---
 
@@ -148,7 +145,7 @@
     [string] $attribute Name of attribute requested
 
 ##### Return:
-    [mixed] $this->attributes->$attributes;
+    [mixed|null] Attribute value, or null if not found
 
 ---
 
@@ -160,7 +157,7 @@
     [string] $feature Feature to check
 
 ##### Return:
-    [mixed] $this->features[$feature]
+    [mixed|null] Feature value, or null if not found
 
 ---
 
@@ -169,7 +166,7 @@
     Returns all organization members of this site
 
 ##### Return:
-    [array] Array of SiteOrganizationMemberships
+    [SiteOrganizationMembership[]]
 
 ---
 
@@ -178,7 +175,7 @@
     Lists user memberships for this site
 
 ##### Return:
-    [SiteUserMemberships] Collection of user memberships for this site
+    [SiteUserMemberships]
 
 ---
 
@@ -190,7 +187,7 @@
     [string] $org UUID of organization site belongs to
 
 ##### Return:
-    [array] $tags Tags in string format
+    [string[]]
 
 ---
 
@@ -199,7 +196,7 @@
     Get upstream updates
 
 ##### Return:
-    [stdClass] $response['data']
+    [\stdClass]
 
 ---
 
@@ -211,7 +208,7 @@
     [string] $url URL to import data from
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -223,7 +220,7 @@
     [string] $url URL to import data from
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -235,7 +232,7 @@
     [string] $url URL to import data from
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -247,7 +244,9 @@
     [string] $key Set to retrieve a specific attribute as named
 
 ##### Return:
-    [array] $info
+    [array|null|mixed]
+    -If $key is supplied, return named bit of info, or null if not found.
+    -If no $key supplied, return entire info array.
 
 ---
 
@@ -256,19 +255,19 @@
     Retrieve New Relic Info
 
 ##### Return:
-    [stdClass] $response['data']
+    [\stdClass]
 
 ---
 
 ### organizationIsMember
 ##### Description:
-    Returns all organization members of this site
+    Determines if an organization is a member of this site
 
 ##### Parameters:
     [string] $uuid UUID of organization to check for
 
 ##### Return:
-    [boolean] True if organization is a member of this site
+    [bool] True if organization is a member of this site
 
 ---
 
@@ -277,7 +276,7 @@
     Removes payment instrument of given site
 
 ##### Return:
-    [Workflow] $workflow Workflow object for the request
+    [Workflow]
 
 ---
 
@@ -287,10 +286,10 @@
 
 ##### Parameters:
     [string] $tag Tag to remove
-    [string] $org Organization to remove the tag associateion from
+    [string] $org Organization to remove the tag association from
 
 ##### Return:
-    [array] $response
+    [array]
 
 ---
 
@@ -302,7 +301,7 @@
     [string] $owner UUID of new owner of site
 
 ##### Return:
-    [stdClass] $data['data']
+    [\stdClass]
 
 ---
 
@@ -311,7 +310,7 @@
     Just the code branches
 
 ##### Return:
-    [stdClass] $data['data']
+    [\stdClass]
 
 ---
 
@@ -323,7 +322,7 @@
     [string] $level Level to set service on site to
 
 ##### Return:
-    [stdClass] $response['data']
+    [\stdClass]
 
 ---
 

--- a/docs/Models/Site.md
+++ b/docs/Models/Site.md
@@ -40,9 +40,9 @@
     Apply upstream updates
 
 ##### Parameters:
-    [string]  $env_id   Environment name
-    [bool]    $updatedb True to run update.php
-    [bool]    $xoption  True to automatically resolve merge conflicts
+    [string] $env_id   Environment name
+    [bool]   $updatedb True to run update.php
+    [bool]   $xoption  True to automatically resolve merge conflicts
 
 ##### Return:
     [Workflow]
@@ -108,8 +108,8 @@
     Delete a multidev environment
 
 ##### Parameters:
-    [string]  $env           Name of environment to remove
-    [bool]    $delete_branch True to delete branch
+    [string] $env           Name of environment to remove
+    [bool]   $delete_branch True to delete branch
 
 ##### Return:
     [Workflow]

--- a/docs/Models/Site.md
+++ b/docs/Models/Site.md
@@ -5,8 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [\stdClass] $attributes Attributes of this model
-    [array]     $options    Options to set as $this->key
+    [object] $attributes Attributes of this model
+    [array]  $options    Options to set as $this->key
 
 ---
 
@@ -301,7 +301,7 @@
     [string] $owner UUID of new owner of site
 
 ##### Return:
-    [\stdClass]
+    [Workflow]
 
 ---
 

--- a/docs/Models/SiteOrganizationMembership.md
+++ b/docs/Models/SiteOrganizationMembership.md
@@ -5,8 +5,7 @@
     Returns organization object within SiteOrganizationMembership object
 
 ##### Return:
-    [Organization] $this->organization
-    -Org associated with this SiteOrganizationMembership
+    [Organization]
 
 ---
 
@@ -15,7 +14,7 @@
     Remove membership of organization
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -27,7 +26,7 @@
     [string] $role Desired role for this organization
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 

--- a/docs/Models/SiteUserMembership.md
+++ b/docs/Models/SiteUserMembership.md
@@ -2,10 +2,10 @@
 
 ### removeMember
 ##### Description:
-    Remove membshipship, either org or user
+    Remove membership, either org or user
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 
@@ -17,7 +17,7 @@
     [string] $role Desired role for this member
 
 ##### Return:
-    [Workflow] $workflow
+    [Workflow]
 
 ---
 

--- a/docs/Models/TerminusModel.md
+++ b/docs/Models/TerminusModel.md
@@ -5,8 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [\stdClass] $attributes Attributes of this model
-    [array]    $options    Options to set as $this->key
+    [object] $attributes Attributes of this model
+    [array]  $options    Options to set as $this->key
 
 ---
 

--- a/docs/Models/TerminusModel.md
+++ b/docs/Models/TerminusModel.md
@@ -5,17 +5,14 @@
     Object constructor
 
 ##### Parameters:
-    [stdClass] $attributes Attributes of this model
+    [\stdClass] $attributes Attributes of this model
     [array]    $options    Options to set as $this->key
-
-##### Return:
-    [TerminusModel] $this
 
 ---
 
 ### __get
 ##### Description:
-    Handles requests for inaccessable properties
+    Handles requests for inaccessible properties
 
 ##### Parameters:
     [string] $property Name of property being requested
@@ -45,7 +42,19 @@
     [string] $attribute Name of the key of the desired attribute
 
 ##### Return:
-    [mixed] $this->attributes->$attribute
+    [mixed] Value of the attribute, or null if not set.
+
+---
+
+### has
+##### Description:
+    Checks whether the model has an attribute
+
+##### Parameters:
+    [string] $attribute Name of the attribute key
+
+##### Return:
+    [boolean] True if attribute exists, false otherwise
 
 ---
 

--- a/docs/Models/User.md
+++ b/docs/Models/User.md
@@ -5,11 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [stdClass] $attributes Attributes of this model
-    [array]    $options    Options to set as $this->key
-
-##### Return:
-    [User] $this
+    [\stdClass] $attributes Attributes of this model
+    [array]     $options    Options to set as $this->key
 
 ---
 
@@ -18,7 +15,7 @@
     Retrieves drush aliases for this user
 
 ##### Return:
-    [stdClass] $this->aliases
+    [\stdClass] $this->aliases
 
 ---
 
@@ -27,7 +24,7 @@
     Retrieves organization data for this user
 
 ##### Return:
-    [stdClass] $organizations
+    [\stdClass] $organizations
 
 ---
 
@@ -36,10 +33,12 @@
     Requests API data and returns an object of user site data
 
 ##### Parameters:
-    [string] $organization UUID of organization to requests sites from
+    [string] $organization
+    -UUID of organization to requests sites from, or null to fetch for all
+    -organizations.
 
 ##### Return:
-    [stdClass] $response['data']
+    [\stdClass] $response['data']
 
 ---
 

--- a/docs/Models/User.md
+++ b/docs/Models/User.md
@@ -5,8 +5,8 @@
     Object constructor
 
 ##### Parameters:
-    [\stdClass] $attributes Attributes of this model
-    [array]     $options    Options to set as $this->key
+    [object] $attributes Attributes of this model
+    [array]  $options    Options to set as $this->key
 
 ---
 
@@ -15,7 +15,7 @@
     Retrieves drush aliases for this user
 
 ##### Return:
-    [\stdClass] $this->aliases
+    [\stdClass]
 
 ---
 
@@ -24,7 +24,7 @@
     Retrieves organization data for this user
 
 ##### Return:
-    [\stdClass] $organizations
+    [Organization[]]
 
 ---
 
@@ -37,7 +37,7 @@
     -or null to fetch for all organizations.
 
 ##### Return:
-    [\stdClass] $response['data']
+    [\stdClass]
 
 ---
 

--- a/docs/Models/User.md
+++ b/docs/Models/User.md
@@ -33,9 +33,8 @@
     Requests API data and returns an object of user site data
 
 ##### Parameters:
-    [string] $organization
-    -UUID of organization to requests sites from, or null to fetch for all
-    -organizations.
+    [string] $organization UUID of organization to requests sites from,
+    -or null to fetch for all organizations.
 
 ##### Return:
     [\stdClass] $response['data']

--- a/docs/Models/Workflow.md
+++ b/docs/Models/Workflow.md
@@ -14,7 +14,7 @@
     Re-fetches workflow data hydrated with logs
 
 ##### Return:
-    [Workflow] $this
+    [Workflow]
 
 ---
 
@@ -23,25 +23,16 @@
     Detects if the workflow has finished
 
 ##### Return:
-    [boolean] $is_finished True if worklow has finished
+    [bool] True if workflow has finished
 
 ---
 
 ### isSuccessful
 ##### Description:
-    Detects if the workflow was successfsul
+    Detects if the workflow was successful
 
 ##### Return:
-    [boolean] $is_successful True if workflow succeeded
-
----
-
-### hasLogs
-##### Description:
-    Detects if the workflow has any operation with logs
-
-##### Return:
-    [boolean] $has_logs True if worklow has logs
+    [bool] True if workflow succeeded
 
 ---
 
@@ -50,7 +41,7 @@
     Returns a list of WorkflowOperations for this workflow
 
 ##### Return:
-    [Array<WorkflowOperation>] $operations list of WorkflowOperations
+    [WorkflowOperation[]]
 
 ---
 
@@ -59,7 +50,7 @@
     Formats workflow object into an associative array for output
 
 ##### Return:
-    [array] $data associative array of data for output
+    [array] Associative array of data for output
 
 ---
 
@@ -68,7 +59,7 @@
     Waits on this workflow to finish
 
 ##### Return:
-    [Workflow] $this
+    [Workflow|void]
 
 ---
 

--- a/docs/Models/WorkflowOperation.md
+++ b/docs/Models/WorkflowOperation.md
@@ -2,10 +2,19 @@
 
 ### serialize
 ##### Description:
-    Formats workflow object into an associative array for output
+    Formats operation object into an associative array for output
 
 ##### Return:
-    [array] $data associative array of data for output
+    [array]
+
+---
+
+### description
+##### Description:
+    Formats operation object into a descriptive string
+
+##### Return:
+    [string]
 
 ---
 

--- a/php/Terminus/Auth.php
+++ b/php/Terminus/Auth.php
@@ -3,18 +3,22 @@
 namespace Terminus;
 
 use Terminus;
-use Terminus\Request;
-use Terminus\Session;
 use Terminus\Exceptions\TerminusException;
+use Terminus\Loggers\Logger;
 
 class Auth {
+
+  /**
+   * @var Logger
+   */
   private $logger;
+  /**
+   * @var Request
+   */
   private $request;
 
   /**
    * Object constructor. Sets the logger class property.
-   *
-   * @return [Auth] $this
    */
   public function __construct() {
     $this->logger  = Terminus::getLogger();
@@ -24,7 +28,8 @@ class Auth {
   /**
    * Ensures the user is logged in or errs.
    *
-   * @return [boolean] Always true
+   * @return bool Always true
+   * @throws TerminusException
    */
   public static function ensureLogin() {
     $session = Session::instance()->getData();
@@ -46,7 +51,7 @@ class Auth {
   /**
    * Checks to see if the current user is logged in
    *
-   * @return [boolean] $is_logged_in True if the user is logged in
+   * @return bool True if the user is logged in
    */
   public function loggedIn() {
     $session      = Session::instance()->getData();
@@ -63,8 +68,9 @@ class Auth {
   /**
    * Execute the login based on a machine token
    *
-   * @param [string] $token Machine token to initiate login with
-   * @return [boolean] True if login succeeded
+   * @param string $token Machine token to initiate login with
+   * @return bool True if login succeeded
+   * @throws TerminusException
    */
   public function logInViaMachineToken($token) {
     $options = array(
@@ -106,8 +112,9 @@ class Auth {
   /**
    * Execute the login based on an existing session token
    *
-   * @param [string] $token Session token to initiate login with
-   * @return [boolean] True if login succeeded
+   * @param string $token Session token to initiate login with
+   * @return bool True if login succeeded
+   * @throws TerminusException
    */
   public function logInViaSessionToken($token) {
     $options = array(
@@ -142,9 +149,10 @@ class Auth {
   /**
    * Execute the login via email/password
    *
-   * @param [string] $email    Email address associated with a Pantheon account
-   * @param [string] $password Password for the account
-   * @return [boolean] True if login succeeded
+   * @param string $email    Email address associated with a Pantheon account
+   * @param string $password Password for the account
+   * @return bool True if login succeeded
+   * @throws TerminusException
    */
   public function logInViaUsernameAndPassword($email, $password) {
     if (!Terminus\Utils\isValidEmail($email)) {
@@ -183,10 +191,10 @@ class Auth {
   /**
    * Saves the session data to a cookie
    *
-   * @param [array] $data Session data to save
-   * @return [boolean] Always true
+   * @param \stdClass $data Session data to save
+   * @return bool Always true
    */
-  private function setInstanceData($data) {
+  private function setInstanceData(\stdClass $data) {
     if (!isset($data->refresh)) {
       $refresh = (array)Session::instance()->get('refresh');
     } else {

--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -20,8 +20,6 @@ class AuthCommand extends TerminusCommand {
 
   /**
    * Instantiates object, sets auth property
-   *
-   * @return [AuthCommand] $this
    */
   public function __construct() {
     parent::__construct();

--- a/php/Terminus/Commands/CommandWithSSH.php
+++ b/php/Terminus/Commands/CommandWithSSH.php
@@ -25,8 +25,8 @@ abstract class CommandWithSSH extends TerminusCommand {
    * Checks to see if the command is not available in Terminus and, if not,
    * it will refer you to an equivalent Terminus command, if such exists.
    *
-   * @param [string] $command The command to check for availability
-   * @return [void]
+   * @param string $command The command to check for availability
+   * @return void
    */
   protected function checkCommand($command) {
     $command_array = explode(' ', $command);
@@ -51,8 +51,8 @@ abstract class CommandWithSSH extends TerminusCommand {
   /**
    * Formats command output into an array
    *
-   * @param [string] $string Output string to format
-   * @return [array] $formatted_data
+   * @param string $string Output string to format
+   * @return array
    */
   protected function formatOutput($string) {
     $exploded_string = explode("\n", $string);
@@ -71,10 +71,10 @@ abstract class CommandWithSSH extends TerminusCommand {
   /**
    * Parses server information for connections
    *
-   * @param [array] $site_info Elements as follows:
+   * @param array $site_info Elements as follows:
    *        [string] site        Site UUID
    *        [string] environment Environment name
-   * @return [array] $server Connection info
+   * @return array Connection info
    */
   protected function getAppserverInfo(array $site_info = array()) {
     $site_id = $site_info['site'];
@@ -97,11 +97,11 @@ abstract class CommandWithSSH extends TerminusCommand {
   /**
    * Sends command through SSH
    *
-   * @param [array] $options Elements as follows:
+   * @param array $options Elements as follows:
    *        [string] server      Server to connect to
    *        [string] remote_exec Program to execute on server
    *        [array]  command     Command and arguments
-   * @return [array] $formatted_result
+   * @return array
    */
   protected function sendCommand(array $options = array()) {
     $server      = $options['server'];

--- a/php/Terminus/Commands/HelpCommand.php
+++ b/php/Terminus/Commands/HelpCommand.php
@@ -6,6 +6,8 @@ use Terminus;
 use Terminus\Dispatcher;
 use Terminus\Utils;
 use Terminus\Commands\TerminusCommand;
+use Terminus\Dispatcher\CompositeCommand;
+use Terminus\Dispatcher\RootCommand;
 use Terminus\Helpers\Input;
 
 class HelpCommand extends TerminusCommand {
@@ -49,8 +51,8 @@ class HelpCommand extends TerminusCommand {
   /**
    * Finds a subcommand listed in the arguments, else returns the root command
    *
-   * @param [array] $args Given command-line arguments
-   * @return [mixed] $command
+   * @param array $args Given command-line arguments
+   * @return mixed
    */
   private function findSubcommand($args) {
     $command = Terminus::getRootCommand();
@@ -65,8 +67,8 @@ class HelpCommand extends TerminusCommand {
   /**
    * Retrieves the synopsis of a given command or subcommand
    *
-   * @param [mixed] $command The command or subcommand to get documentation on
-   * @return [string] $binding
+   * @param mixed $command The command or subcommand to get documentation on
+   * @return array
    */
   private function getMarkdown($command) {
     $name = implode(' ', Dispatcher\getPath($command));
@@ -89,10 +91,10 @@ class HelpCommand extends TerminusCommand {
   /**
    * Gets the basic descriptions of a command's paramters and options from docs
    *
-   * @param [CompositeCommand] $command The command of which to get options
-   * @return [array] $options
+   * @param CompositeCommand $command The command of which to get options
+   * @return array
    */
-  private function getOptions($command) {
+  private function getOptions(CompositeCommand $command) {
     $longdesc = $command->getLongdesc();
     $synopses = explode(
       ' ',
@@ -128,8 +130,8 @@ class HelpCommand extends TerminusCommand {
   /**
    * Gets the basic descriptions of a command's subcommands from internal docs
    *
-   * @param [CompositeCommand] $command The command of which to get subcommands
-   * @return [array <string>] $subcommands An array of stringified
+   * @param CompositeCommand $command The command of which to get subcommands
+   * @return string[] $subcommands An array of stringified
    *   subcommands of the command
    */
   private function getSubcommands($command) {
@@ -147,8 +149,8 @@ class HelpCommand extends TerminusCommand {
   /**
    * Displays the output with Less
    *
-   * @param [string] $out Help text to be displayed
-   * @return [integer] $exit_status Exit status of Less
+   * @param string $out Help text to be displayed
+   * @return int Exit status of Less
    */
   private function passThroughPager($out) {
     if (Utils\isWindows()) {
@@ -174,10 +176,10 @@ class HelpCommand extends TerminusCommand {
   /**
    * Takes a command to get help for and processes its internal documentation
    *
-   * @param [mixed] $command The command to offer help for
-   * @return [integer] $exit_status
+   * @param CompositeCommand $command The command to offer help for
+   * @return int
    */
-  private function showHelp($command) {
+  private function showHelp(CompositeCommand $command) {
     $out         = $this->getMarkdown($command);
     $exit_status = 0;
 

--- a/php/Terminus/Commands/InstrumentsCommand.php
+++ b/php/Terminus/Commands/InstrumentsCommand.php
@@ -14,8 +14,6 @@ class InstrumentsCommand extends TerminusCommand {
 
   /**
    * Instantiates object, ensures login
-   *
-   * @return [InstrumentsCommand] $this
    */
   public function __construct() {
     Auth::ensureLogin();

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -8,6 +8,7 @@ use Terminus\Helpers\Input;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Models\User;
 use Terminus\Models\Organization;
+use Terminus\Models\OrganizationSiteMembership;
 use Terminus\Models\Collections\Sites;
 use Terminus\Models\Collections\UserOrganizationMemberships;
 
@@ -227,10 +228,10 @@ class OrganizationsCommand extends TerminusCommand {
   /**
    * Retrieves a succinct list of member sites
    *
-   * @param [array] $memberships Members of this org
-   * @return [array] $list
+   * @param OrganizationSiteMembership[] $memberships Members of this org
+   * @return array
    */
-  private function getMemberSiteList($memberships) {
+  private function getMemberSiteList(array $memberships) {
     $list = array();
     foreach ($memberships as $membership) {
       $site = $membership->get('site');
@@ -242,8 +243,8 @@ class OrganizationsCommand extends TerminusCommand {
   /**
    * Retrieves a succinct list of non-member sites
    *
-   * @param [array] $memberships Members of this org
-   * @return [array] $list
+   * @param OrganizationSiteMembership[] $memberships Members of this org
+   * @return array
    */
   private function getNonmemberSiteList($memberships) {
     $members = $this->getMemberSiteList($memberships);
@@ -255,8 +256,8 @@ class OrganizationsCommand extends TerminusCommand {
   /**
    * Determines whether the site is a member of an org
    *
-   * @param [array] $memberships Members of this org
-   * @return [boolean] $is_member
+   * @param OrganizationSiteMembership[] $memberships Members of this org
+   * @return bool
    */
   private function siteIsMember($memberships, $site_id) {
     $list      = $this->getMemberSiteList($memberships);

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -10,6 +10,7 @@ use Terminus\Commands\TerminusCommand;
 use Terminus\Helpers\Input;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\User;
+use Terminus\Models\Workflow;
 use Terminus\Models\Collections\Sites;
 
 /**
@@ -1841,10 +1842,10 @@ class SiteCommand extends TerminusCommand {
   /**
    * Cancels an environment's regular backup schedule
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [void]
+   * @param array $assoc_args Parameters and flags from the command line
+   * @return void
    */
-  private function cancelBackupSchedule($assoc_args) {
+  private function cancelBackupSchedule(array $assoc_args) {
     $site     = $this->sites->get(Input::sitename($assoc_args));
     $env      = $site->environments->get(
       Input::env(
@@ -1858,8 +1859,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Creates a backup
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [Workflow] $workflow
+   * @param array $assoc_args Parameters and flags from the command line
+   * @return Workflow
    */
   private function createBackup($assoc_args) {
     $site = $this->sites->get(Input::sitename($assoc_args));
@@ -1882,8 +1883,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Retrieves a single backup or downloads it as requested
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [string] $url->url
+   * @param array $assoc_args Parameters and flags from the command line
+   * @return string
    */
   private function getBackup($assoc_args) {
     $site = $this->sites->get(Input::sitename($assoc_args));
@@ -1934,8 +1935,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Checks to ensure user can access the given organization
    *
-   * @param [string] $org_id Organization name or UUID
-   * @return [boolean] $is_ok True if this organization is accessible
+   * @param string $org_id Organization name or UUID
+   * @return bool True if this organization is accessible
    */
   private function isOrgAccessible($org_id) {
     $user  = new User();
@@ -1947,8 +1948,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Lists available backups
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [array] $data Elements as follows:
+   * @params array $assoc_args Parameters and flags from the command line
+   * @return array $data Elements as follows:
    *         [string] file The backup's file name
    *         [string] size The backup file's size
    *         [string] date The datetime of the backup's creation
@@ -1987,8 +1988,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Loads a single backup
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [boolean] Always true, else the function has thrown an exception
+   * @params array $assoc_args Parameters and flags from the command line
+   * @return bool Always true, else the function has thrown an exception
    */
   private function loadBackup($assoc_args) {
     $site = $this->sites->get(Input::sitename($assoc_args));
@@ -2065,8 +2066,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Sets an environment's regular backup schedule
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [void]
+   * @param array $assoc_args Parameters and flags from the command line
+   * @return void
    */
   private function setBackupSchedule($assoc_args) {
     $site     = $this->sites->get(Input::sitename($assoc_args));
@@ -2083,8 +2084,8 @@ class SiteCommand extends TerminusCommand {
   /**
    * Displays an environment's regular backup schedule
    *
-   * @params [array] $assoc_args Parameters and flags from the command line
-   * @return [void]
+   * @params array $assoc_args Parameters and flags from the command line
+   * @return void
    */
   private function showBackupSchedule($assoc_args) {
     $site     = $this->sites->get(Input::sitename($assoc_args));

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -23,8 +23,6 @@ class SitesCommand extends TerminusCommand {
 
   /**
    * Shows a list of your sites on Pantheon
-   *
-   * @return [SitesCommand] $this
    */
   public function __construct() {
     Auth::ensureLogin();
@@ -423,8 +421,8 @@ class SitesCommand extends TerminusCommand {
   /**
    * A helper function for getting/prompting for the site create options.
    *
-   * @param [array] $assoc_args Arguments from command
-   * @return [array] $options
+   * @param array $assoc_args Arguments from command
+   * @return array
    */
   private function getSiteCreateOptions($assoc_args) {
     $options          = array();

--- a/php/Terminus/Commands/TerminusCommand.php
+++ b/php/Terminus/Commands/TerminusCommand.php
@@ -8,8 +8,10 @@ use Terminus\Endpoint;
 use Terminus\Request;
 use Terminus\Session;
 use Terminus\Utils;
+use Terminus\Outputters\OutputterInterface;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Loggers\Regular as Logger;
+use Terminus\Models\Workflow;
+use Terminus\Loggers\Logger;
 
 /**
  * The base class for Terminus commands
@@ -22,24 +24,22 @@ abstract class TerminusCommand {
   protected $func;
 
   /**
-   * @var [LoggerInterface]
+   * @var Logger
    */
   protected $logger;
 
   /**
-   * @var [OutputterInterface]
+   * @var OutputterInterface
    */
   protected $outputter;
 
   /**
-   * @var [Request]
+   * @var Request
    */
   protected $request;
 
   /**
    * Instantiates object, sets cache and session
-   *
-   * @return [TerminusCommand] $this
    */
   public function __construct() {
     //Load commonly used data from cache
@@ -56,10 +56,11 @@ abstract class TerminusCommand {
   /**
    * Sends the given message to logger as an error and exits with -1
    *
-   * @param [string]  $message   Message to log as error before exit
-   * @param [array]   $context   Vars to interpolate in message
-   * @param [integer] $exit_code Code to exit with
-   * @return [void]
+   * @param string $message   Message to log as error before exit
+   * @param array  $context   Vars to interpolate in message
+   * @param int    $exit_code Code to exit with
+   * @return void
+   * @throws TerminusException
    */
   protected function failure(
     $message       = 'Command failed',
@@ -72,7 +73,7 @@ abstract class TerminusCommand {
   /**
    * Retrieves the logger for use
    *
-   * @return [LoggerInterface] $this->logger
+   * @return Logger
    */
   protected function log() {
     return $this->logger;
@@ -81,7 +82,7 @@ abstract class TerminusCommand {
   /**
    * Retrieves the outputter for use
    *
-   * @return [OutputterInterface] $this->outputter
+   * @return OutputterInterface
    */
   protected function output() {
     return $this->outputter;
@@ -90,28 +91,28 @@ abstract class TerminusCommand {
   /**
    * Saves the logger object as a class property
    *
-   * @param [LoggerInterface] $logger Logger object to save
-   * @return [void]
+   * @param Logger $logger Logger object to save
+   * @return void
    */
-  protected function setLogger($logger) {
+  protected function setLogger(Logger $logger) {
     $this->logger = $logger;
   }
 
   /**
    * Saves the outputter object as a class property
    *
-   * @param [OutputterInterface] $outputter Outputter object to save
-   * @return [void]
+   * @param OutputterInterface $outputter Outputter object to save
+   * @return void
    */
-  protected function setOutputter($outputter) {
+  protected function setOutputter(OutputterInterface $outputter) {
     $this->outputter = $outputter;
   }
 
   /**
    * Outputs basic workflow success/failure messages
    *
-   * @param [Workflow] $workflow Workflow to output message about
-   * @return [void]
+   * @param Workflow $workflow Workflow to output message about
+   * @return void
    */
   protected function workflowOutput($workflow) {
     if ($workflow->get('result') == 'succeeded') {

--- a/php/Terminus/Commands/WorkflowsCommand.php
+++ b/php/Terminus/Commands/WorkflowsCommand.php
@@ -21,8 +21,6 @@ class WorkflowsCommand extends TerminusCommand {
 
   /**
    * Object constructor.
-   *
-   * @return [WorkflowsCommand] $this
    */
   public function __construct() {
     Auth::ensureLogin();

--- a/php/Terminus/Completions.php
+++ b/php/Terminus/Completions.php
@@ -6,14 +6,19 @@ use Terminus;
 
 class Completions {
 
+  /**
+   * @var array
+   */
   private $words;
+  /**
+   * @var array
+   */
   private $opts = array();
 
   /**
    * Constructs object, parses command
    *
-   * @param [string] $line Command to make completions for
-   * @return [Completions] $htis
+   * @param string $line Command to make completions for
    */
   function __construct($line) {
     // TODO: properly parse single and double quotes
@@ -30,6 +35,7 @@ class Completions {
       return;
     }
 
+    /** @var \Terminus\Dispatcher\RootCommand $command */
     list($command, $args, $assoc_args) = $r;
 
     $spec = SynopsisParser::parse($command->getSynopsis());
@@ -69,8 +75,8 @@ class Completions {
   /**
    * Adds options to opts array
    *
-   * @param [string] $opt Option to add
-   * @return [void]
+   * @param string $opt Option to add
+   * @return void
    */
   private function add($opt) {
     if ($this->cur_word !== '') {
@@ -85,9 +91,9 @@ class Completions {
   /**
    * Gets command to run
    *
-   * @param [array] $words Words of the command-line string to process
-   * @return [array] $command_array
-   *         [string] $command
+   * @param array $words Words of the command-line string to process
+   * @return array $command_array
+   *         [RootCommand] $command
    *         [array]  $args
    *         [array]  $assoc_args
    */
@@ -119,7 +125,7 @@ class Completions {
   /**
    * Prints out all opt elements on their own lines
    *
-   * @return [void]
+   * @return void
    */
   public function render() {
     foreach ($this->opts as $opt) {

--- a/php/Terminus/Configurator.php
+++ b/php/Terminus/Configurator.php
@@ -11,8 +11,7 @@ class Configurator {
   /**
    * Constructs configurator, configures
    *
-   * @param [string] $path Path to configuration specification file
-   * @return [Configurator] $this
+   * @param string $path Path to configuration specification file
    */
   public function __construct($path) {
     $this->spec = include $path;
@@ -34,10 +33,10 @@ class Configurator {
   /**
    * Splits positional args from associative args.
    *
-   * @param [array] $arguments Arguments to parse
-   * @return [array] $array
+   * @param array $arguments Arguments to parse
+   * @return array
    */
-  public static function extractAssoc($arguments) {
+  public static function extractAssoc(array $arguments) {
     $positional_args = $assoc_args = array();
 
     foreach ($arguments as $arg) {
@@ -61,7 +60,7 @@ class Configurator {
   /**
    * Get configuration specification, i.e. list of accepted keys.
    *
-   * @return [array] $this->spec
+   * @return array
    */
   public function getSpec() {
     return $this->spec;
@@ -70,8 +69,8 @@ class Configurator {
   /**
    * Adds the given array to the config property array
    *
-   * @param [array] $config Details to add to config
-   * @return [void]
+   * @param array $config Details to add to config
+   * @return void
    */
   public function mergeArray($config) {
     foreach ($this->spec as $key => $details) {
@@ -91,8 +90,8 @@ class Configurator {
   /**
    * Splits a list of arguments into positional, associative and config.
    *
-   * @param [array] $arguments Arguments to parse
-   * @return [array] $array positional_args, assoc_args, runtime_config
+   * @param array $arguments Arguments to parse
+   * @return array positional_args, assoc_args, runtime_config
    */
   public function parseArgs($arguments) {
     list($positional_args, $mixed_args) = self::extractAssoc($arguments);
@@ -104,7 +103,7 @@ class Configurator {
   /**
    * Returns the config property
    *
-   * @return [array] $this->config
+   * @return array
    */
   public function toArray() {
     return $this->config;
@@ -113,8 +112,8 @@ class Configurator {
   /**
    * Puts the given value into an array, if it is not already
    *
-   * @param [mixed] $val Value to put in an array
-   * @return [array] $val
+   * @param mixed $val Value to put in an array
+   * @return array
    */
   private function arrayify($val) {
     if (!is_array($val)) {
@@ -126,8 +125,8 @@ class Configurator {
   /**
    * Separates assoc_args from runtime configuration
    *
-   * @param [array] $mixed_args A mixture of runtime args and command args
-   * @return [array] $array [0] = assoc_args, [1] = runtime_config
+   * @param array $mixed_args A mixture of runtime args and command args
+   * @return array [0] = assoc_args, [1] = runtime_config
    */
   private function unmixAssocArgs($mixed_args) {
     $assoc_args = $runtime_config = array();

--- a/php/Terminus/Dispatcher/CommandFactory.php
+++ b/php/Terminus/Dispatcher/CommandFactory.php
@@ -13,12 +13,12 @@ class CommandFactory {
   /**
    * Creates a new composite command or subcommand
    *
-   * @param [string]      $name   Name of command to create
-   * @param [string]      $class  Name of class command belongs to
-   * @param [RootCommand] $parent Parent command
-   * @return [mixed] $command Either CompositeCommand or Subcommand
+   * @param string           $name   Name of command to create
+   * @param string           $class  Name of class command belongs to
+   * @param CompositeCommand $parent Parent command
+   * @return CompositeCommand
    */
-  public static function create($name, $class, $parent) {
+  public static function create($name, $class, CompositeCommand $parent) {
     $reflection = new \ReflectionClass($class);
 
     if ($reflection->hasMethod('__invoke')) {
@@ -38,12 +38,16 @@ class CommandFactory {
   /**
    * Creates a new composite command
    *
-   * @param [RootCommand]      $parent     Parent command
-   * @param [string]           $name       Name of command to create
-   * @param [\ReflectionClass] $reflection Object with name of class to call
-   * @return [CompositeCommand] $container
+   * @param RootCommand      $parent     Parent command
+   * @param string           $name       Name of command to create
+   * @param \ReflectionClass $reflection Object with name of class to call
+   * @return CompositeCommand
    */
-  private static function createCompositeCommand($parent, $name, $reflection) {
+  private static function createCompositeCommand(
+    RootCommand $parent,
+    $name,
+    \ReflectionClass $reflection
+  ) {
     $docparser = new DocParser($reflection->getDocComment());
     $container = new CompositeCommand($parent, $name, $docparser);
 
@@ -67,17 +71,17 @@ class CommandFactory {
   /**
    * Creates a new subcommand
    *
-   * @param [RootCommand] $parent     Parent command
-   * @param [string]      $name       Name of command to create
-   * @param [string]      $class_name Name of class command belongs to
-   * @param [string]      $method     Name of function to invoke in class
-   * @return [Subcommand] $subcommand
+   * @param CompositeCommand  $parent     Parent command
+   * @param string            $name       Name of command to create
+   * @param string            $class_name Name of class command belongs to
+   * @param \ReflectionMethod $method     Name of function to invoke in class
+   * @return Subcommand
    */
   private static function createSubcommand(
-    $parent,
+    CompositeCommand $parent,
     $name,
     $class_name,
-    $method
+    \ReflectionMethod $method
   ) {
     $docparser = new DocParser($method->getDocComment());
     if (!$name) {
@@ -103,10 +107,10 @@ class CommandFactory {
   /**
    * Decides if the given method is a good one
    *
-   * @param [string] $method Name of method to be called
-   * @return [boolean] $is_good_method
+   * @param \ReflectionMethod $method Method to be called
+   * @return bool
    */
-  private static function isGoodMethod($method) {
+  private static function isGoodMethod(\ReflectionMethod $method) {
     $is_good_method = $method->isPublic()
       && !$method->isConstructor()
       && !$method->isStatic();

--- a/php/Terminus/Dispatcher/CompositeCommand.php
+++ b/php/Terminus/Dispatcher/CompositeCommand.php
@@ -3,6 +3,7 @@
 namespace Terminus\Dispatcher;
 
 use Terminus;
+use Terminus\DocParser;
 
 /**
  * A non-leaf node in the command tree.
@@ -17,12 +18,12 @@ class CompositeCommand {
   /**
    * Object constructor. Sets object properties
    *
-   * @param [RootCommand] $parent    Parent command dispatcher object
-   * @param [string]      $name      Name of command to run
-   * @param [DocParser]   $docparser DocParser object for analysis of docs
-   * @return [CompositeCommand] $this
+   * @param CompositeCommand $parent    Parent command dispatcher object
+   * @param string           $name      Name of command to run
+   * @param DocParser        $docparser DocParser object for analysis of docs
+   * @return CompositeCommand $this
    */
-  public function __construct($parent, $name, $docparser) {
+  public function __construct(CompositeCommand $parent, $name, DocParser $docparser) {
     $this->name      = $name;
     $this->parent    = $parent;
     $this->shortdesc = $docparser->getShortdesc();
@@ -32,18 +33,18 @@ class CompositeCommand {
   /**
    * Adds a subcommand to the subcommand array
    *
-   * @param [string]     $name    Name of subcommand to add
-   * @param [Subcommand] $command Subcommand object to add
-   * @return [void]
+   * @param string           $name    Name of subcommand to add
+   * @param CompositeCommand $command Command object to add
+   * @return void
    */
-  public function addSubcommand($name, $command) {
+  public function addSubcommand($name, CompositeCommand $command) {
     $this->subcommands[$name] = $command;
   }
 
   /**
    * Tells whether there can be subcommands of this object
    *
-   * @return [boolean] Always true
+   * @return bool Always true
    */
   public function canHaveSubcommands() {
     return true;
@@ -52,8 +53,8 @@ class CompositeCommand {
   /**
    * Finds and retrieves the subcommand from the first element of the param
    *
-   * @param [array] $args An array of strings representing subcommand names
-   * @return [mixed] $subcommands[$name] or false if DNE
+   * @param array $args An array of strings representing subcommand names
+   * @return Subcommand|false
    */
   public function findSubcommand(&$args) {
     $name        = array_shift($args);
@@ -76,7 +77,7 @@ class CompositeCommand {
   /**
    * Gets the long description of the command this object represents
    *
-   * @return [string] $this->longdesc
+   * @return string
    */
   public function getLongdesc() {
     return $this->longdesc;
@@ -85,7 +86,7 @@ class CompositeCommand {
   /**
    * Gets the name of the command this object represents
    *
-   * @return [string] $this->name
+   * @return string
    */
   public function getName() {
     return $this->name;
@@ -94,7 +95,7 @@ class CompositeCommand {
   /**
    * Gets the parent command object
    *
-   * @return [RootCommand] $this->parent
+   * @return RootCommand
    */
   public function getParent() {
     return $this->parent;
@@ -103,7 +104,7 @@ class CompositeCommand {
   /**
    * Gets the short description of the command this object represents
    *
-   * @return [string] $this->shortdesc
+   * @return string
    */
   public function getShortdesc() {
     return $this->shortdesc;
@@ -112,7 +113,7 @@ class CompositeCommand {
   /**
    * Sorts and retrieves the subcommands
    *
-   * @return [array] $this->subcommands Array of Subcommand objects
+   * @return Subcommand[]
    */
   public function getSubcommands() {
     ksort($this->subcommands);
@@ -123,7 +124,7 @@ class CompositeCommand {
   /**
    * Gets the synopsis of the command this object represents
    *
-   * @return [string] Always "<command>"
+   * @return string Always "<command>"
    */
   public function getSynopsis() {
     return '<command>';
@@ -132,8 +133,8 @@ class CompositeCommand {
   /**
    * Gets the usage parameters of the command this object represents
    *
-   * @param [string] $prefix Prefix to usage string
-   * @return [string] $usage
+   * @param string $prefix Prefix to usage string
+   * @return string
    */
   public function getUsage($prefix) {
     $usage = sprintf(
@@ -148,18 +149,18 @@ class CompositeCommand {
   /**
    * Displays the usage parameters of the command this object represents
    *
-   * @param [array] $args       Array of command line non-params and non-flags
-   * @param [array] $assoc_args Array of command line params and flags
-   * @return [void]
+   * @param array $args       Array of command line non-params and non-flags
+   * @param array $assoc_args Array of command line params and flags
+   * @return void
    */
-  public function invoke($args, $assoc_args) {
+  public function invoke(array $args, array $assoc_args) {
     $this->showUsage();
   }
 
   /**
    * Displays the usage parameters of the command this object represents
    *
-   * @return [void]
+   * @return void
    */
   public function showUsage() {
     $methods = $this->getSubcommands();
@@ -182,8 +183,8 @@ class CompositeCommand {
   /**
    * Retrieves aliases of a subcommand
    *
-   * @param [array] $subcommands An array of subcommandname strings
-   * @return [array] $aliases An array of alias strings
+   * @param Subcommand[] $subcommands An array of subcommands, keyed by name
+   * @return string[]
    */
   private static function getAliases($subcommands) {
     $aliases = array();

--- a/php/Terminus/Dispatcher/RootCommand.php
+++ b/php/Terminus/Dispatcher/RootCommand.php
@@ -12,8 +12,6 @@ class RootCommand extends CompositeCommand {
 
   /**
    * Object constructor, sets object properties
-   *
-   * @return [RootCommand] $this
    */
   function __construct() {
     $this->parent    = false;
@@ -24,8 +22,8 @@ class RootCommand extends CompositeCommand {
   /**
    * Finds a subcommand of the root command
    *
-   * @param [array] $args Arguments to parse into subcommands
-   * @return [mixed] $this->$subcommands[$command] or false if DNE
+   * @param array $args Arguments to parse into subcommands
+   * @return Subcommand|false
    */
   function findSubcommand(&$args) {
     $command = array_shift($args);
@@ -41,7 +39,7 @@ class RootCommand extends CompositeCommand {
   /**
    * Returns long description of this command by parsing the docs
    *
-   * @return [string] $binding
+   * @return array
    */
   function getLongdesc() {
     $binding = array();
@@ -74,7 +72,7 @@ class RootCommand extends CompositeCommand {
   /**
    * Returns all subcommands of the root command
    *
-   * @return [array] $subcommands An array of Subcommand objects
+   * @return Subcommand[]
    */
   function getSubcommands() {
     Utils\loadAllCommands();

--- a/php/Terminus/Dispatcher/Subcommand.php
+++ b/php/Terminus/Dispatcher/Subcommand.php
@@ -4,26 +4,37 @@ namespace Terminus\Dispatcher;
 
 use Terminus;
 use Terminus\Exceptions\TerminusException;
+use Terminus\DocParser;
 
 /**
  * A leaf node in the command tree.
  */
 class Subcommand extends CompositeCommand {
 
+  /**
+   * @var string
+   */
   private $alias;
 
+  /**
+   * @var callable
+   */
   private $when_invoked;
 
   /**
    * Object constructor. Sets object properties
    *
-   * @param [RootCommand] $parent       Parent command dispatcher object
-   * @param [string]      $name         Name of command to run
-   * @param [DocParser]   $docparser    DocParser object for analysis of docs
-   * @param [Closure]     $when_invoked Indicates classes & methods to use
-   * @return [CompositeCommand] $this
+   * @param CompositeCommand $parent       Parent command dispatcher object
+   * @param string           $name         Name of command to run
+   * @param DocParser        $docparser    DocParser object for analysis of docs
+   * @param callable         $when_invoked Indicates classes & methods to use
    */
-  public function __construct($parent, $name, $docparser, $when_invoked) {
+  public function __construct(
+    CompositeCommand $parent,
+    $name,
+    DocParser $docparser,
+    callable $when_invoked
+  ) {
     parent::__construct($parent, $name, $docparser);
     $this->when_invoked = $when_invoked;
     $this->alias        = $docparser->getTag('alias');
@@ -36,7 +47,7 @@ class Subcommand extends CompositeCommand {
   /**
    * Tells whether there can be subcommands of this object
    *
-   * @return [boolean] Always false
+   * @return bool Always false
    */
   public function canHaveSubcommands() {
     return false;
@@ -45,7 +56,7 @@ class Subcommand extends CompositeCommand {
   /**
    * Gets the synopsis of the command this object represents
    *
-   * @return [string] $this->synopsis
+   * @return string
    */
   public function getSynopsis() {
     return $this->synopsis;
@@ -54,7 +65,7 @@ class Subcommand extends CompositeCommand {
   /**
    * Gets the alias of the command this object represents
    *
-   * @return [string] $this->alias
+   * @return string
    */
   public function getAlias() {
     return $this->alias;
@@ -63,8 +74,8 @@ class Subcommand extends CompositeCommand {
   /**
    * Displays the usage parameters of the command this object represents
    *
-   * @param [string] $prefix Prefix for this command's usage
-   * @return [void]
+   * @param string $prefix Prefix for this command's usage
+   * @return void
    */
   public function showUsage($prefix = 'usage: ') {
     Terminus::line($this->getUsage($prefix));
@@ -73,8 +84,8 @@ class Subcommand extends CompositeCommand {
   /**
    * Gets the usage parameters of the command this object represents
    *
-   * @param [string] $prefix Prefix to usage string
-   * @return [string] $usage
+   * @param string $prefix Prefix to usage string
+   * @return string
    */
   public function getUsage($prefix) {
     $usage = sprintf(
@@ -89,11 +100,11 @@ class Subcommand extends CompositeCommand {
   /**
    * Displays the usage parameters of the command this object represents
    *
-   * @param [array] $args       Array of command line non-params and non-flags
-   * @param [array] $assoc_args Array of command line params and flags
-   * @return [void]
+   * @param array $args       Array of command line non-params and non-flags
+   * @param array $assoc_args Array of command line params and flags
+   * @return void
    */
-  public function invoke($args, $assoc_args) {
+  public function invoke(array $args, array $assoc_args) {
     $to_unset = $this->validateArgs($args, $assoc_args);
     foreach ($to_unset as $key) {
       unset($assoc_args[$key]);
@@ -107,10 +118,10 @@ class Subcommand extends CompositeCommand {
   }
 
   /**
-   * Parses thhe synopsis into an array
+   * Parses the synopsis into an array
    *
-   * @param [string] $longdesc The synopsis to parse
-   * @return [array] $synopsis
+   * @param string $longdesc The synopsis to parse
+   * @return array
    */
   private static function extractSynopsis($longdesc) {
     preg_match_all('/(.+?)[\r\n]+:/', $longdesc, $matches);
@@ -121,11 +132,12 @@ class Subcommand extends CompositeCommand {
   /**
    * Parses the arguments for prompting in interactive mode
    *
-   * @param [array] $args       Array of command line non-params and non-flags
-   * @param [array] $assoc_args Array of command line params and flags
-   * @return [array] $args_array Elements as follows:
+   * @param array $args       Array of command line non-params and non-flags
+   * @param array $assoc_args Array of command line params and flags
+   * @return array Elements as follows:
    *         [array] Array of command line non-params and non-flags
    *         [array] Array of command line params and flags
+   * @todo This function is unused; remove?
    */
   private function promptArgs($args, $assoc_args) {
     $synopsis = $this->getSynopsis();
@@ -234,9 +246,10 @@ class Subcommand extends CompositeCommand {
   /**
    * Decides which arguments are invalid for this command
    *
-   * @param [array] $args       Array of command line non-params and non-flags
-   * @param [array] $assoc_args Array of command line params and flags
-   * @return [array] A list of invalid $assoc_args keys to unset
+   * @param array $args       Array of command line non-params and non-flags
+   * @param array $assoc_args Array of command line params and flags
+   * @return array A list of invalid $assoc_args keys to unset
+   * @throws TerminusException
    */
   private function validateArgs($args, $assoc_args) {
     $synopsis = $this->getSynopsis();

--- a/php/Terminus/DocParser.php
+++ b/php/Terminus/DocParser.php
@@ -9,8 +9,8 @@ class DocParser {
   /**
    * Object constructor
    *
-   * @param [string] $docComment Will be undeorated and saved
-   * @return [DocParser] $this
+   * @param string $docComment Will be undecorated and saved
+   * @return DocParser
    */
   function __construct($docComment) {
     $this->docComment = $this->removeDecorations($docComment);
@@ -19,7 +19,7 @@ class DocParser {
   /**
    * Gives short description plus more information
    *
-   * @return [string] $longdesc
+   * @return string
    */
   public function getLongdesc() {
     $shortdesc = $this->getShortdesc();
@@ -45,7 +45,7 @@ class DocParser {
   /**
    * Parses the doc comment to find short description
    *
-   * @return [string] $matches[1]
+   * @return string
    */
   public function getShortdesc() {
     if (!preg_match('|^([^@][^\n]+)\n*|', $this->docComment, $matches)) {
@@ -58,7 +58,7 @@ class DocParser {
   /**
    * Parses the synopsis out of the doc comment
    *
-   * @return [string] $matches[1]
+   * @return string
    */
   public function getSynopsis() {
     if (!preg_match('|^@synopsis\s+(.+)|m', $this->docComment, $matches)) {
@@ -71,8 +71,8 @@ class DocParser {
   /**
    * Parses tag of given name out of the doc comment
    *
-   * @param [string] $name Name of the tag to retrieve
-   * @return [string] $matches[1]
+   * @param string $name Name of the tag to retrieve
+   * @return string
    */
   public function getTag($name) {
     if (preg_match(
@@ -89,8 +89,8 @@ class DocParser {
   /**
    * Removes decorators from the given string
    *
-   * @param [string] $comment Will be undecorated
-   * @return [string] $comment
+   * @param string $comment Will be undecorated
+   * @return string
    */
   private function removeDecorations($comment) {
     $comment = preg_replace('|^/\*\*[\r\n]+|', '', $comment);

--- a/php/Terminus/Endpoint.php
+++ b/php/Terminus/Endpoint.php
@@ -29,8 +29,6 @@ class Endpoint {
 
   /**
    * Object constructor. Sets target property to private.
-   *
-   * @return [Endpoint] $this
    */
   public function __construct() {
     $this->target = 'private';
@@ -41,8 +39,8 @@ class Endpoint {
    * endpoint. Once we're fully committed to the 2.0 api we can clean it up a
    * bit.
    *
-   * @param [array] $args Should contain a realm and uuid, can also have a path
-   * @return [string] $url
+   * @param array $args Should contain a realm and uuid, can also have a path
+   * @return string
    *
    *    Example:
    *
@@ -85,10 +83,10 @@ class Endpoint {
 
   /**
    * Retrieves an endpoint
-   * @param [array] $args Elements as follow:
+   * @param array $args Elements as follow:
    *        [string] realm user, site, organization
    *        [string] path specific method to call
-   * @return [string] $endpoint_string
+   * @return stringß
    */
   static function get($args) {
     $endpoint        = new Endpoint($args);

--- a/php/Terminus/FileCache.php
+++ b/php/Terminus/FileCache.php
@@ -44,11 +44,10 @@ class FileCache {
   /**
    * Object constructor. Sets properties.
    *
-   * @param [string]  $cacheDir  The location of the cache
-   * @param [integer] $ttl       The cache file's default expiry time
-   * @param [integer] $maxSize   The max total cache size
-   * @param [string]  $whitelist A list of characters that are allowed in path
-   * @return [FileCache] $this
+   * @param string $cacheDir  The location of the cache
+   * @param int    $ttl       The cache file's default expiry time
+   * @param int    $maxSize   The max total cache size
+   * @param string $whitelist A list of characters that are allowed in path
    */
   public function __construct(
     $cacheDir,
@@ -70,7 +69,7 @@ class FileCache {
   /**
    * Clean cache based on time to live and max size
    *
-   * @return [boolean] True if cache clean succeeded
+   * @return bool True if cache clean succeeded
    */
   public function clean() {
     if (!$this->enabled) {
@@ -117,10 +116,10 @@ class FileCache {
   /**
    * Copies a file out of the cache
    *
-   * @param [string]  $key    Cache key
-   * @param [string]  $target Target filename
-   * @param [integer] $ttl    Time to live
-   * @return [boolean] $export True if export succeeded
+   * @param string $key    Cache key
+   * @param string $target Target filename
+   * @param int    $ttl    Time to live
+   * @return bool True if export succeeded
    */
   public function export($key, $target, $ttl = null) {
     $filename = $this->has($key, $ttl);
@@ -135,7 +134,7 @@ class FileCache {
   /**
    * Flushes all caches
    *
-   * @return [void]
+   * @return void
    */
   public function flush() {
     $finder = $this->getFinder();
@@ -147,13 +146,13 @@ class FileCache {
   /**
    * Reads retrieves data from cache
    *
-   * @param [string] $key     A cache key
-   * @param [array]  $options Elements as follows:
-   *        [boolean] decode_array Argument 2 for json_decode
-   *        [boolean] ttl          TTL for file read
-   * @return [boolean|string] $data The file contents or false
+   * @param string $key     A cache key
+   * @param array  $options Elements as follows:
+   *        [bool] decode_array Argument 2 for json_decode
+   *        [bool] ttl          TTL for file read
+   * @return bool|string The file contents or false
    */
-  public function getData($key, $options = array()) {
+  public function getData($key, array $options = array()) {
     $defaults = array(
       'decode_array' => false,
       'ttl'          => null
@@ -172,7 +171,7 @@ class FileCache {
   /**
    * Returns the cache root
    *
-   * @return [string] $this->root
+   * @return string
    */
   public function getRoot() {
     return $this->root;
@@ -181,9 +180,9 @@ class FileCache {
   /**
    * Checks if a file is in cache and return its filename
    *
-   * @param [string]  $key Cache key
-   * @param [integer] $ttl Time to live
-   * @return [boolean|string] The filename or false
+   * @param string $key Cache key
+   * @param int    $ttl Time to live
+   * @return bool|string The filename or false
    */
   public function has($key, $ttl = null) {
     if (!$this->enabled) {
@@ -219,9 +218,9 @@ class FileCache {
   /**
    * Copies a file into the cache
    *
-   * @param [string] $key    Cache key
-   * @param [string] $source Source filename
-   * @return [boolean] $import True if import succeeded
+   * @param string $key    Cache key
+   * @param string $source Source filename
+   * @return bool True if import succeeded
    */
   public function import($key, $source) {
     $filename = $this->prepareWrite($key);
@@ -236,7 +235,7 @@ class FileCache {
   /**
    * Returns whether cache is enabled
    *
-   * @return [boolean] $this->enabled
+   * @return bool
    */
   public function isEnabled() {
     return $this->enabled;
@@ -245,9 +244,9 @@ class FileCache {
   /**
    * Saves data to the cache, JSON-encoded
    *
-   * @param [string] $key  A cache key
-   * @param [mixed]  $data Data to save to cache
-   * @return [boolean] $result True if write succeeded
+   * @param string $key  A cache key
+   * @param mixed  $data Data to save to cache
+   * @return bool True if write succeeded
    */
   public function putData($key, $data) {
     $json   = json_encode($data);
@@ -258,9 +257,9 @@ class FileCache {
   /**
    * Reads from the cache file
    *
-   * @param [string]  $key A cache key
-   * @param [integer] $ttl The time to live
-   * @return [boolean|string] $data The file contents or false
+   * @param string  $key A cache key
+   * @param integer $ttl The time to live
+   * @return bool|string The file contents or false
    */
   public function read($key, $ttl = null) {
     $filename = $this->has($key, $ttl);
@@ -275,8 +274,8 @@ class FileCache {
   /**
    * Remove file from cache
    *
-   * @param [string] $key Cache key
-   * @return [boolean]
+   * @param string $key Cache key
+   * @return bool
    */
   public function remove($key) {
     if (!$this->enabled) {
@@ -296,9 +295,9 @@ class FileCache {
   /**
    * Writes to cache file
    *
-   * @param [string] $key      A cache key
-   * @param [string] $contents The file contents
-   * @return [boolean] $written True if write was successful
+   * @param string $key      A cache key
+   * @param string $contents The file contents
+   * @return bool True if write was successful
    */
   public function write($key, $contents) {
     $filename = $this->prepareWrite($key);
@@ -313,8 +312,8 @@ class FileCache {
   /**
    * Ensures a directory exists
    *
-   * @param [string] $dir Directory to ensure existence of
-   * @return [boolean] $dir_exists
+   * @param string $dir Directory to ensure existence of
+   * @return bool
    */
   protected function ensureDirExists($dir) {
     $dir_exists = (
@@ -327,8 +326,8 @@ class FileCache {
   /**
    * Filename from key
    *
-   * @param [string] $key Key to validate
-   * @return [string] $filename
+   * @param string $key Key to validate
+   * @return string
    */
   protected function filename($key) {
     $filename = $this->root . $this->validateKey($key);
@@ -338,7 +337,7 @@ class FileCache {
   /**
    * Get a Finder that iterates in cache root only the files
    *
-   * @return [Finder] $finder
+   * @return Finder
    */
   protected function getFinder() {
     $finder = Finder::create()->in($this->root)->files();
@@ -348,8 +347,8 @@ class FileCache {
   /**
    * Prepare cache write
    *
-   * @param [string] $key A cache key
-   * @return [bool|string] A filename or false
+   * @param string $key A cache key
+   * @return bool|string A filename or false
    */
   protected function prepareWrite($key) {
     if (!$this->enabled) {
@@ -365,8 +364,8 @@ class FileCache {
   /**
    * Validate cache key
    *
-   * @param [string] $key A cache key
-   * @return [string] $parts_string A relative filename
+   * @param string $key A cache key
+   * @return string A relative filename
    */
   protected function validateKey($key) {
     $url_parts = parse_url($key);

--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -24,6 +24,7 @@ class Input {
    *        [string] label   Prompt for STDOUT
    *        [array]  backups Array of Backup objects
    * @return \stdClass An object representing the backup desired
+   * @throws TerminusException
    */
   public static function backup(array $arg_options = array()) {
     $default_options = array(

--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -4,7 +4,10 @@ namespace Terminus\Helpers;
 
 use Terminus;
 use Terminus\Exceptions\TerminusException;
+use Terminus\Models\Site;
+use Terminus\Models\Upstream;
 use Terminus\Models\User;
+use Terminus\Models\Workflow;
 use Terminus\Models\Collections\Sites;
 use Terminus\Models\Collections\Upstreams;
 
@@ -17,10 +20,10 @@ class Input {
   /**
    * Produces a menu to select a backup
    *
-   * @param [array] $arg_options Elements as follows:
+   * @param array $arg_options Elements as follows:
    *        [string] label   Prompt for STDOUT
    *        [array]  backups Array of Backup objects
-   * @return [stdClass] $target_backup An object representing the backup desired
+   * @return \stdClass An object representing the backup desired
    */
   public static function backup(array $arg_options = array()) {
     $default_options = array(
@@ -56,12 +59,12 @@ class Input {
   /**
    * Produces a menu to narrow down an element selection
    *
-   * @param [array] $arg_options Elements as follows:
+   * @param array $arg_options Elements as follows:
    *        [array]  args    Arguments given via param
    *        [string] key     Args key to search for
    *        [string] label   Prompt for STDOUT
    *        [array]  choices Menu options for the user
-   * @return [string] Either the selection, its index, or the default
+   * @return string Either the selection, its index, or the default
    */
   public static function backupElement(array $arg_options = array()) {
     $default_options = array(
@@ -96,9 +99,9 @@ class Input {
   /**
    * Asks for confirmation before running a destructive operation.
    *
-   * @param [string] $question Prompt text
-   * @param [array]  $params   Elements to interpolate into the prompt text
-   * @return [boolean] True if prompt is accepted
+   * @param string $question Prompt text
+   * @param array  $params   Elements to interpolate into the prompt text
+   * @return bool True if prompt is accepted
    */
   static function confirm(
     $question,
@@ -120,12 +123,12 @@ class Input {
   /**
    * Facilitates the selection of a day of the week
    *
-   * @param [array] $arg_options Arguments as follows:
+   * @param array $arg_options Arguments as follows:
    *        [array]  args    Arguments given via param
    *        [string] key     Args key to search for
    *        [string] label   Prompt for STDOUT
    *        [array]  choices Menu options for the user, may be a collection
-   * @return [integer] $day_number
+   * @return int
    */
   public static function day(array $arg_options = array()) {
     $default_options = array(
@@ -160,13 +163,13 @@ class Input {
   /**
    * Produces a menu with the given attributes
    *
-   * @param [array] $arg_options Arguments as follows:
+   * @param array $arg_options Arguments as follows:
    *        [array]  args    Arguments given via param
    *        [string] key     Args key to search for
    *        [string] label   Prompt for STDOUT
    *        [array]  choices Menu options for the user, may be a collection
    *        [Site]   site    Site object to gather environment choices from
-   * @return [string] Either the selection, its index, or the default
+   * @return string Either the selection, its index, or the default
    */
   public static function env(array $arg_options = array()) {
     $default_options = array(
@@ -202,11 +205,11 @@ class Input {
   /**
    * Produces a menu with the given attributes
    *
-   * @param [array]   $choices      Menu options for the user
-   * @param [mixed]   $default      Given as null option in the menu
-   * @param [string]  $text         Prompt printed to STDOUT
-   * @param [boolean] $return_value If true, returns selection. False, the index
-   * @return [string] Either the selection, its index, or the default
+   * @param array  $choices      Menu options for the user
+   * @param mixed  $default      Given as null option in the menu
+   * @param string $text         Prompt printed to STDOUT
+   * @param bool   $return_value If true, returns selection. False, the index
+   * @return string Either the selection, its index, or the default
    */
   public static function menu(
       $choices,
@@ -231,10 +234,10 @@ class Input {
   /**
    * Returns $args[$key] if exists, $default otherwise
    *
-   * @param [string] $key     Index of arg to return
-   * @param [array]  $args    Args to search for key
-   * @param [mixed]  $default Returned if $args[$key] DNE
-   * @return [mixed] Either $args[$key] or $default
+   * @param string $key     Index of arg to return
+   * @param array  $args    Args to search for key
+   * @param mixed  $default Returned if $args[$key] DNE
+   * @return mixed Either $args[$key] or $default
    */
   public static function optional($key, $args, $default = null) {
     if (isset($args[$key])) {
@@ -246,11 +249,11 @@ class Input {
   /**
    * Input helper that provides interactive menu to select org name
    *
-   * @param [array]  $args    The args passed in from argv
-   * @param [string] $key     Args key to search for
-   * @param [string] $default Returned if arg and stdin fail in interactive
-   * @param [array]  $options Options to feed into the orglist function
-   * @return [string] ID of selected organization
+   * @param array  $args    The args passed in from argv
+   * @param string $key     Args key to search for
+   * @param string $default Returned if arg and stdin fail in interactive
+   * @param array  $options Options to feed into the orglist function
+   * @return string ID of selected organization
   */
   public static function orgid(
     $args,
@@ -297,9 +300,9 @@ class Input {
   /**
    * Returns an array listing organizaitions applicable to user
    *
-   * @param [array] $options Elements as follows:
+   * @param array $options Elements as follows:
    *        [boolean] allow_none True to allow the "none" option
-   * @return [array] $orgs A list of organizations
+   * @return array A list of organizations
   */
   public static function orglist($options = array()) {
     $orgs = array();
@@ -319,9 +322,9 @@ class Input {
   /**
    * Input helper that provides interactive menu to select org name
    *
-   * @param [array]  $args The args passed in from argv
-   * @param [string] $key  Args key to search for
-   * @return [string] Site name
+   * @param array  $args The args passed in from argv
+   * @param string $key  Args key to search for
+   * @return string Site name
   */
   public static function orgname($args, $key) {
     $orglist = Input::orglist();
@@ -339,9 +342,9 @@ class Input {
   /**
    * Helper function to get role
    *
-   * @param [array]  $assoc_args Argument array passed from commands
-   * @param [string] $message    Prompt to STDOUT
-   * @return [string] $role Name of role
+   * @param array  $assoc_args Argument array passed from commands
+   * @param string $message    Prompt to STDOUT
+   * @return string Name of role
    */
   static public function role(
     $assoc_args,
@@ -367,10 +370,10 @@ class Input {
   /**
    * Input helper that provides interactive site list
    *
-   * @param [array]  $args  The args passed in from argv
-   * @param [string] $key   Args key to search for
-   * @param [string] $label Prompt for STDOUT
-   * @return [string] Site name
+   * @param array  $args  The args passed in from argv
+   * @param string $key   Args key to search for
+   * @param string $label Prompt for STDOUT
+   * @return string Site name
   */
   public static function sitename(
     $args = array(),
@@ -387,7 +390,7 @@ class Input {
     $sites     = new Sites();
     $sites     = $sites->all();
     $sitenames = array_map(
-      function($site) {
+      function(Site $site) {
         $site_name = $site->get('name');
         return $site_name;
       }, $sites
@@ -404,12 +407,12 @@ class Input {
   /**
    * Returns $args[key] if exists, then STDIN, then $default
    *
-   * @param [array]  $args    Args already input
-   * @param [string] $key     Key for searched-for argument
-   * @param [string] $label   Promp printed to STDOUT
-   * @param [mixed]  $default Returns if no other choice
+   * @param array  $args    Args already input
+   * @param string $key     Key for searched-for argument
+   * @param string $label   Prompt printed to STDOUT
+   * @param mixed  $default Returns if no other choice
    *
-   * @return [string] Either $args[$key]. $default, or string from prompt
+   * @return string Either $args[$key], $default, or string from prompt
    */
   public static function string(
       $args,
@@ -433,11 +436,11 @@ class Input {
   /**
    * Helper function to select valid upstream
    *
-   * @param [array]   $args Args to parse value from
-   * @param [string]  $key  Index to search for in args
-   * @param [boolean] $exit If true, throw error when no value is found
-   *
-   * @return [Upstream] $upstream
+   * @param array  $args Args to parse value from
+   * @param string $key  Index to search for in args
+   * @param bool   $exit If true, throw error when no value is found
+   * @return Upstream
+   * @throws TerminusException
    */
   public static function upstream($args, $key, $exit = true) {
     $upstreams = new Upstreams();
@@ -461,11 +464,11 @@ class Input {
   /**
    * Helper function to select Site Workflow
    *
-   * @param [array<Workflow>] $workflows Array of workflows to list
-   * @param [array]           $args      Args to parse value from
-   * @param [string]          $key       Index to search for in args
-   *
-   * @return [Workflow] $workflow
+   * @param Workflow[] $workflows Array of workflows to list
+   * @param array      $args      Args to parse value from
+   * @param string     $key       Index to search for in args
+   * @return Workflow
+   * @throws TerminusException
    */
   public static function workflow($workflows, $args = array(), $key = 'workflow_id') {
     if (isset($args['workflow_id'])) {
@@ -520,10 +523,10 @@ class Input {
   /**
    * Same as confirm but doesn't exit
    *
-   * @param [string] $question Question to ask
-   * @param [array]  $params   Args for vsprintf()
+   * @param string $question Question to ask
+   * @param array  $params   Args for vsprintf()
    *
-   * @return [boolean] $is_yes
+   * @return bool
    */
   public static function yesno($question, $params = array()) {
     if (Terminus::getConfig('yes')) {

--- a/php/Terminus/Loggers/Logger.php
+++ b/php/Terminus/Loggers/Logger.php
@@ -10,11 +10,10 @@ class Logger extends KLogger {
   /**
    * Class constructor. Feeds in output destination from env vars
    *
-   * @param [array]  $options           Options for operation of logger
+   * @param array  $options           Options for operation of logger
    *        [array] config Configuration options from Runner
-   * @param [string] $logDirectory      File path to the logging directory
-   * @param [string] $logLevelThreshold The LogLevel Threshold
-   * @return [Logger] $this
+   * @param string $logDirectory      File path to the logging directory
+   * @param string $logLevelThreshold The LogLevel Threshold
    */
   public function __construct(
     array $options = array(),
@@ -50,10 +49,10 @@ class Logger extends KLogger {
   /**
     * Logs with an arbitrary level
     *
-    * @param [mixed]  $level   PSR log level of message
-    * @param [string] $message Message to give
-    * @param [array]  $context Context of message
-    * @return [void]
+    * @param mixed  $level   PSR log level of message
+    * @param string $message Message to give
+    * @param array  $context Context of message
+    * @return void
     */
   public function log($level, $message, array $context = array()) {
     if (isset($this->logLevelThreshold)
@@ -78,22 +77,12 @@ class Logger extends KLogger {
   }
 
   /**
-   * Sets the output handle to php://std___
-   *
-   * @return [void]
-   */
-  public function setBufferHandle() {
-    $handle_name      = strtoupper(substr($this->getLogFilePath(), 6));
-    $this->fileHandle = constant($handle_name);
-  }
-
-  /**
     * Formats the message for logging.
     *
-    * @param  [string] $level   The Log Level of the message
-    * @param  [string] $message The message to log
-    * @param  [array]  $context The context
-    * @return [string] $message
+    * @param  string $level   The Log Level of the message
+    * @param  string $message The message to log
+    * @param  array  $context The context
+    * @return string
     */
   protected function formatMessage($level, $message, $context) {
     if (isset($this->options)
@@ -120,9 +109,9 @@ class Logger extends KLogger {
   /**
     * Formats the message for bash-type logging.
     *
-    * @param  [string] $level   The Log Level of the message
-    * @param  [string] $message The message to log
-    * @return [string] $message
+    * @param  string $level   The Log Level of the message
+    * @param  string $message The message to log
+    * @return string
     */
   private function formatBashMessages($level, $message) {
     $parts   = $this->getMessageParts($level, $message);
@@ -136,9 +125,9 @@ class Logger extends KLogger {
   /**
     * Formats the message for JSON-type logging.
     *
-    * @param  [string] $level   The Log Level of the message
-    * @param  [string] $message The message to log
-    * @return [string] $message
+    * @param  string $level   The Log Level of the message
+    * @param  string $message The message to log
+    * @return string
     */
   private function formatJsonMessages($level, $message) {
     $parts   = $this->getMessageParts($level, $message);
@@ -149,9 +138,9 @@ class Logger extends KLogger {
   /**
     * Collects and formats the log message parts
     *
-    * @param  [string] $level   The Log Level of the message
-    * @param  [string] $message The message to log
-    * @return [string] $parts
+    * @param  string $level   The Log Level of the message
+    * @param  string $message The message to log
+    * @return array
     */
   private function getMessageParts($level, $message) {
     $parts = array(
@@ -167,7 +156,7 @@ class Logger extends KLogger {
   /**
    * Gets the correctly formatted Date/Time for the log entry.
    *
-   * @return [string] $date
+   * @return string $date
    */
   private function getTimestamp() {
     $date_format = 'Y-m-dTH:i:s';
@@ -181,9 +170,9 @@ class Logger extends KLogger {
   /**
    * Interpolates context variables per the PSR spec
    *
-   * @param [string] $message The message containing curly brace-enclosed keys
-   * @param [array]  $context The array containing substitutionary values
-   * @return [string] $interpolated_string
+   * @param string $message The message containing curly brace-enclosed keys
+   * @param array  $context The array containing substitutionary values
+   * @return string
    */
   private function interpolate($message, $context) {
     // build a replacement array with braces around the context keys

--- a/php/Terminus/Models/Backup.php
+++ b/php/Terminus/Models/Backup.php
@@ -2,14 +2,12 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class Backup extends TerminusModel {
 
   /**
    * Determines whether the backup has been completed or not
    *
-   * @return [boolean]] $is_finished
+   * @return bool True if backup is completed.
    */
   public function backupIsFinished() {
     $is_finished = (
@@ -23,9 +21,9 @@ class Backup extends TerminusModel {
   }
 
   /**
-   * Retruns the bucket name for this backup
+   * Returns the bucket name for this backup
    *
-   * @return [string] $bucket
+   * @return string
    */
   public function getBucket() {
     $bucket = str_replace('_' . $this->getElement(), '', $this->get('id'));
@@ -35,7 +33,7 @@ class Backup extends TerminusModel {
   /**
    * Returns the date the backup was completed
    *
-   * @return [string] $date Y-m-d H:i:s completion time or "Pending"
+   * @return string Y-m-d H:i:s completion time or "Pending"
    */
   public function getDate() {
     if ($this->get('finish_time') != null) {
@@ -50,9 +48,9 @@ class Backup extends TerminusModel {
   }
 
   /**
-   * Retruns the element type of the backup
+   * Returns the element type of the backup
    *
-   * @return [string] $type code, database, files, or null
+   * @return string code, database, files, or null
    */
   public function getElement() {
     if ($this->get('filename') == null) {
@@ -72,9 +70,9 @@ class Backup extends TerminusModel {
   }
 
   /**
-   * Retruns the type of initiator of the backup
+   * Returns the type of initiator of the backup
    *
-   * @return [string] $initiator Either "manual" or "automated"
+   * @return string Either "manual" or "automated"
    */
   public function getInitiator() {
     $initiator = 'manual';
@@ -88,10 +86,9 @@ class Backup extends TerminusModel {
   /**
    * Returns the size of the backup in MB
    *
-   * @return [string] $size_string
+   * @return string A number (int or float) followed by 'MB'.
    */
   public function getSizeInMb() {
-    $size        = 0;
     $size_string = '0';
     if ($this->get('size') != null) {
       $size = $this->get('size') / 1048576;
@@ -107,7 +104,7 @@ class Backup extends TerminusModel {
   /**
    * Gets the URL of a backup
    *
-   * @return [string] $response['data']->url
+   * @return string
    */
   public function getUrl() {
     $path        = sprintf(

--- a/php/Terminus/Models/Collections/Backups.php
+++ b/php/Terminus/Models/Collections/Backups.php
@@ -3,16 +3,18 @@
 namespace Terminus\Models\Collections;
 
 use Terminus\Exceptions\TerminusException;
+use Terminus\Models\Workflow;
+use Terminus\Models\Backup;
 
-DEFINE('DAILY_BACKUP_TTL', 691200);
-DEFINE('WEEKLY_BACKUP_TTL', 2764800);
+define('DAILY_BACKUP_TTL', 691200);
+define('WEEKLY_BACKUP_TTL', 2764800);
 
 class Backups extends TerminusCollection {
 
   /**
    * Cancels an environment's regular backup schedule
    *
-   * @return [boolean] True if operation was successful
+   * @return bool True if operation was successful
    */
   public function cancelBackupSchedule() {
     $path_root = sprintf(
@@ -30,13 +32,14 @@ class Backups extends TerminusCollection {
   /**
    * Creates a backup
    *
-   * @param [array] $arg_params Array of args to dictate backup choices
-   *   [string]  type     Sort of operation to conduct (e.g. backup)
-   *   [integer] keep-for Days to keep the backup for
-   *   [string]  element  Which aspect of the arg to back up
-   * @return [Workflow] $workflow
+   * @param array $arg_params Array of args to dictate backup choices,
+   *   which may have the following keys:
+   *   - type: string: Sort of operation to conduct (e.g. backup)
+   *   - keep-for: int: Days to keep the backup for
+   *   - element: string: Which aspect of the arg to back up
+   * @return Workflow
    */
-  public function create($arg_params) {
+  public function create(array $arg_params) {
     $default_params = array(
       'code'       => false,
       'database'   => false,
@@ -78,10 +81,11 @@ class Backups extends TerminusCollection {
   }
 
   /**
-   * Lists all backups
+   * Fetches backup for a specified filename
    *
-   * @param [string] $filename Name of the file name to filter by
-   * @return [array] $backup
+   * @param string $filename Name of the file name to filter by
+   * @return Backup
+   * @throws TerminusException
    */
   public function getBackupByFileName($filename) {
     $matches = $this->getFilteredMemberList(compact('filename'), 'id', 'id');
@@ -98,10 +102,10 @@ class Backups extends TerminusCollection {
   }
 
   /**
-   * Lists all backups
+   * Lists all backups for a specific element.
    *
-   * @param [string] $element Name of the element type to filter by
-   * @return [array] $backups
+   * @param string $element Name of the element type to filter by
+   * @return Backup[]
    */
   public function getBackupsByElement($element = null) {
     $backups = array_filter(
@@ -117,9 +121,9 @@ class Backups extends TerminusCollection {
   /**
    * Retrieves an environment's regular backup schedule
    *
-   * @return [array] $schedule Elements as follows:
-   *         [string]  daily_backup_time
-   *         [string]  weekly_backup_day
+   * @return array $schedule Elements as follows:
+   *   - daily_backup_time: string
+   *   - weekly_backup_day: string
    */
   public function getBackupSchedule() {
     $path     = sprintf(
@@ -153,8 +157,8 @@ class Backups extends TerminusCollection {
   /**
    * Filters the backups for only ones which have finished
    *
-   * @param [string] $element Element requested (i.e. code, db, or files)
-   * @return [array] $backups An array of stdClass objects representing backups
+   * @param string $element Element requested (i.e. code, db, or files)
+   * @return Backup[] An array of Backup objects
    */
   public function getFinishedBackups($element) {
     if ($element != null) {
@@ -189,8 +193,8 @@ class Backups extends TerminusCollection {
   /**
    * Sets an environment's regular backup schedule
    *
-   * @param [integer] $day_number A numerical of a day of the week
-   * @return [boolean] True if operation was successful
+   * @param int $day_number A numerical of a day of the week
+   * @return bool True if operation was successful
    */
   public function setBackupSchedule($day_number) {
     $daily_ttl   = 691200;
@@ -226,7 +230,7 @@ class Backups extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = sprintf(
@@ -238,9 +242,9 @@ class Backups extends TerminusCollection {
   }
 
   /**
-   * Names the model-owner of this collection
+   * Gets the name of the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'environment';

--- a/php/Terminus/Models/Collections/Bindings.php
+++ b/php/Terminus/Models/Collections/Bindings.php
@@ -2,20 +2,20 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Binding;
 
 class Bindings extends TerminusCollection {
 
   /**
    * Get bindings by type
    *
-   * @param [string] $type e.g. "appserver", "db server", etc
-   * @return [array] $bindings
+   * @param string $type e.g. "appserver", "db server", etc
+   * @return Binding[]
    */
   public function getByType($type) {
     $models = array_filter(
       $this->all(),
-      function($binding) use ($type) {
+      function(Binding $binding) use ($type) {
         $is_valid = (
           $binding->get('type') == $type
           && !$binding->get('failover')
@@ -32,7 +32,7 @@ class Bindings extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = sprintf('sites/%s/bindings', $this->environment->site->get('id'));
@@ -40,9 +40,9 @@ class Bindings extends TerminusCollection {
   }
 
   /**
-   * Names the model-owner of this collection, false if DNE
+   * Names the model-owner of this collection.
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'environment';

--- a/php/Terminus/Models/Collections/Environments.php
+++ b/php/Terminus/Models/Collections/Environments.php
@@ -2,16 +2,19 @@
 
 namespace Terminus\Models\Collections;
 
+use Terminus\Models\Environment;
+use Terminus\Models\Workflow;
+
 class Environments extends TerminusCollection {
 
   /**
    * Creates a multidev environment
    *
-   * @param [string]      $to_env_id Name of new the environment
-   * @param [Environment] $from_env  Environment to clone from
-   * @return [Workflow] $workflow
+   * @param string      $to_env_id Name of new the environment
+   * @param Environment $from_env  Environment to clone from
+   * @return Workflow
    */
-  public function create($to_env_id, $from_env) {
+  public function create($to_env_id, Environment $from_env) {
     $workflow = $this->site->workflows->create(
       'create_cloud_development_environment',
       array(
@@ -34,7 +37,7 @@ class Environments extends TerminusCollection {
   /**
    * List Environment IDs, with Dev/Test/Live first
    *
-   * @return [array] $ids
+   * @return string[] $ids
    */
   public function ids() {
     $ids = array_keys($this->getMembers());
@@ -50,7 +53,7 @@ class Environments extends TerminusCollection {
   /**
    * Returns a list of all multidev environments on the collection-owning Site
    *
-   * @return [array] $environment An array of all Environment objects
+   * @return Environment[]
    */
   public function multidev() {
     $environments = array_filter(
@@ -66,7 +69,7 @@ class Environments extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = 'sites/' . $this->site->get('id') . '/environments';
@@ -76,7 +79,7 @@ class Environments extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'site';

--- a/php/Terminus/Models/Collections/Instruments.php
+++ b/php/Terminus/Models/Collections/Instruments.php
@@ -7,7 +7,7 @@ class Instruments extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = 'users/' . $this->user->id . '/instruments';
@@ -17,7 +17,7 @@ class Instruments extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'user';

--- a/php/Terminus/Models/Collections/OrganizationSiteMemberships.php
+++ b/php/Terminus/Models/Collections/OrganizationSiteMemberships.php
@@ -2,8 +2,8 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\User;
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Site;
+use Terminus\Models\Workflow;
 
 class OrganizationSiteMemberships extends TerminusCollection {
   protected $organization;
@@ -11,10 +11,10 @@ class OrganizationSiteMemberships extends TerminusCollection {
   /**
    * Adds a site to this organization
    *
-   * @param [Site] $site Site object of site to add to this organization
-   * @return [Workflow] $workflow
+   * @param Site $site Site object of site to add to this organization
+   * @return Workflow
    */
-  public function addMember($site) {
+  public function addMember(Site $site) {
     $workflow = $this->organization->workflows->create(
       'add_organization_site_membership',
       array(
@@ -30,8 +30,8 @@ class OrganizationSiteMemberships extends TerminusCollection {
   /**
    * Retrieves the model with site of the given UUID or name
    *
-   * @param [string] $id UUID or name of desired site membership instance
-   * @return [Site] $model
+   * @param string $id UUID or name of desired site membership instance
+   * @return Site
    */
   public function get($id) {
     $models = $this->getMembers();
@@ -53,7 +53,7 @@ class OrganizationSiteMemberships extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = sprintf(
@@ -66,10 +66,10 @@ class OrganizationSiteMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [OrganizationSiteMemberships] $this
+   * @param array $options params to pass to url request
+   * @return OrganizationSiteMemberships
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (!isset($options['paged'])) {
       $options['paged'] = true;
     }
@@ -79,9 +79,9 @@ class OrganizationSiteMemberships extends TerminusCollection {
   }
 
   /**
-   * Names the model-owner of this collection, false if DNE
+   * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'organization';

--- a/php/Terminus/Models/Collections/OrganizationUserMemberships.php
+++ b/php/Terminus/Models/Collections/OrganizationUserMemberships.php
@@ -2,7 +2,8 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\User;
+use Terminus\Models\Workflow;
 
 class OrganizationUserMemberships extends TerminusCollection {
   protected $organization;
@@ -10,10 +11,10 @@ class OrganizationUserMemberships extends TerminusCollection {
   /**
    * Adds a user to this organization
    *
-   * @param [User] $user User object of user to add to this organization
-   * @return [Workflow] $workflow
+   * @param User $user User object of user to add to this organization
+   * @return Workflow $workflow
    */
-  public function addMember($user) {
+  public function addMember(User $user) {
     $workflow = $this->organization->workflows->create(
       'add_organization_user_membership',
       array(
@@ -29,7 +30,7 @@ class OrganizationUserMemberships extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = sprintf(
@@ -42,10 +43,10 @@ class OrganizationUserMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [OrganizationUserMemberships] $this
+   * @param array $options params to pass to url request
+   * @return OrganizationUserMemberships
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (!isset($options['paged'])) {
       $options['paged'] = true;
     }
@@ -55,9 +56,9 @@ class OrganizationUserMemberships extends TerminusCollection {
   }
 
   /**
-   * Names the model-owner of this collection, false if DNE
+   * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'organization';

--- a/php/Terminus/Models/Collections/SiteOrganizationMemberships.php
+++ b/php/Terminus/Models/Collections/SiteOrganizationMemberships.php
@@ -2,18 +2,26 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Site;
+use Terminus\Models\SiteOrganizationMembership;
+use Terminus\Models\Workflow;
 
 class SiteOrganizationMemberships extends TerminusCollection {
+  /**
+   * @var Site
+   */
   protected $site;
+  /**
+   * @var Workflows
+   */
   protected $workflows;
 
   /**
    * Adds this org as a member to the site
    *
-   * @param [string] $name Name of site to add org to
-   * @param [string] $role Role for supporting organization to take
-   * @return [Workflow] $workflow
+   * @param string $name Name of site to add org to
+   * @param string $role Role for supporting organization to take
+   * @return Workflow
    **/
   public function addMember($name, $role) {
     $workflow = $this->site->workflows->create(
@@ -26,10 +34,10 @@ class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [TerminusModel] $this
+   * @param array $options params to pass to url request
+   * @return SiteOrganizationMemberships
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (!isset($options['paged'])) {
       $options['paged'] = true;
     }
@@ -41,11 +49,10 @@ class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * Returns UUID of organization with given name
    *
-   * @param [string] $name A name to search for
-   * @return [SiteOrganizationMembership] $orgs[$name]
+   * @param string $name A name to search for
+   * @return SiteOrganizationMembership|null
    */
   public function findByName($name) {
-    $orgs = array();
     foreach ($this->models as $org_member) {
       $org = $org_member->getName();
       if ($name == $org) {
@@ -58,7 +65,7 @@ class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'site';
@@ -68,7 +75,7 @@ class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = 'sites/' . $this->site->get('id') . '/memberships/organizations';

--- a/php/Terminus/Models/Collections/SiteUserMemberships.php
+++ b/php/Terminus/Models/Collections/SiteUserMemberships.php
@@ -2,17 +2,22 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Site;
+use Terminus\Models\SiteUserMembership;
+use Terminus\Models\Workflow;
 
 class SiteUserMemberships extends TerminusCollection {
+  /**
+   * @var Site
+   */
   protected $site;
 
   /**
    * Adds this user as a member to the site
    *
-   * @param [string] $email Email of team member to add
-   * @param [string] $role  Role to assign to the new user
-   * @return [workflow] $workflow
+   * @param string $email Email of team member to add
+   * @param string $role  Role to assign to the new user
+   * @return Workflow
    **/
   public function addMember($email, $role) {
     $workflow = $this->site->workflows->create(
@@ -25,10 +30,10 @@ class SiteUserMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [SiteUserMemberships] $this
+   * @param array $options params to pass to url request
+   * @return SiteUserMemberships
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (!isset($options['paged'])) {
       $options['paged'] = true;
     }
@@ -39,8 +44,10 @@ class SiteUserMemberships extends TerminusCollection {
   /**
    * Retrieves the membership of the given UUID or email
    *
-   * @param [string] $id UUID or email of desired user
-   * @return [SiteUserMembership] $membership
+   * @param string $id UUID or email of desired user
+   * @return SiteUserMembership
+   * @throws \Exception
+   * @todo Should this throw TerminusException instead?
    */
   public function get($id) {
     $models     = $this->getMembers();
@@ -65,9 +72,9 @@ class SiteUserMemberships extends TerminusCollection {
   }
 
   /**
-   * Retrieves and fills in team member data
+   * Give the URL for collection data fetching
    *
-   * @return [SiteUserMemberships] $this
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = 'sites/' . $this->site->get('id') . '/memberships/users';
@@ -77,7 +84,7 @@ class SiteUserMemberships extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     return 'site';

--- a/php/Terminus/Models/Collections/Sites.php
+++ b/php/Terminus/Models/Collections/Sites.php
@@ -5,21 +5,28 @@ namespace Terminus\Models\Collections;
 use Terminus\Session;
 use Terminus\SitesCache;
 use Terminus\Exceptions\TerminusException;
+use Terminus\Models\Organization;
 use Terminus\Models\Site;
 use Terminus\Models\User;
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Workflow;
 
 class Sites extends TerminusCollection {
+  /**
+   * @var SitesCache
+   */
   private $sites_cache;
+  /**
+   * @var User
+   */
   private $user;
 
   /**
    * Instantiates the collection, sets param members as properties
    *
-   * @param [array] $options To be set to $this->key
-   * @return [Sites] $this
+   * @param array $options To be set to $this->key
+   * @return Sites
    */
-  public function __construct($options = array()) {
+  public function __construct(array $options = array()) {
     parent::__construct($options);
     $this->sites_cache = new SitesCache();
     $this->user        = new User();
@@ -28,12 +35,13 @@ class Sites extends TerminusCollection {
   /**
    * Creates a new site
    *
-   * @param [array] $options Information to run workflow
-   *        [string] label
-   *        [string] name
-   *        [string] organization_id
-   *        [string] upstream_id
-   * @return [Workflow]
+   * @param string[] $options Information to run workflow, with the following
+   *   keys:
+   *   - label
+   *   - name
+   *   - organization_id
+   *   - upstream_id
+   * @return Workflow
    */
   public function addSite($options = array()) {
     $data = array(
@@ -62,9 +70,9 @@ class Sites extends TerminusCollection {
   /**
    * Adds site with given site ID to cache
    *
-   * @param [string] $site_id UUID of site to add to cache
-   * @param [string] $org_id  UUID of org to which new site belongs
-   * @return [Site] $site The newly created site object
+   * @param string $site_id UUID of site to add to cache
+   * @param string $org_id  UUID of org to which new site belongs
+   * @return Site The newly created site object
    */
   public function addSiteToCache($site_id, $org_id = null) {
     if (count($this->models) == 0) {
@@ -101,8 +109,8 @@ class Sites extends TerminusCollection {
   /**
    * Removes site with given site ID from cache
    *
-   * @param [string] $site_name Name of site to remove from cache
-   * @return [void]
+   * @param string $site_name Name of site to remove from cache
+   * @return void
    */
   public function deleteSiteFromCache($site_name) {
     $this->sites_cache->remove($site_name);
@@ -111,10 +119,10 @@ class Sites extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [Sites] $this
+   * @param array $options params to pass to url request
+   * @return Sites
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (empty($this->models)) {
       $cache = $this->sites_cache->all();
       if (count($cache) === 0) {
@@ -131,9 +139,9 @@ class Sites extends TerminusCollection {
   /**
    * Filters sites list by tag
    *
-   * @param [string] $tag Tag to filter by
-   * @param [string] $org Organization which has tagged sites
-   * @return [array] $sites A filtered list of sites
+   * @param string $tag Tag to filter by
+   * @param string $org Organization which has tagged sites
+   * @return Site[]
    */
   public function filterAllByTag($tag, $org = '') {
     $all_sites = $this->all();
@@ -163,8 +171,10 @@ class Sites extends TerminusCollection {
   /**
    * Retrieves the site of the given UUID or name
    *
-   * @param [string] $id UUID or name of desired site
-   * @return [Site] $site
+   * @param string $id UUID or name of desired site
+   * @return Site
+   * @throws \Exception
+   * @todo Shouldn't this throw a TerminusException instead?
    */
   public function get($id) {
     $models = $this->getMembers();
@@ -184,7 +194,7 @@ class Sites extends TerminusCollection {
   /**
    * Clears sites cache
    *
-   * @return [void]
+   * @return void
    */
   public function rebuildCache() {
     $this->sites_cache->rebuild();

--- a/php/Terminus/Models/Collections/TerminusCollection.php
+++ b/php/Terminus/Models/Collections/TerminusCollection.php
@@ -7,15 +7,17 @@ use Terminus\Exceptions\TerminusException;
 use Terminus\Models\TerminusModel;
 
 abstract class TerminusCollection extends TerminusModel {
+  /**
+   * @var TerminusModel[]
+   */
   protected $models = array();
 
   /**
    * Instantiates the collection, sets param members as properties
    *
-   * @param [array] $options To be set to $this->key
-   * @return [TerminusCollection] $this
+   * @param array $options To be set to $this->key
    */
-  public function __construct($options = array()) {
+  public function __construct(array $options = array()) {
     foreach ($options as $key => $option) {
       $this->$key = $option;
     }
@@ -25,7 +27,7 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Retrieves all models
    *
-   * @return [array] $models
+   * @return TerminusModel[]
    */
   public function all() {
     $models = array_values($this->getMembers());
@@ -35,10 +37,10 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [TerminusCollection] $this
+   * @param array $options params to pass to url request
+   * @return TerminusCollection $this
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     $results = $this->getCollectionData($options);
     $data    = $this->objectify($results['data']);
 
@@ -55,8 +57,9 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Retrieves the model of the given ID
    *
-   * @param [string] $id ID of desired model instance
-   * @return [TerminusModel] $this->models[$id]
+   * @param string $id ID of desired model instance
+   * @return TerminusModel $this->models[$id]
+   * @throws TerminusException
    */
   public function get($id) {
     $models = $this->getMembers();
@@ -77,7 +80,7 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * List Model IDs
    *
-   * @return [array] $ids Array of all model IDs
+   * @return string[] Array of all model IDs
    */
   public function ids() {
     $models = $this->getMembers();
@@ -88,11 +91,11 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Adds a model to this collection
    *
-   * @param [stdClass] $model_data Data to feed into attributes of new model
-   * @param [array]    $options    Data to make properties of the new model
-   * @return [mixed] $model newly added model
+   * @param object $model_data Data to feed into attributes of new model
+   * @param array  $options    Data to make properties of the new model
+   * @return TerminusModel
    */
-  public function add($model_data, $options = array()) {
+  public function add($model_data, array $options = array()) {
     $model   = $this->getMemberName();
     $owner   = $this->getOwnerName();
     $options = array_merge(
@@ -123,7 +126,7 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Gives the name of this class
    *
-   * @return [string] $class_name
+   * @return string
    */
   protected function getClassName() {
     $class_name = get_class($this);
@@ -133,8 +136,8 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Retrieves collection data from the API
    *
-   * @param [array] $options params to pass to url request
-   * @return [array] $results
+   * @param array $options params to pass to url request
+   * @return array
    */
   protected function getCollectionData($options = array()) {
     $function_name = 'simpleRequest';
@@ -162,15 +165,15 @@ abstract class TerminusCollection extends TerminusModel {
    * Returns an array of data where the keys are the attribute $key and the
    *   values are the attribute $value, filtered by the given array
    *
-   * @param [array]  $filters Attributes to match during filtration
+   * @param array        $filters Attributes to match during filtration
    *   e.g. array('category' => 'other')
-   * @param [string] $key     Name of attribute to make array keys
-   * @param [mixed]  $value   Name(s) of attribute to make array values
-   * @return [array] $member_list Array rendered as requested
-   *         [mixed] $this->attribute->$key = $this->attribute->$value
+   * @param string       $key     Name of attribute to make array keys
+   * @param string|array $value   Name(s) of attribute to make array values
+   * @return array Array rendered as requested
+   *         $this->attribute->$key = $this->attribute->$value
    */
   public function getFilteredMemberList(
-    $filters,
+    array $filters,
     $key   = 'id',
     $value = 'name'
   ) {
@@ -204,7 +207,7 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Names the model-owner of this collection, false if DNE
    *
-   * @return [string|boolean] $owner_name
+   * @return string|bool
    */
   protected function getOwnerName() {
     return false;
@@ -214,10 +217,10 @@ abstract class TerminusCollection extends TerminusModel {
    * Returns an array of data where the keys are the attribute $key and the
    *   values are the attribute $value
    *
-   * @param [string] $key   Name of attribute to make array keys
-   * @param [string] $value Name of attribute to make array values
-   * @return [array] $member_list Array rendered as requested
-   *         [mixed] $this->attribute->$key = $this->attribute->$value
+   * @param string $key   Name of attribute to make array keys
+   * @param string $value Name of attribute to make array values
+   * @return array Array rendered as requested
+   *         $this->attribute->$key = $this->attribute->$value
    */
   public function getMemberList($key = 'id', $value = 'name') {
     $member_list = $this->getFilteredMemberList(array(), $key, $value);
@@ -225,9 +228,9 @@ abstract class TerminusCollection extends TerminusModel {
   }
 
   /**
-   * Returns name of the model collected by this collection
+   * Returns class name of the model collected by this collection.
    *
-   * @return [string] $model_name Name of model
+   * @return string Name of model
    */
   protected function getMemberName() {
     $name_array = explode('\\', get_class($this));
@@ -240,7 +243,7 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Retrieves all members of this collection
    *
-   * @return [array] $this->models
+   * @return TerminusModel[]
    */
   protected function getMembers() {
     if (empty($this->models)) {
@@ -252,8 +255,8 @@ abstract class TerminusCollection extends TerminusModel {
   /**
    * Turns an associative array into a stdClass object
    *
-   * @param [array] $array Array to turn into object
-   * @return [stdClass] $object
+   * @param mixed $array Array to turn into object
+   * @return \stdClass
    */
   protected function objectify($array = array()) {
     if (is_array($array)) {

--- a/php/Terminus/Models/Collections/Upstreams.php
+++ b/php/Terminus/Models/Collections/Upstreams.php
@@ -2,15 +2,15 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Models\Upstream;
 
 class Upstreams extends TerminusCollection {
 
   /**
    * Search available upstreams by UUID or name
    *
-   * @param [string] $id_or_name UUID or name
-   * @return [Upstream] $member
+   * @param string $id_or_name UUID or name
+   * @return Upstream
    */
   public function getByIdOrName($id_or_name) {
     $members   = $this->getMemberList('id', 'longname');
@@ -27,18 +27,18 @@ class Upstreams extends TerminusCollection {
   /**
    * Adds a model to this collection
    *
-   * @param [stdClass] $model_data Data to feed into attributes of new model
-   * @param [array]    $options    Data to make properties of the new model
-   * @return [void]
+   * @param object $model_data Data to feed into attributes of new model
+   * @param array  $options    Data to make properties of the new model
+   * @return void
    */
-  public function add($model_data, $options = array()) {
+  public function add($model_data, array $options = array()) {
     parent::add($model_data->attributes, $options);
   }
 
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = 'products';

--- a/php/Terminus/Models/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Models/Collections/UserOrganizationMemberships.php
@@ -2,8 +2,8 @@
 
 namespace Terminus\Models\Collections;
 
-use Terminus\Models\Collections\TerminusCollection;
 use Terminus\Models\User;
+use Terminus\Models\UserOrganizationMembership;
 
 class UserOrganizationMemberships extends TerminusCollection {
   protected $user;
@@ -11,8 +11,7 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Object constructor
    *
-   * @param [array] $options Options to set as $this->key
-   * @return [TerminusModel] $this
+   * @param array $options Options to set as $this->key
    */
   public function __construct($options = array()) {
     parent::__construct($options);
@@ -24,10 +23,10 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Fetches model data from API and instantiates its model instances
    *
-   * @param [array] $options params to pass to url request
-   * @return [UserOrganizationMemberships] $this
+   * @param array $options params to pass to url request
+   * @return UserOrganizationMemberships
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     if (!isset($options['paged'])) {
       $options['paged'] = true;
     }
@@ -39,8 +38,8 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Retrieves the model of the given ID
    *
-   * @param [string] $id ID or name of desired organization
-   * @return [UserOrganizationMembership] $model
+   * @param string $id ID or name of desired organization
+   * @return UserOrganizationMembership $model
    */
   public function get($id) {
     $orgs    = $this->getMembers();
@@ -57,7 +56,7 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = sprintf('users/%s/memberships/organizations', $this->user->id);
@@ -67,7 +66,7 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = 'user';

--- a/php/Terminus/Models/Collections/Workflows.php
+++ b/php/Terminus/Models/Collections/Workflows.php
@@ -3,22 +3,29 @@
 namespace Terminus\Models\Collections;
 
 use Terminus\Models\Workflow;
-use Terminus\Models\Collections\TerminusCollection;
 
 class Workflows extends TerminusCollection {
+  /**
+   * @var string
+   */
   protected $environment;
+  /**
+   * @var object
+   * @todo Find specific type for this
+   */
   protected $owner;
 
   /**
    * Creates a new workflow and adds its data to the collection
    *
-   * @param [string] $type    Type of workflow to create
-   * @param [array]  $options Additional information for the request
-   *        [string] environment UUID of environment running workflow
-   *        [array]  params      Parameters for the request
-   * @return [TerminusModel] $model
+   * @param string $type    Type of workflow to create
+   * @param array  $options Additional information for the request, with the
+   *   following possible keys:
+   *   - environment: string
+   *   - params: associative array of parameters for the request
+   * @return Workflow $model
    */
-  public function create($type, $options = array()) {
+  public function create($type, array $options = array()) {
     $options = array_merge(array('params' => array()), $options);
     if (isset($options['environment'])) {
       $this->environment = $options['environment'];
@@ -49,7 +56,7 @@ class Workflows extends TerminusCollection {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     $url = '';
@@ -88,8 +95,8 @@ class Workflows extends TerminusCollection {
   /**
    * Fetches workflow data hydrated with operations
    *
-   * @param [array] $options Additional information for the request
-   * @return [Workflows] $this
+   * @param array $options Additional information for the request
+   * @return void
    */
   public function fetchWithOperations($options = array()) {
     $options = array_merge(
@@ -108,7 +115,7 @@ class Workflows extends TerminusCollection {
   /**
    * Returns all existing workflows that have finished
    *
-   * @return [Array<Workflows>] $workflows
+   * @return Workflow[]
    */
   public function allFinished() {
     $workflows = array_filter(
@@ -124,7 +131,7 @@ class Workflows extends TerminusCollection {
   /**
    * Returns all existing workflows that contain logs
    *
-   * @return [Array<Workflows>] $workflows
+   * @return Workflow[]
    */
   public function allWithLogs() {
     $workflows = $this->allFinished();
@@ -142,7 +149,7 @@ class Workflows extends TerminusCollection {
   /**
    * Get timestamp of most recently finished workflow
    *
-   * @return [integer] $timestamp
+   * @return int|null Timestamp
    */
   public function lastFinishedAt() {
     $workflows = $this->all();
@@ -169,7 +176,7 @@ class Workflows extends TerminusCollection {
   /**
    * Get timestamp of most recently created Workflow
    *
-   * @return [integer] $timestamp
+   * @return int|null Timestamp
    */
   public function lastCreatedAt() {
     $workflows = $this->all();
@@ -194,9 +201,9 @@ class Workflows extends TerminusCollection {
   }
 
   /**
-   * Get most-recent workflow from existingcollection that has logs
+   * Get most-recent workflow from existing collection that has logs
    *
-   * @return [Workflow] $workflow
+   * @return Workflow|null
    */
   public function findLatestWithLogs() {
     $workflows = $this->allWithLogs();
@@ -224,7 +231,7 @@ class Workflows extends TerminusCollection {
   /**
    * Names the model-owner of this collection
    *
-   * @return [string] $this->owner_type or $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     if (isset($this->owner_type)) {
@@ -243,12 +250,12 @@ class Workflows extends TerminusCollection {
   /**
    * Adds a model to this collection
    *
-   * @param [stdClass] $model_data Data to feed into attributes of new model
-   * @param [array]    $options    Data to make properties of the new model
-   * @return [mixed] $model newly added model
+   * @param object $model_data Data to feed into attributes of new model
+   * @param array  $options    Data to make properties of the new model
+   * @return Workflow  The newly-added model
    */
-  public function add($model_data, $options = array()) {
-    $model = parent::add($model_data, $options = array());
+  public function add($model_data, array $options = array()) {
+    $model = parent::add($model_data, $options);
     $model->owner = $this->owner;
     return $model;
   }

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -23,10 +23,10 @@ class Environment extends TerminusModel {
   /**
    * Object constructor
    *
-   * @param \stdClass $attributes Attributes of this model
-   * @param array     $options    Options to set as $this->key
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
    */
-  public function __construct(\stdClass $attributes, array $options = array()) {
+  public function __construct($attributes, array $options = array()) {
     parent::__construct($attributes, $options);
     $this->backups  = new Backups(array('environment' => $this));
     $this->bindings = new Bindings(array('environment' => $this));

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -10,18 +10,23 @@ use Terminus\Models\Collections\Backups;
 use Terminus\Models\Collections\Bindings;
 
 class Environment extends TerminusModel {
+  /**
+   * @var Backups
+   */
   public $backups;
 
+  /**
+   * @var Bindings
+   */
   private $bindings;
 
   /**
    * Object constructor
    *
-   * @param [stdClass] $attributes Attributes of this model
-   * @param [array]    $options    Options to set as $this->key
-   * @return [TerminusModel] $this
+   * @param \stdClass $attributes Attributes of this model
+   * @param array     $options    Options to set as $this->key
    */
-  public function __construct($attributes, $options = array()) {
+  public function __construct(\stdClass $attributes, array $options = array()) {
     parent::__construct($attributes, $options);
     $this->backups  = new Backups(array('environment' => $this));
     $this->bindings = new Bindings(array('environment' => $this));
@@ -30,8 +35,8 @@ class Environment extends TerminusModel {
   /**
    * Add hostname to environment
    *
-   * @param [string] $hostname Hostname to add to environment
-   * @return [array] $response['data']
+   * @param string $hostname Hostname to add to environment
+   * @return array Response data
    */
   public function addHostname($hostname) {
     $response = $this->request->request(
@@ -50,8 +55,8 @@ class Environment extends TerminusModel {
   /**
    * Changes connection mode
    *
-   * @param [string] $value Connection mode, "git" or "sftp"
-   * @return [Workflow] $workflow
+   * @param string $value Connection mode, "git" or "sftp"
+   * @return Workflow|string
    */
   public function changeConnectionMode($value) {
     $current_mode = $this->getConnectionMode();
@@ -74,10 +79,10 @@ class Environment extends TerminusModel {
   }
 
   /**
-   * Clones files from this environment to another
+   * Clones database from this environment to another
    *
-   * @param [string] $to_env Environment to clone into
-   * @return [Workflow] $workflow
+   * @param string $to_env Environment to clone into
+   * @return Workflow
    */
   public function cloneDatabase($to_env) {
     $params   = array(
@@ -91,8 +96,8 @@ class Environment extends TerminusModel {
   /**
    * Clones files from this environment to another
    *
-   * @param [string] $to_env Environment to clone into
-   * @return [Workflow] $workflow
+   * @param string $to_env Environment to clone into
+   * @return Workflow
    */
   public function cloneFiles($to_env) {
     $params   = array(
@@ -106,9 +111,9 @@ class Environment extends TerminusModel {
   /**
    * Commits changes to code
    *
-   * @param [string] $commit Should be the commit message to use if committing
+   * @param string $commit Should be the commit message to use if committing
    *   on server changes
-   * @return [array] $data['data']
+   * @return array Response data
    */
   public function commitChanges($commit = null) {
     ob_start();
@@ -136,7 +141,7 @@ class Environment extends TerminusModel {
   /**
    * Gives connection info for this environment
    *
-   * @return [array] $info
+   * @return array
    */
   public function connectionInfo() {
     $info = array();
@@ -292,8 +297,10 @@ class Environment extends TerminusModel {
   /**
    * Creates a new environment
    *
-   * @param [string] $env_name Name of environment to create
-   * @return [array] $response['data']
+   * @param string $env_name Name of environment to create
+   * @return array Response data
+   *
+   * @todo This doesn't currently work because $site_id is undefined.
    */
   public function create($env_name) {
     $path     = sprintf('environments/%s', $env_name);
@@ -311,8 +318,8 @@ class Environment extends TerminusModel {
   /**
    * Delete hostname from environment
    *
-   * @param [string] $hostname Hostname to remove from environment
-   * @return [array] $response['data']
+   * @param string $hostname Hostname to remove from environment
+   * @return array Response data
    */
   public function deleteHostname($hostname) {
     $response = $this->request->request(
@@ -326,7 +333,7 @@ class Environment extends TerminusModel {
       'delete'
     );
     return $response['data'];
-
+    // dead code:
     $options  = array('environment' => $this->get('id'), 'params' => $params);
     $workflow = $this->site->workflows->create('do_export', $options);
     $workflow->wait();
@@ -337,8 +344,8 @@ class Environment extends TerminusModel {
   /**
    * Deploys the Test or Live environment
    *
-   * @param [array] $params Parameters for the deploy workflow
-   * @return [Workflow] workflow response
+   * @param array $params Parameters for the deploy workflow
+   * @return Workflow
    */
   public function deploy($params) {
     $params   = array('environment' => $this->get('id'), 'params' => $params);
@@ -349,7 +356,7 @@ class Environment extends TerminusModel {
   /**
    * Gets diff from multidev environment
    *
-   * @return [array] $data['data']
+   * @return array
    */
   public function diffstat() {
     $path = sprintf(
@@ -368,7 +375,7 @@ class Environment extends TerminusModel {
   /**
    * Generate environment URL
    *
-   * @return [string] $host
+   * @return string
    */
   public function domain() {
     $host = sprintf(
@@ -383,7 +390,7 @@ class Environment extends TerminusModel {
   /**
    * Returns the connection mode of this environment
    *
-   * @return [string] $connection_mode
+   * @return string 'git' or 'sftp'
    */
   public function getConnectionMode() {
     $path   = sprintf(
@@ -404,9 +411,9 @@ class Environment extends TerminusModel {
   }
 
   /**
-   * List hotnames for environment
+   * List hostnames for environment
    *
-   * @return [array] $response['data']
+   * @return array
    */
   public function getHostnames() {
     $response = $this->request->request(
@@ -421,7 +428,7 @@ class Environment extends TerminusModel {
   /**
    * Returns the environment's name
    *
-   * @return [string] $name
+   * @return string
    */
   public function getName() {
     $name = $this->get('id');
@@ -431,8 +438,9 @@ class Environment extends TerminusModel {
   /**
    * Load site info
    *
-   * @param [string] $key Set to retrieve a specific attribute as named
-   * @return [array] $info
+   * @param string $key Set to retrieve a specific attribute as named
+   * @return array $info
+   * @throws TerminusException
    */
   public function info($key = null) {
     $path   = sprintf('environments/%s', $this->get('id'));
@@ -471,7 +479,7 @@ class Environment extends TerminusModel {
    * content from previous environment (e.g. test clones dev content, live
    * clones test content.)
    *
-   * @return [Workflow] $workflow In-progress workflow
+   * @return Workflow In-progress workflow
    */
   public function initializeBindings() {
     if ($this->get('id') == 'test') {
@@ -498,11 +506,11 @@ class Environment extends TerminusModel {
   /**
    * Have the environment's bindings have been initialized?
    *
-   * @return [boolean] $has_commits True if environment has been instantiated
+   * @return bool True if environment has been instantiated
    */
   public function isInitialized() {
     // One can determine whether an environment has been initialized
-    // by checking if it has code commits. Unitialized environments do not.
+    // by checking if it has code commits. Uninitialized environments do not.
     $commits     = $this->log();
     $has_commits = (count($commits) > 0);
     return $has_commits;
@@ -511,7 +519,7 @@ class Environment extends TerminusModel {
   /**
    * Is this branch a multidev environment?
    *
-   * @return [boolean] True if ths environment is a multidev environment
+   * @return bool True if ths environment is a multidev environment
    */
   public function isMultidev() {
     $is_multidev = !in_array($this->get('id'), array('dev', 'test', 'live'));
@@ -521,8 +529,8 @@ class Environment extends TerminusModel {
   /**
    * Enable HTTP Basic Access authentication on the web environment
    *
-   * @param [array] $options Parameters to override defaults
-   * @return [Workflow] $workflow;
+   * @param array $options Parameters to override defaults
+   * @return Workflow
    */
   public function lock($options = array()) {
     $username = $options['username'];
@@ -542,7 +550,7 @@ class Environment extends TerminusModel {
   /**
    * Get Info on an environment lock
    *
-   * @return [string] $lock
+   * @return string
    */
   public function lockinfo() {
     $lock = $this->get('lock');
@@ -552,7 +560,7 @@ class Environment extends TerminusModel {
   /**
    * Get the code log (commits)
    *
-   * @return [array] $response['data']
+   * @return array
    */
   public function log() {
     $path     = sprintf('environments/%s/code-log', $this->get('id'));
@@ -568,12 +576,14 @@ class Environment extends TerminusModel {
   /**
    * Merge code from the Dev Environment into this Multidev Environment
    *
-   * @param [array] $options Parameters to override defaults
-   * @return [Workflow] $workflow
+   * @param array $options Parameters to override defaults
+   * @return Workflow
+   * @throws \Exception
+   * @todo Should this throw TerminusException instead?
    */
   public function mergeFromDev($options = array()) {
     if (!$this->isMultidev()) {
-      throw new Exception(
+      throw new \Exception(
         sprintf(
           'The %s environment is not a multidev environment',
           $this->get('id')
@@ -595,12 +605,14 @@ class Environment extends TerminusModel {
   /**
    * Merge code from this Multidev Environment into the Dev Environment
    *
-   * @param [array] $options Parameters to override defaults
-   * @return [Workflow] $workflow
+   * @param array $options Parameters to override defaults
+   * @return Workflow
+   * @throws \Exception
+   * @todo Should this throw TerminusException instead?
    */
   public function mergeToDev($options = array()) {
     if (!$this->isMultidev()) {
-      throw new Exception(
+      throw new \Exception(
         sprintf(
           'The %s environment is not a multidev environment',
           $this->get('id')
@@ -628,7 +640,7 @@ class Environment extends TerminusModel {
   /**
    * Disable HTTP Basic Access authentication on the web environment
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    */
   public function unlock() {
     $params   = array('environment' => $this->get('id'));
@@ -639,7 +651,7 @@ class Environment extends TerminusModel {
   /**
    * "Wake" a site
    *
-   * @return [array] $return_data
+   * @return array
    */
   public function wake() {
     $on_stats = function (TransferStats $stats) {
@@ -663,7 +675,7 @@ class Environment extends TerminusModel {
   /**
    * Deletes all content (files and database) from the Environment
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    */
   public function wipe() {
     $params   = array('environment' => $this->get('id'));
@@ -674,10 +686,10 @@ class Environment extends TerminusModel {
   /**
    * Start a work flow
    *
-   * @param [Workflow] $workflow String work flow "slot"
-   * @return [array] $response['data']
+   * @param Workflow $workflow String work flow "slot"
+   * @return array
    */
-  public function workflow($workflow) {
+  public function workflow(Workflow $workflow) {
     $path        = sprintf("environments/%s/workflows", $this->get('id'));
     $form_params = array(
       'type'        => $workflow,

--- a/php/Terminus/Models/Instrument.php
+++ b/php/Terminus/Models/Instrument.php
@@ -2,7 +2,5 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class Instrument extends TerminusModel {
 }

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -2,26 +2,35 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\User;
-use Terminus\Models\TerminusModel;
 use Terminus\Models\Collections\OrganizationSiteMemberships;
 use Terminus\Models\Collections\OrganizationUserMemberships;
 use Terminus\Models\Collections\Workflows;
 
 class Organization extends TerminusModel {
+  /**
+   * @var OrganizationSiteMemberships
+   */
   protected $site_memberships;
+  /**
+   * @var User
+   */
   protected $user;
+  /**
+   * @var OrganizationUserMemberships
+   */
   protected $user_memberships;
+  /**
+   * @var Workflows
+   */
   protected $workflows;
 
   /**
    * Object constructor
    *
-   * @param [stdClass] $attributes Attributes of this model
-   * @param [array]    $options    Options to set as $this->key
-   * @return [Organization] $this
+   * @param \stdClass $attributes Attributes of this model
+   * @param array     $options    Options to set as $this->key
    */
-  public function __construct($attributes = null, $options = array()) {
+  public function __construct(\stdClass $attributes = null, array $options = array()) {
     parent::__construct($attributes, $options);
     if (!isset($this->user)) {
       $this->user = new User();
@@ -52,7 +61,7 @@ class Organization extends TerminusModel {
   /**
    * Retrieves organization sites
    *
-   * @return [array] $sites An array of OrganizationSiteMember objects
+   * @return OrganizationSiteMembership[]
    */
   public function getSites() {
     $sites = $this->site_memberships->all();
@@ -62,7 +71,7 @@ class Organization extends TerminusModel {
   /**
    * Retrieves organization users
    *
-   * @return [array] $users An array of OrganizationUserMember objects
+   * @return OrganizationUserMembership[]
    */
   public function getUsers() {
     $users = $this->user_memberships->all();

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -27,10 +27,10 @@ class Organization extends TerminusModel {
   /**
    * Object constructor
    *
-   * @param \stdClass $attributes Attributes of this model
-   * @param array     $options    Options to set as $this->key
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
    */
-  public function __construct(\stdClass $attributes = null, array $options = array()) {
+  public function __construct($attributes = null, array $options = array()) {
     parent::__construct($attributes, $options);
     if (!isset($this->user)) {
       $this->user = new User();

--- a/php/Terminus/Models/OrganizationSiteMembership.php
+++ b/php/Terminus/Models/OrganizationSiteMembership.php
@@ -8,9 +8,9 @@ use Terminus\Models\Organization;
 class OrganizationSiteMembership extends Organization {
 
   /**
-   * Adds a site to this organization
+   * Removes a site from this organization
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    */
   public function removeMember() {
     $site     = $this->get('site');

--- a/php/Terminus/Models/OrganizationUserMembership.php
+++ b/php/Terminus/Models/OrganizationUserMembership.php
@@ -8,9 +8,9 @@ use Terminus\Models\Organization;
 class OrganizationUserMembership extends Organization {
 
   /**
-   * Adds a site to this organization
+   * Removes a user from this organization
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    */
   public function removeMember() {
     $user     = $this->get('user');

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -52,10 +52,10 @@ class Site extends TerminusModel {
   /**
    * Object constructor
    *
-   * @param \stdClass $attributes Attributes of this model
-   * @param array     $options    Options to set as $this->key
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
    */
-  public function __construct(\stdClass $attributes = null, array $options = array()) {
+  public function __construct($attributes = null, array $options = array()) {
     if ($attributes == null) {
       $attributes = new \stdClass();
     }
@@ -522,7 +522,7 @@ class Site extends TerminusModel {
    * Owner handler
    *
    * @param string $owner UUID of new owner of site
-   * @return \stdClass
+   * @return Workflow
    */
   public function setOwner($owner = null) {
     $new_owner = $this->user_memberships->get($owner);
@@ -582,7 +582,6 @@ class Site extends TerminusModel {
         $method,
         compact('form_params')
       );
-      return $response['data'];
     } catch (\Exception $e) {
       if (strpos($e->getMessage(), '403') !== false) {
         throw new TerminusException(
@@ -593,6 +592,7 @@ class Site extends TerminusModel {
       }
       throw $e;
     }
+    return $response['data'];
   }
 
   /**
@@ -600,6 +600,7 @@ class Site extends TerminusModel {
    *
    * @param string $framework_name Name of framework to verify
    * @return bool
+   * @todo This function is unused; remove?
    */
   private function hasFramework($framework_name) {
     $has_framework = ($framework_name == $this->get('framework'));

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -13,24 +13,49 @@ use Terminus\Models\Collections\SiteUserMemberships;
 use Terminus\Models\Collections\Workflows;
 
 class Site extends TerminusModel {
+  /**
+   * @var array
+   * @todo Use Bindings collection?
+   */
   public $bindings;
 
+  /**
+   * @var Environments
+   */
   protected $environments;
+
+  /**
+   * @var SiteOrganizationMemberships
+   */
   protected $org_memberships;
+
+  /**
+   * @var SiteUserMemberships
+   */
   protected $user_memberships;
+
+  /**
+   * @var Workflows
+   */
   protected $workflows;
 
+  /**
+   * @var array
+   */
   private $features;
+
+  /**
+   * @var array
+   */
   private $tags;
 
   /**
    * Object constructor
    *
-   * @param [stdClass] $attributes Attributes of this model
-   * @param [array]    $options    Options to set as $this->key
-   * @return [Site] $this
+   * @param \stdClass $attributes Attributes of this model
+   * @param array     $options    Options to set as $this->key
    */
-  public function __construct($attributes = null, $options = array()) {
+  public function __construct(\stdClass $attributes = null, array $options = array()) {
     if ($attributes == null) {
       $attributes = new \stdClass();
     }
@@ -60,8 +85,8 @@ class Site extends TerminusModel {
   /**
    * Adds payment instrument of given site
    *
-   * @param [string] $uuid UUID of new payment instrument
-   * @return [Workflow] $workflow Workflow object for the request
+   * @param string $uuid UUID of new payment instrument
+   * @return Workflow
    */
   public function addInstrument($uuid) {
     $args     = array(
@@ -77,9 +102,9 @@ class Site extends TerminusModel {
   /**
    * Adds a tag to the site
    *
-   * @param [string] $tag Tag to apply
-   * @param [string] $org Organization to add the tag associateion to
-   * @return [array] $response
+   * @param string $tag Name of tag to apply
+   * @param string $org Organization to add the tag association to
+   * @return array
    */
   public function addTag($tag, $org) {
     $params   = array($tag => array('sites' => array($this->get('id'))));
@@ -93,10 +118,10 @@ class Site extends TerminusModel {
   /**
    * Apply upstream updates
    *
-   * @param [string]  $env_id   Environment name
-   * @param [boolean] $updatedb True to run update.php
-   * @param [boolean] $xoption  True to automatically resolve merge conflicts
-   * @return [Workflow] $workflow
+   * @param string $env_id   Environment name
+   * @param bool   $updatedb True to run update.php
+   * @param bool   $xoption  True to automatically resolve merge conflicts
+   * @return Workflow
    */
   public function applyUpstreamUpdates(
     $env_id,
@@ -121,7 +146,7 @@ class Site extends TerminusModel {
   /**
    * Returns an array of attributes
    *
-   * @return [stdClass] $atts['data']
+   * @return \stdClass
    */
   public function attributes() {
     $path   = 'attributes';
@@ -138,11 +163,12 @@ class Site extends TerminusModel {
   /**
    * Fetch Binding info
    *
-   * @param [string] $type Which sort of binding to retrieve
-   * @return [array] $this->bindings
+   * @param string $type Which sort of binding to retrieve
+   * @return array
    */
   public function bindings($type = null) {
     if (empty($this->bindings)) {
+      // TODO: $bindings is undefined.
       $response = $this->request->simpleRequest(
         'sites/' . $this->get('id') . '/' . $bindings
       );
@@ -164,8 +190,8 @@ class Site extends TerminusModel {
   /**
    * Create a new branch
    *
-   * @param [string] $branch Name of new branch
-   * @return [Workflow] $workflow
+   * @param string $branch Name of new branch
+   * @return Workflow
    */
   public function createBranch($branch) {
     $form_params = array('refspec' => sprintf('refs/heads/%s', $branch));
@@ -182,7 +208,7 @@ class Site extends TerminusModel {
   /**
    * Deletes site
    *
-   * @return [array] $response
+   * @return array
    */
   public function delete() {
     $response = $this->request->simpleRequest(
@@ -195,8 +221,8 @@ class Site extends TerminusModel {
   /**
    * Delete a branch from site remove
    *
-   * @param [string] $branch Name of branch to remove
-   * @return [void]
+   * @param string $branch Name of branch to remove
+   * @return Workflow
    */
   public function deleteBranch($branch) {
     $workflow = $this->workflows->create(
@@ -213,9 +239,9 @@ class Site extends TerminusModel {
   /**
    * Delete a multidev environment
    *
-   * @param [string]  $env           Name of environment to remove
-   * @param [boolean] $delete_branch True to delete branch
-   * @return [void]
+   * @param string $env           Name of environment to remove
+   * @param bool   $delete_branch True to delete branch
+   * @return Workflow
    */
   public function deleteEnvironment($env, $delete_branch) {
     $workflow = $this->workflows->create(
@@ -233,19 +259,20 @@ class Site extends TerminusModel {
   /**
    * Deletes site from cache
    *
-   * @return [void]
+   * @return void
    */
   public function deleteFromCache() {
+    // TODO: $this->collection is not defined.
     $this->collection->deleteSiteFromCache($this->get('name'));
   }
 
   /**
    * Fetches this object from Pantheon
    *
-   * @param [array] $options params to pass to url request
-   * @return [Site] $this
+   * @param array $options params to pass to url request
+   * @return Site
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     $response         = $this->request->simpleRequest(
       sprintf('sites/%s?site_state=true', $this->get('id'))
     );
@@ -256,8 +283,8 @@ class Site extends TerminusModel {
   /**
    * Returns given attribute, if present
    *
-   * @param [string] $attribute Name of attribute requested
-   * @return [mixed] $this->attributes->$attributes;
+   * @param string $attribute Name of attribute requested
+   * @return mixed|null Attribute value, or null if not found
    */
   public function get($attribute) {
     if (isset($this->attributes->$attribute)) {
@@ -269,8 +296,8 @@ class Site extends TerminusModel {
   /**
    * Returns a specific site feature value
    *
-   * @param [string] $feature Feature to check
-   * @return [mixed] $this->features[$feature]
+   * @param string $feature Feature to check
+   * @return mixed|null Feature value, or null if not found
    */
   public function getFeature($feature) {
     if (!isset($this->features)) {
@@ -288,7 +315,7 @@ class Site extends TerminusModel {
   /**
    * Returns all organization members of this site
    *
-   * @return [array] Array of SiteOrganizationMemberships
+   * @return SiteOrganizationMembership[]
    */
   public function getOrganizations() {
     $orgs = $this->org_memberships->all();
@@ -298,7 +325,7 @@ class Site extends TerminusModel {
   /**
    * Lists user memberships for this site
    *
-   * @return [SiteUserMemberships] Collection of user memberships for this site
+   * @return SiteUserMemberships
    */
   public function getSiteUserMemberships() {
     $this->user_memberships = $this->user_memberships->fetch();
@@ -308,8 +335,8 @@ class Site extends TerminusModel {
   /**
    * Returns tags from the site/org join
    *
-   * @param [string] $org UUID of organization site belongs to
-   * @return [array] $tags Tags in string format
+   * @param string $org UUID of organization site belongs to
+   * @return string[]
    */
   public function getTags($org) {
     if (isset($this->tags)) {
@@ -327,7 +354,7 @@ class Site extends TerminusModel {
   /**
    * Get upstream updates
    *
-   * @return [stdClass] $response['data']
+   * @return \stdClass
    */
   public function getUpstreamUpdates() {
     $response = $this->request->simpleRequest(
@@ -339,8 +366,8 @@ class Site extends TerminusModel {
   /**
    * Imports a full-site archive
    *
-   * @param [string] $url URL to import data from
-   * @return [Workflow] $workflow
+   * @param string $url URL to import data from
+   * @return Workflow
    */
   public function import($url) {
     $params = array(
@@ -364,8 +391,8 @@ class Site extends TerminusModel {
   /**
    * Imports a database archive
    *
-   * @param [string] $url URL to import data from
-   * @return [Workflow] $workflow
+   * @param string $url URL to import data from
+   * @return Workflow
    */
   public function importDatabase($url) {
     $workflow = $this->workflows->create(
@@ -381,8 +408,8 @@ class Site extends TerminusModel {
   /**
    * Imports a file archive
    *
-   * @param [string] $url URL to import data from
-   * @return [Workflow] $workflow
+   * @param string $url URL to import data from
+   * @return Workflow
    */
   public function importFiles($url) {
     $workflow = $this->workflows->create(
@@ -398,8 +425,10 @@ class Site extends TerminusModel {
   /**
    * Load site info
    *
-   * @param [string] $key Set to retrieve a specific attribute as named
-   * @return [array] $info
+   * @param string $key Set to retrieve a specific attribute as named
+   * @return array|null|mixed
+   *   If $key is supplied, return named bit of info, or null if not found.
+   *   If no $key supplied, return entire info array.
    */
   public function info($key = null) {
     $info = array(
@@ -436,10 +465,9 @@ class Site extends TerminusModel {
   /**
    * Retrieve New Relic Info
    *
-   * @return [stdClass] $response['data']
+   * @return \stdClass
    */
   public function newRelic() {
-    $path     = 'new-relic';
     $response = $this->request->simpleRequest(
       'sites/' . $this->get('id') . '/new-relic'
     );
@@ -447,10 +475,10 @@ class Site extends TerminusModel {
   }
 
   /**
-   * Returns all organization members of this site
+   * Determines if an organization is a member of this site
    *
-   * @param [string] $uuid UUID of organization to check for
-   * @return [boolean] True if organization is a member of this site
+   * @param string $uuid UUID of organization to check for
+   * @return bool True if organization is a member of this site
    */
   public function organizationIsMember($uuid) {
     $org_ids       = $this->org_memberships->ids();
@@ -461,8 +489,8 @@ class Site extends TerminusModel {
   /**
    * Removes payment instrument of given site
    *
-   * @params [string] $uuid UUID of new payment instrument
-   * @return [Workflow] $workflow Workflow object for the request
+   * @params string $uuid UUID of new payment instrument
+   * @return Workflow
    */
   public function removeInstrument() {
     $args     = array('site'   => $this->get('id'),);
@@ -473,9 +501,9 @@ class Site extends TerminusModel {
   /**
    * Removes a tag to the site
    *
-   * @param [string] $tag Tag to remove
-   * @param [string] $org Organization to remove the tag associateion from
-   * @return [array] $response
+   * @param string $tag Tag to remove
+   * @param string $org Organization to remove the tag association from
+   * @return array
    */
   public function removeTag($tag, $org) {
     $response = $this->request->simpleRequest(
@@ -493,8 +521,8 @@ class Site extends TerminusModel {
   /**
    * Owner handler
    *
-   * @param [string] $owner UUID of new owner of site
-   * @return [stdClass] $data['data']
+   * @param string $owner UUID of new owner of site
+   * @return \stdClass
    */
   public function setOwner($owner = null) {
     $new_owner = $this->user_memberships->get($owner);
@@ -516,7 +544,7 @@ class Site extends TerminusModel {
   /**
    * Just the code branches
    *
-   * @return [stdClass] $data['data']
+   * @return \stdClass
    */
   public function tips() {
     $path = 'code-tips';
@@ -527,8 +555,9 @@ class Site extends TerminusModel {
   /**
    * Update service level
    *
-   * @param [string] $level Level to set service on site to
-   * @return [stdClass] $response['data']
+   * @param string $level Level to set service on site to
+   * @return \stdClass
+   * @throws TerminusException
    */
   public function updateServiceLevel($level) {
     if (!in_array(
@@ -569,8 +598,8 @@ class Site extends TerminusModel {
   /**
    * Verifies if the given framework is in use
    *
-   * @param [string] $framework_name Name of framework to verify
-   * @return [boolean] $has_framework
+   * @param string $framework_name Name of framework to verify
+   * @return bool
    */
   private function hasFramework($framework_name) {
     $has_framework = ($framework_name == $this->get('framework'));

--- a/php/Terminus/Models/SiteOrganizationMembership.php
+++ b/php/Terminus/Models/SiteOrganizationMembership.php
@@ -2,17 +2,20 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class SiteOrganizationMembership extends TerminusModel {
+  /**
+   * @var Site
+   */
   protected $site;
+  /**
+   * @var Organization
+   */
   protected $organization;
 
   /**
    * Returns organization object within SiteOrganizationMembership object
    *
-   * @return [Organization] $this->organization
-   *   Org associated with this SiteOrganizationMembership
+   * @return Organization
    */
   public function getOrganization() {
     if (!isset($this->organization)) {
@@ -24,7 +27,7 @@ class SiteOrganizationMembership extends TerminusModel {
   /**
    * Remove membership of organization
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    **/
   public function removeMember() {
     $workflow = $this->site->workflows->create(
@@ -37,8 +40,8 @@ class SiteOrganizationMembership extends TerminusModel {
   /**
    * Changes the role of the given member
    *
-   * @param [string] $role Desired role for this organization
-   * @return [Workflow] $workflow
+   * @param string $role Desired role for this organization
+   * @return Workflow
    */
   public function setRole($role) {
     $workflow = $this->site->workflows->create(

--- a/php/Terminus/Models/SiteUserMembership.php
+++ b/php/Terminus/Models/SiteUserMembership.php
@@ -8,9 +8,9 @@ class SiteUserMembership extends TerminusModel {
   protected $site;
 
   /**
-   * Remove membshipship, either org or user
+   * Remove membership, either org or user
    *
-   * @return [Workflow] $workflow
+   * @return Workflow
    **/
   public function removeMember() {
     $workflow = $this->site->workflows->create(
@@ -23,8 +23,8 @@ class SiteUserMembership extends TerminusModel {
   /**
    * Changes the role of the given member
    *
-   * @param [string] $role Desired role for this member
-   * @return [Workflow] $workflow
+   * @param string $role Desired role for this member
+   * @return Workflow
    */
   public function setRole($role) {
     $workflow = $this->site->workflows->create(

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -11,7 +11,7 @@ abstract class TerminusModel {
    */
   protected $request;
   /**
-   * @var \stdClass
+   * @var object
    */
   protected $attributes;
 

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -6,17 +6,22 @@ use Terminus\Request;
 
 abstract class TerminusModel {
   protected $id;
+  /**
+   * @var Request
+   */
   protected $request;
-  private $attributes;
+  /**
+   * @var \stdClass
+   */
+  protected $attributes;
 
   /**
    * Object constructor
    *
-   * @param [stdClass] $attributes Attributes of this model
-   * @param [array]    $options    Options to set as $this->key
-   * @return [TerminusModel] $this
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
    */
-  public function __construct($attributes = null, $options = array()) {
+  public function __construct($attributes = null, array $options = array()) {
     if ($attributes == null) {
       $attributes = new \stdClass();
     }
@@ -31,10 +36,10 @@ abstract class TerminusModel {
   }
 
   /**
-   * Handles requests for inaccessable properties
+   * Handles requests for inaccessible properties
    *
-   * @param [string] $property Name of property being requested
-   * @return [mixed] $this->$property
+   * @param string $property Name of property being requested
+   * @return mixed $this->$property
    */
   public function __get($property) {
     if (property_exists($this, $property)) {
@@ -57,10 +62,10 @@ abstract class TerminusModel {
   /**
    * Fetches this object from Pantheon
    *
-   * @param [array] $options Params to pass to url request
-   * @return [TerminusModel] $this
+   * @param array $options Params to pass to url request
+   * @return TerminusModel $this
    */
-  public function fetch($options = array()) {
+  public function fetch(array $options = array()) {
     $fetch_args = array();
     if (isset($options['fetch_args'])) {
       $fetch_args = $options['fetch_args'];
@@ -84,8 +89,8 @@ abstract class TerminusModel {
   /**
    * Retrieves attribute of given name
    *
-   * @param [string] $attribute Name of the key of the desired attribute
-   * @return [mixed] $this->attributes->$attribute
+   * @param string $attribute Name of the key of the desired attribute
+   * @return mixed Value of the attribute, or null if not set.
    */
   public function get($attribute) {
     if ($this->has($attribute)) {
@@ -97,8 +102,8 @@ abstract class TerminusModel {
   /**
    * Checks whether the model has an attribute
    *
-   * @param [string] $attribute Name of the attribute key
-   * @return [boolean] $isset whether the attribute is set
+   * @param string $attribute Name of the attribute key
+   * @return boolean True if attribute exists, false otherwise
    */
   public function has($attribute) {
     $isset = isset($this->attributes->$attribute);
@@ -108,7 +113,7 @@ abstract class TerminusModel {
   /**
    * Give necessary args for collection data fetching
    *
-   * @return [array]
+   * @return array
    */
   protected function getFetchArgs() {
     return array();
@@ -117,7 +122,7 @@ abstract class TerminusModel {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
     return '';

--- a/php/Terminus/Models/Upstream.php
+++ b/php/Terminus/Models/Upstream.php
@@ -2,7 +2,5 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class Upstream extends TerminusModel {
 }

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -38,10 +38,10 @@ class User extends TerminusModel {
   /**
    * Object constructor
    *
-   * @param \stdClass $attributes Attributes of this model
-   * @param array     $options    Options to set as $this->key
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
    */
-  public function __construct(\stdClass $attributes = null, array $options = array()) {
+  public function __construct($attributes = null, array $options = array()) {
     if (!isset($options['id'])) {
       $options['id'] = Session::getValue('user_uuid');
     }
@@ -62,7 +62,7 @@ class User extends TerminusModel {
   /**
    * Retrieves drush aliases for this user
    *
-   * @return \stdClass $this->aliases
+   * @return \stdClass
    */
   public function getAliases() {
     if (!$this->aliases) {
@@ -74,7 +74,7 @@ class User extends TerminusModel {
   /**
    * Retrieves organization data for this user
    *
-   * @return \stdClass $organizations
+   * @return Organization[]
    */
   public function getOrganizations() {
     $organizations = $this->organizations->all();
@@ -86,7 +86,7 @@ class User extends TerminusModel {
    *
    * @param string $organization UUID of organization to requests sites from,
    *   or null to fetch for all organizations.
-   * @return \stdClass $response['data']
+   * @return \stdClass
    */
   public function getSites($organization = null) {
     if ($organization) {

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -3,28 +3,45 @@
 namespace Terminus\Models;
 
 use Terminus\Models\Collections\UserOrganizationMemberships;
-use Terminus\Models\TerminusModel;
 use Terminus\Models\Collections\Instruments;
 use Terminus\Models\Collections\Workflows;
 use Terminus\Session;
 
 class User extends TerminusModel {
+  /**
+   * @var UserOrganizationMemberships
+   */
   public $organizations;
 
+  /**
+   * @var Instruments
+   */
   protected $instruments;
+
+  /**
+   * @var Workflows
+   */
   protected $workflows;
 
+  /**
+   * @var \stdClass
+   * @todo Wrap this in a proper class.
+   */
   private $aliases;
+
+  /**
+   * @var \stdClass
+   * @todo Wrap this in a proper class.
+   */
   private $profile;
 
   /**
    * Object constructor
    *
-   * @param [stdClass] $attributes Attributes of this model
-   * @param [array]    $options    Options to set as $this->key
-   * @return [User] $this
+   * @param \stdClass $attributes Attributes of this model
+   * @param array     $options    Options to set as $this->key
    */
-  public function __construct($attributes = null, $options = array()) {
+  public function __construct(\stdClass $attributes = null, array $options = array()) {
     if (!isset($options['id'])) {
       $options['id'] = Session::getValue('user_uuid');
     }
@@ -45,7 +62,7 @@ class User extends TerminusModel {
   /**
    * Retrieves drush aliases for this user
    *
-   * @return [stdClass] $this->aliases
+   * @return \stdClass $this->aliases
    */
   public function getAliases() {
     if (!$this->aliases) {
@@ -57,7 +74,7 @@ class User extends TerminusModel {
   /**
    * Retrieves organization data for this user
    *
-   * @return [stdClass] $organizations
+   * @return \stdClass $organizations
    */
   public function getOrganizations() {
     $organizations = $this->organizations->all();
@@ -67,8 +84,9 @@ class User extends TerminusModel {
   /**
    * Requests API data and returns an object of user site data
    *
-   * @param [string] $organization UUID of organization to requests sites from
-   * @return [stdClass] $response['data']
+   * @param string $organization UUID of organization to requests sites from,
+   *   or null to fetch for all organizations.
+   * @return \stdClass $response['data']
    */
   public function getSites($organization = null) {
     if ($organization) {
@@ -84,7 +102,7 @@ class User extends TerminusModel {
   /**
    * Requests API data and populates $this->aliases
    *
-   * @return [void]
+   * @return void
    */
   private function setAliases() {
     $path     = 'drush_aliases';

--- a/php/Terminus/Models/UserOrganizationMembership.php
+++ b/php/Terminus/Models/UserOrganizationMembership.php
@@ -2,7 +2,5 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class UserOrganizationMembership extends Organization {
 }

--- a/php/Terminus/Models/Workflow.php
+++ b/php/Terminus/Models/Workflow.php
@@ -12,7 +12,7 @@ class Workflow extends TerminusModel {
   /**
    * Give the URL for collection data fetching
    *
-   * @return [string] $url URL to use in fetch query
+   * @return string $url URL to use in fetch query
    */
   public function getFetchUrl() {
     $url = '';
@@ -46,7 +46,7 @@ class Workflow extends TerminusModel {
   /**
    * Re-fetches workflow data hydrated with logs
    *
-   * @return [Workflow] $this
+   * @return Workflow
    */
   public function fetchWithLogs() {
     $options = array(
@@ -63,7 +63,7 @@ class Workflow extends TerminusModel {
   /**
    * Detects if the workflow has finished
    *
-   * @return [boolean] $is_finished True if worklow has finished
+   * @return bool True if workflow has finished
    */
   public function isFinished() {
     $is_finished = (boolean)$this->get('result');
@@ -71,9 +71,9 @@ class Workflow extends TerminusModel {
   }
 
   /**
-   * Detects if the workflow was successfsul
+   * Detects if the workflow was successful
    *
-   * @return [boolean] $is_successful True if workflow succeeded
+   * @return bool True if workflow succeeded
    */
   public function isSuccessful() {
     $is_successful = ($this->get('result') == 'succeeded');
@@ -83,7 +83,7 @@ class Workflow extends TerminusModel {
   /**
    * Returns a list of WorkflowOperations for this workflow
    *
-   * @return [Array<WorkflowOperation>] $operations list of WorkflowOperations
+   * @return WorkflowOperation[]
    */
   public function operations() {
     if (is_array($this->get('operations'))) {
@@ -103,7 +103,7 @@ class Workflow extends TerminusModel {
   /**
    * Formats workflow object into an associative array for output
    *
-   * @return [array] $data associative array of data for output
+   * @return array Associative array of data for output
    */
   public function serialize() {
     $user = 'Pantheon';
@@ -137,7 +137,8 @@ class Workflow extends TerminusModel {
   /**
    * Waits on this workflow to finish
    *
-   * @return [Workflow] $this
+   * @return Workflow|void
+   * @throws TerminusException
    */
   public function wait() {
     while (!$this->isFinished()) {
@@ -168,9 +169,9 @@ class Workflow extends TerminusModel {
   }
 
   /**
-   * Names the model-owner of this collection
+   * Gets name of the model-owner of this collection
    *
-   * @return [string] $owner_name
+   * @return string
    */
   protected function getOwnerName() {
     $owner_name = strtolower(

--- a/php/Terminus/Models/WorkflowOperation.php
+++ b/php/Terminus/Models/WorkflowOperation.php
@@ -11,7 +11,7 @@ class WorkflowOperation extends TerminusModel {
   /**
    * Formats operation object into an associative array for output
    *
-   * @return [array] $data associative array of data for output
+   * @return array
    */
   public function serialize() {
     $data = array(
@@ -32,7 +32,7 @@ class WorkflowOperation extends TerminusModel {
   /**
    * Formats operation object into a descriptive string
    *
-   * @return [string] $description string description of operation
+   * @return string
    */
   public function description() {
     $description = sprintf(
@@ -46,7 +46,7 @@ class WorkflowOperation extends TerminusModel {
   /**
    * Formats operation duration into a string
    *
-   * @return [string] $duration
+   * @return string
    */
   protected function duration() {
     if ($this->has('run_time')) {

--- a/php/Terminus/Outputters/BashFormatter.php
+++ b/php/Terminus/Outputters/BashFormatter.php
@@ -18,8 +18,8 @@ class BashFormatter implements OutputFormatterInterface {
   /**
    * Formats any kind of value as a raw dump
    *
-   * @param [mixed] $object An object to dump via print_r
-   * @return [string] $printout
+   * @param mixed $object An object to dump via print_r
+   * @return string
    */
   public function formatDump($object) {
     $printout = print_r($object, true);
@@ -29,17 +29,17 @@ class BashFormatter implements OutputFormatterInterface {
   /**
    * Format a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [string] $out
+   * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
+  public function formatRecord($record, array $human_labels = array()) {
     $out = '';
     foreach ((array)$record as $key => $value) {
-      $value = BashFormatter::flattenValue($value);
-      $out  .= $key . BashFormatter::FIELD_SEPARATOR . $value
-        . BashFormatter::ROW_SEPARATOR;
+      $value = self::flattenValue($value);
+      $out  .= $key . self::FIELD_SEPARATOR . $value
+        . self::ROW_SEPARATOR;
     }
     return $out;
   }
@@ -47,24 +47,24 @@ class BashFormatter implements OutputFormatterInterface {
   /**
    * Format a list of records of the same type.
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array mapping record keys to human names
-   * @return [string] $table
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array mapping record keys to human names
+   * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
+  public function formatRecordList(array $records, array $human_labels = array()) {
     $out = '';
     foreach ($records as $record) {
       foreach ((array)$record as $value) {
-        $out .= BashFormatter::flattenValue($value);
-        $out .= BashFormatter::FIELD_SEPARATOR;
+        $out .= self::flattenValue($value);
+        $out .= self::FIELD_SEPARATOR;
       }
       // Remove the trailing separator.
       $out  = substr(
         $out,
         0,
-        (strlen($out)-(strlen(BashFormatter::FIELD_SEPARATOR)))
+        (strlen($out)-(strlen(self::FIELD_SEPARATOR)))
       );
-      $out .= BashFormatter::ROW_SEPARATOR;
+      $out .= self::ROW_SEPARATOR;
     }
     return $out;
   }
@@ -72,25 +72,25 @@ class BashFormatter implements OutputFormatterInterface {
   /**
    * Formats a single scalar value with an optional human label.
    *
-   * @param [mixed]  $value       A scalar value to format
-   * @param [string] $human_label A human readable label for that value
-   * @return [string] $formatted_value
+   * @param mixed  $value       A scalar value to format
+   * @param string $human_label A human readable label for that value
+   * @return string
    */
   public function formatValue($value, $human_label = '') {
-    $value = BashFormatter::flattenValue($value)
-      . BashFormatter::ROW_SEPARATOR;
+    $value = self::flattenValue($value)
+      . self::ROW_SEPARATOR;
     return $value;
   }
 
   /**
    * Format a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label A human name for the entire list. If each
-   *   value needs a separate label, then formatRecord should be used.
-   * @return [string] $out
+   * @param array  $values      The values to format
+   * @param string $human_label A human name for the entire list. If each value
+   *   needs a separate label, then formatRecord should be used.
+   * @return void
    */
-  public function formatValueList($values, $human_label = '') {
+  public function formatValueList(array $values, $human_label = '') {
     $out = '';
     foreach ($values as $value) {
       $out .= $this->formatValue($value);
@@ -101,8 +101,8 @@ class BashFormatter implements OutputFormatterInterface {
   /**
    * Flatten a value for display
    *
-   * @param [mixed] $value Value to stringify
-   * @return [string] $value or $output
+   * @param mixed $value Value to stringify
+   * @return string
    */
   private static function flattenValue($value) {
     if (is_scalar($value)) {
@@ -112,9 +112,9 @@ class BashFormatter implements OutputFormatterInterface {
     $output = array();
 
     foreach ($value as $key => $val) {
-      $output[] = $key . ': ' . BashFormatter::flattenValue($val);
+      $output[] = $key . ': ' . self::flattenValue($val);
     }
-    $output = '(' . implode(BashFormatter::VALUE_SEPARATOR, $output) . ')';
+    $output = '(' . implode(self::VALUE_SEPARATOR, $output) . ')';
     return $output;
   }
 

--- a/php/Terminus/Outputters/JSONFormatter.php
+++ b/php/Terminus/Outputters/JSONFormatter.php
@@ -14,7 +14,7 @@ namespace Terminus\Outputters;
 class JSONFormatter implements OutputFormatterInterface {
 
   /**
-   * @var [integer] The options to be passed to json_encode
+   * @var int The options to be passed to json_encode
    * See: http://php.net/manual/en/function.json-encode.php
    */
   protected $json_options;
@@ -22,8 +22,7 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Object constructor. Sets the JSON options property
    *
-   * @param [integer] $options The json_encode options bitmask
-   * @return [JSONFormatter] $this
+   * @param int $options The json_encode options bitmask
    */
   public function __construct($options = 0) {
     $this->json_options = $options;
@@ -32,8 +31,8 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Formats any kind of value as a raw dump
    *
-   * @param [mixed] $object An object to dump via print_r
-   * @return [string] $printout
+   * @param mixed $object An object to dump via print_r
+   * @return string
    */
   public function formatDump($object) {
     $printout = json_encode($object, $this->json_options);
@@ -43,12 +42,12 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Format a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [string] $record
+   * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
+  public function formatRecord($record, array $human_labels = array()) {
     $record = json_encode((array)$record, $this->json_options);
     return $record;
   }
@@ -56,11 +55,11 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Format a list of records of the same type.
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array mapping record keys to human names
-   * @return [string] $list
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array mapping record keys to human names
+   * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
+  public function formatRecordList(array $records, array $human_labels = array()) {
     $list = json_encode((array)$records, $this->json_options);
     return $list;
   }
@@ -68,9 +67,9 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Formats a single scalar value with an optional human label.
    *
-   * @param [mixed]  $value       A scalar value to format
-   * @param [string] $human_label A human readable label for that value
-   * @return [string] $formatted_value
+   * @param mixed  $value       A scalar value to format
+   * @param string $human_label A human readable label for that value
+   * @return string
    */
   public function formatValue($value, $human_label = '') {
     $formatted_value = json_encode($value, $this->json_options);
@@ -80,12 +79,12 @@ class JSONFormatter implements OutputFormatterInterface {
   /**
    * Format a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label A human name for the entire list. If each
-   *   value needs a separate label, then formatRecord should be used.
-   * @return [string] $list
+   * @param array  $values      The values to format
+   * @param string $human_label A human name for the entire list. If each value
+   *   needs a separate label, then formatRecord should be used.
+   * @return void
    */
-  public function formatValueList($values, $human_label = '') {
+  public function formatValueList(array $values, $human_label = '') {
     $list = json_encode((array)$values, $this->json_options);
     return $list;
   }

--- a/php/Terminus/Outputters/OutputFormatterInterface.php
+++ b/php/Terminus/Outputters/OutputFormatterInterface.php
@@ -10,52 +10,53 @@ namespace Terminus\Outputters;
  * Interface OutputFormatterInterface
  * @package Terminus\Outputters
  */
-interface OutputFormatterInterface {
+interface OutputFormatterInterface
+{
 
   /**
    * Formats any kind of value as a raw dump
    *
-   * @param [mixed] $object An object to dump via print_r
-   * @return [string]
+   * @param mixed $object An object to dump via print_r
+   * @return string
    */
   public function formatDump($object);
 
   /**
    * Format a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [string]
+   * @return string
    */
-  public function formatRecord($record, $human_labels = array());
+  public function formatRecord($record, array $human_labels = array());
 
   /**
    * Format a list of records of the same type.
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array mapping record keys to human names
-   * @return [string]
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array mapping record keys to human names
+   * @return string
    */
-  public function formatRecordList($records, $human_labels = array());
+  public function formatRecordList(array $records, array $human_labels = array());
 
   /**
    * Formats a single scalar value with an optional human label.
    *
-   * @param [mixed]  $value       A scalar value to format
-   * @param [string] $human_label A human readable label for that value
-   * @return [string]
+   * @param mixed  $value       A scalar value to format
+   * @param string $human_label A human readable label for that value
+   * @return string
    */
   public function formatValue($value, $human_label = '');
 
   /**
    * Format a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label A human name for the entire list. If each
-   *   value needs a separate label, then formatRecord should be used.
-   * @return [void]
+   * @param array  $values      The values to format
+   * @param string $human_label A human name for the entire list. If each value
+   *   needs a separate label, then formatRecord should be used.
+   * @return void
    */
-  public function formatValueList($values, $human_label = '');
+  public function formatValueList(array $values, $human_label = '');
 
 }

--- a/php/Terminus/Outputters/OutputWriterInterface.php
+++ b/php/Terminus/Outputters/OutputWriterInterface.php
@@ -15,8 +15,8 @@ namespace Terminus\Outputters;
 interface OutputWriterInterface {
 
   /**
-   * @param [string] $output The formatted output to be written.
-   * @return [void]
+   * @param string $output The formatted output to be written.
+   * @return void
    */
   public function write($output);
 

--- a/php/Terminus/Outputters/Outputter.php
+++ b/php/Terminus/Outputters/Outputter.php
@@ -15,21 +15,20 @@ namespace Terminus\Outputters;
 class Outputter implements OutputterInterface {
 
   /**
-   * @var [OutputFormatterInterface]
+   * @var OutputFormatterInterface
    */
   protected $formatter;
 
   /**
-   * @var [OutputWriterInterface]
+   * @var OutputWriterInterface
    */
   protected $writer;
 
   /**
    * Object constructor. Sets writer and formatter properties.
    *
-   * @param [OutputWriterInterface]    $writer    Writer object to set
-   * @param [OutputFormatterInterface] $formatter Formatter object to set
-   * @return [Outputter] $this
+   * @param OutputWriterInterface    $writer    Writer object to set
+   * @param OutputFormatterInterface $formatter Formatter object to set
    */
   public function __construct(
     OutputWriterInterface $writer,
@@ -42,7 +41,7 @@ class Outputter implements OutputterInterface {
   /**
    * Retrieves the set formatter object
    *
-   * @return [OutputFormatterInterface] $this->formatter
+   * @return OutputFormatterInterface
    */
   public function getFormatter() {
     return $this->formatter;
@@ -51,7 +50,7 @@ class Outputter implements OutputterInterface {
   /**
    * Retrieves the set writer object
    *
-   * @return [OutputWriterInterface] $this->writer
+   * @return OutputWriterInterface
    */
   public function getWriter() {
     return $this->writer;
@@ -60,8 +59,8 @@ class Outputter implements OutputterInterface {
   /**
    * Outputs any variable type as a raw dump
    *
-   * @param [object|array] $object Item to dump information on
-   * @return [void]
+   * @param object|array $object Item to dump information on
+   * @return void
    */
   public function outputDump($object) {
     $this->getWriter()->write($this->getFormatter()->formatDump($object));
@@ -70,12 +69,12 @@ class Outputter implements OutputterInterface {
   /**
    * Formats a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [void]
+   * @return void
    */
-  public function outputRecord($record, $human_labels = array()) {
+  public function outputRecord($record, array $human_labels = array()) {
     $this->getWriter()->write(
       $this->getFormatter()->formatRecord($record, $human_labels)
     );
@@ -84,11 +83,11 @@ class Outputter implements OutputterInterface {
   /**
    * Formats a list of records of the same type
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array that maps record keys to human names
-   * @return [void]
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array that maps record keys to human names
+   * @return void
    */
-  public function outputRecordList($records, $human_labels = array()) {
+  public function outputRecordList(array $records, array $human_labels = array()) {
     $this->getWriter()->write(
       $this->getFormatter()->formatRecordList($records, $human_labels)
     );
@@ -97,9 +96,9 @@ class Outputter implements OutputterInterface {
   /**
    * Formats a single scalar value with an optional human label
    *
-   * @param [mixed]  $value       The scalar value to format
-   * @param [string] $human_label The human readable label for the value
-   * @return [void]
+   * @param mixed  $value       The scalar value to format
+   * @param string $human_label The human readable label for the value
+   * @return void
    */
   public function outputValue($value, $human_label = '') {
     $this->getWriter()->write(
@@ -110,12 +109,12 @@ class Outputter implements OutputterInterface {
   /**
    * Formats a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label One human name for the entire list. If each
+   * @param array  $values      The values to format
+   * @param string $human_label One human name for the entire list. If each
    *   value needs a separate label, then formatRecord should be used.
-   * @return [void]
+   * @return void
    */
-  public function outputValueList($values, $human_label = '') {
+  public function outputValueList(array $values, $human_label = '') {
     $this->getWriter()->write(
       $this->getFormatter()->formatRecord($values, $human_label)
     );
@@ -124,18 +123,18 @@ class Outputter implements OutputterInterface {
   /**
    * Sets the formatter which converts the output to a useful string
    *
-   * @param [OutputFormatterInterface] $formatter Formatter selected for use
-   * @return [void]
+   * @param OutputFormatterInterface $formatter Formatter selected for use
+   * @return void
    */
   public function setFormatter(OutputFormatterInterface $formatter) {
     $this->formatter = $formatter;
   }
 
   /**
-   * Sets the writer which sends the output to it's final destination
+   * Sets the writer which sends the output to its final destination
    *
-   * @param [OutputWriterInterface] $writer Writer selected for use
-   * @return [void]
+   * @param OutputWriterInterface $writer Writer selected for use
+   * @return void
    */
   public function setWriter(OutputWriterInterface $writer) {
     $this->writer = $writer;

--- a/php/Terminus/Outputters/OutputterInterface.php
+++ b/php/Terminus/Outputters/OutputterInterface.php
@@ -15,62 +15,62 @@ interface OutputterInterface {
   /**
    * Outputs any variable type as a raw dump
    *
-   * @param [object|array] $object Item to dump information on
-   * @return [void]
+   * @param object|array $object Item to dump information on
+   * @return void
    */
   public function outputDump($object);
 
   /**
    * Formats a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [void]
+   * @return void
    */
-  public function outputRecord($record, $human_labels = array());
+  public function outputRecord($record, array $human_labels = array());
 
   /**
    * Formats a list of records of the same type
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array that maps record keys to human names
-   * @return [void]
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array that maps record keys to human names
+   * @return void
    */
-  public function outputRecordList($records, $human_labels = array());
+  public function outputRecordList(array $records, array $human_labels = array());
 
   /**
    * Formats a single scalar value with an optional human label
    *
-   * @param [mixed]  $value       The scalar value to format
-   * @param [string] $human_label The human readable label for the value
-   * @return [void]
+   * @param mixed  $value       The scalar value to format
+   * @param string $human_label The human readable label for the value
+   * @return void
    */
   public function outputValue($value, $human_label = '');
 
   /**
    * Formats a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label One human name for the entire list. If each
+   * @param array  $values      The values to format
+   * @param string $human_label One human name for the entire list. If each
    *   value needs a separate label, then formatRecord should be used.
-   * @return [void]
+   * @return void
    */
-  public function outputValueList($values, $human_label = '');
+  public function outputValueList(array $values, $human_label = '');
 
   /**
    * Sets the formatter which converts the output to a useful string
    *
-   * @param [OutputFormatterInterface] $formatter Formatter selected for use
-   * @return [void]
+   * @param OutputFormatterInterface $formatter Formatter selected for use
+   * @return void
    */
   public function setFormatter(OutputFormatterInterface $formatter);
 
   /**
-   * Sets the writer which sends the output to it's final destination
+   * Sets the writer which sends the output to its final destination
    *
-   * @param [OutputWriterInterface] $writer Writer selected for use
-   * @return [void]
+   * @param OutputWriterInterface $writer Writer selected for use
+   * @return void
    */
   public function setWriter(OutputWriterInterface $writer);
 

--- a/php/Terminus/Outputters/PrettyFormatter.php
+++ b/php/Terminus/Outputters/PrettyFormatter.php
@@ -11,8 +11,8 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Formats any kind of value as a raw dump
    *
-   * @param [mixed] $object An object to dump via print_r
-   * @return [string] $printout
+   * @param mixed $object An object to dump via print_r
+   * @return string
    */
   public function formatDump($object) {
     $printout = print_r($object, true);
@@ -22,16 +22,14 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Format a single record or object
    *
-   * @param [array|object] $record       A key/value array or object
-   * @param [array]        $human_labels A key/value array mapping the keys in
+   * @param array|object $record       A key/value array or object
+   * @param array        $human_labels A key/value array mapping the keys in
    *   the record to human labels
-   * @return [string] $table
+   * @return string
    */
-  public function formatRecord($record, $human_labels = array()) {
-    /**
-     * No output for empty records. This should be handled by the logger with
-     * a friendly message.
-     */
+  public function formatRecord($record, array $human_labels = array()) {
+    // No output for empty records. This should be handled by the logger with
+    // a friendly message.
     if (empty($record)) {
       return '';
     }
@@ -53,15 +51,13 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Format a list of records of the same type.
    *
-   * @param [array] $records      A list of arrays or objects.
-   * @param [array] $human_labels An array mapping record keys to human names
-   * @return [string] $table
+   * @param array $records      A list of arrays or objects.
+   * @param array $human_labels An array mapping record keys to human names
+   * @return string
    */
-  public function formatRecordList($records, $human_labels = array()) {
-    /**
-     * No output for empty records. This should be handled by the logger with
-     * a friendly message.
-     */
+  public function formatRecordList(array $records, array $human_labels = array()) {
+     // No output for empty records. This should be handled by the logger with
+     // a friendly message.
     if (empty($records)) {
       return '';
     }
@@ -105,9 +101,9 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Formats a single scalar value with an optional human label.
    *
-   * @param [mixed]  $value       A scalar value to format
-   * @param [string] $human_label A human readable label for that value
-   * @return [string] $formatted_value
+   * @param mixed  $value       A scalar value to format
+   * @param string $human_label A human readable label for that value
+   * @return string
    */
   public function formatValue($value, $human_label = '') {
     $formatted_value = PrettyFormatter::flattenValue($value);
@@ -120,23 +116,23 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Format a list of scalar values
    *
-   * @param [array]  $values      The values to format
-   * @param [string] $human_label A human name for the entire list. If each
+   * @param array  $values      The values to format
+   * @param string $human_label A human name for the entire list. If each
    *   value needs a separate label, then formatRecord should be used.
-   * @return [void]
+   * @return void
    */
-  public function formatValueList($values, $human_label = '') {
+  public function formatValueList(array $values, $human_label = '') {
     $this->formatValue(implode(', ', $values), $human_label);
   }
 
   /**
    * Formats data into a table for display
    *
-   * @param [mixed] $data    Data to format into a table
-   * @param [array] $headers Headers to replace array/object keys
-   * @return [string] $out
+   * @param array      $data    Data to format into a table
+   * @param array|null $headers Headers to replace array/object keys
+   * @return string
    */
-  private function formatTable($data, $headers = null) {
+  private function formatTable(array $data, array $headers = null) {
     $table = new \cli\Table();
 
     if ($headers) {
@@ -162,11 +158,11 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Flatten a value for display
    *
-   * @param [mixed] $value        Value to stringify
-   * @param [array] $human_labels Human-readable labels to replace keys with
-   * @return [string] $value
+   * @param mixed $value        Value to stringify
+   * @param array $human_labels Human-readable labels to replace keys with
+   * @return string
    */
-  private static function flattenValue($value, $human_labels = array()) {
+  private static function flattenValue($value, array $human_labels = array()) {
     if (is_scalar($value)) {
       return $value;
     }
@@ -187,11 +183,11 @@ class PrettyFormatter implements OutputFormatterInterface {
   /**
    * Gets the human name for a key, if available
    *
-   * @param [string] $key          Array key referencing some data item
-   * @param [array]  $human_labels Human-readable labels keyed to data
-   * @return [string] $label
+   * @param string $key          Array key referencing some data item
+   * @param array  $human_labels Human-readable labels keyed to data
+   * @return string
    */
-  private static function getHumanLabel($key, $human_labels) {
+  private static function getHumanLabel($key, array $human_labels) {
     $label = ucwords(strtr($key, '_', ' '));
     if (isset($human_labels[$key])) {
       $label = $human_labels[$key];

--- a/php/Terminus/Outputters/StreamWriter.php
+++ b/php/Terminus/Outputters/StreamWriter.php
@@ -12,25 +12,24 @@ namespace Terminus\Outputters;
  */
 class StreamWriter implements OutputWriterInterface {
   /**
-   * @var [string] The stream URI
+   * @var string The stream URI
    */
   var $uri;
 
   /**
    * Object constructor. Assigns URI property
    *
-   * @param [string] $uri File or stream to write to
-   * @return [StreamWriter] $this
+   * @param string $uri File or stream to write to
    */
   public function __construct($uri = 'php://stdout') {
     $this->uri = $uri;
   }
 
   /**
-   * Outputs fiven data to file or stream
+   * Outputs given data to file or stream
    *
-   * @param [string] $output The formatted output to be written.
-   * @return [void]
+   * @param string $output The formatted output to be written.
+   * @return void
    */
   public function write($output) {
     file_put_contents($this->uri, $output);

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -5,20 +5,38 @@ namespace Terminus;
 use Terminus;
 use Terminus\Utils;
 use Terminus\Exceptions\TerminusException;
+use Terminus\Loggers\Logger;
 
 class Runner {
+  /**
+   * @var array
+   */
   private $arguments;
+  /**
+   * @var array
+   */
   private $assoc_args;
+  /**
+   * @var array
+   */
   private $config;
+  /**
+   * @var Configurator
+   */
   private $configurator;
+  /**
+   * @var Logger
+   */
   private $logger;
+  /**
+   * @var Terminus
+   */
   private $terminus;
 
   /**
-   * Constructs object. Initializes config, colorizaiton, loger, and outputter
+   * Constructs object. Initializes config, colorization, loger, and outputter
    *
-   * @param [array] $config Extra settings for the config property
-   * @return [Runner] $this
+   * @param array $config Extra settings for the config property
    */
   public function __construct($config = array()) {
     $this->setConfigurator();
@@ -34,8 +52,8 @@ class Runner {
   /**
    * Retrieves properties requested
    *
-   * @param [string] $key Property name to return
-   * @return [mixed] $this->$key
+   * @param string $key Property name to return
+   * @return mixed
    */
   public function __get($key) {
     if (($key[0] == '_') || (!isset($this->$key))) {
@@ -47,8 +65,11 @@ class Runner {
   /**
    * Identifies the command to be run
    *
-   * @param [array] $args The non-hyphenated (--) terms from the CL
-   * @return [array] $command_array
+   * @param array $args The non-hyphenated (--) terms from the CL
+   * @return array
+   *   0 => [Terminus\Dispatcher\RootCommand]
+   *   1 => [array] args
+   *   2 => [array] command path
    */
   public function findCommandToRun($args) {
     $command = Terminus::getRootCommand();
@@ -78,7 +99,7 @@ class Runner {
   /**
    * Retrieves the configurator property
    *
-   * @return [Configurator] $this->configurator
+   * @return Configurator
    */
   public function getConfigurator() {
     return $this->configurator;
@@ -87,7 +108,7 @@ class Runner {
   /**
    * Runs the Terminus command
    *
-   * @return [void]
+   * @return void
    */
   public function run() {
     if (empty($this->arguments)) {
@@ -108,6 +129,7 @@ class Runner {
       // Show synopsis if it's a composite command.
       $r = $this->findCommandToRun($this->arguments);
       if (is_array($r)) {
+        /** @var \Terminus\Dispatcher\RootCommand $command */
         list($command) = $r;
 
         if ($command->canHaveSubcommands()) {
@@ -131,12 +153,13 @@ class Runner {
   /**
    * Runs a command
    *
-   * @param [array] $args       The non hyphenated (--) terms from the CL
-   * @param [array] $assoc_args The hyphenated terms from the CL
-   * @return [void]
+   * @param array $args       The non hyphenated (--) terms from the CL
+   * @param array $assoc_args The hyphenated terms from the CL
+   * @return void
    */
   public function runCommand($args, $assoc_args = array()) {
     try {
+      /** @var \Terminus\Dispatcher\RootCommand $command */
       list($command, $final_args, $cmd_path) = $this->findCommandToRun($args);
       $name = implode(' ', $cmd_path);
 
@@ -155,7 +178,7 @@ class Runner {
   /**
    * Runs a command via runCommand by supplying it with properties as args
    *
-   * @return [void]
+   * @return void
    */
   private function _runCommand() {
     $this->runCommand($this->arguments, $this->assoc_args);
@@ -164,8 +187,8 @@ class Runner {
   /**
    * Initializes configurator, saves config data to it
    *
-   * @param [array] $config Config options to set explicitly
-   * @return [void]
+   * @param array $config Config options to set explicitly
+   * @return void
    */
   private function setConfig($config = array()) {
     $args = array('terminus', '--debug');
@@ -189,10 +212,10 @@ class Runner {
   /**
    * Sets the configurator property
    *
-   * @param [Configurator] $configurator Configurator object to set
-   * @return [void]
+   * @param Configurator|null $configurator Configurator object to set
+   * @return void
    */
-  private function setConfigurator($configurator = null) {
+  private function setConfigurator(Configurator $configurator = null) {
     if (is_null($configurator)) {
       $this->configurator = new Configurator(
         TERMINUS_ROOT . '/php/config-spec.php'

--- a/php/Terminus/Session.php
+++ b/php/Terminus/Session.php
@@ -5,13 +5,17 @@ namespace Terminus;
 use Terminus;
 
 class Session {
+  /**
+   * @var Session
+   */
   static $instance;
+  /**
+   * @var \stdClass
+   */
   protected $data;
 
   /**
    * Instantiates object, sets session data
-   *
-   * @return [Session] $this
    */
   public function __construct() {
     $cache   = Terminus::getCache();
@@ -23,15 +27,14 @@ class Session {
     }
 
     self::$instance = $this;
-    return $this;
   }
 
   /**
-   * Retruns given data property or default if DNE.
+   * Returns given data property or default if DNE.
    *
-   * @param [string] $key     Name of property to return
-   * @param [mixed]  $default Default return value in case property DNE
-   * @return [mixed] $this->data->$key or $default
+   * @param string $key     Name of property to return
+   * @param mixed  $default Default return value in case property DNE
+   * @return mixed
    */
   public function get($key = 'session', $default = false) {
     if (isset($this->data) && isset($this->data->$key)) {
@@ -43,9 +46,9 @@ class Session {
   /**
    * Sets a keyed value to be part of the data property object
    *
-   * @param [string] $key   Name of data property
-   * @param [mixed]  $value Value of property to set
-   * @return [Session] $this
+   * @param string $key   Name of data property
+   * @param mixed  $value Value of property to set
+   * @return Session
    */
   public function set($key, $value) {
     $this->data->$key = null;
@@ -58,7 +61,7 @@ class Session {
   /**
    * Retrieves session data
    *
-   * @return [array] $data
+   * @return \stdClass
    */
   public static function getData() {
     $session = Session::instance();
@@ -66,10 +69,10 @@ class Session {
   }
 
   /**
-   * Returnes session data indicated by the key
+   * Returns session data indicated by the key
    *
-   * @param [string] $key Name of session property to retrieve
-   * @return [mixed] $session_property
+   * @param string $key Name of session property to retrieve
+   * @return mixed
    */
   public static function getValue($key) {
     $session          = Session::instance();
@@ -80,7 +83,7 @@ class Session {
   /**
    * Returns self, instantiating self if necessary
    *
-   * @return [Session] self::$instance Static version of $this
+   * @return Session
    */
   public static function instance() {
     if (!self::$instance) {
@@ -92,8 +95,9 @@ class Session {
   /**
    * Saves session data to cache
    *
-   * @param [array] $data Session data to save
-   * @return [void]
+   * @param array $data Session data to save
+   * @return void|bool
+   * @todo fix return value on this.
    */
   public static function setData($data) {
     $cache = Terminus::getCache();

--- a/php/Terminus/Session.php
+++ b/php/Terminus/Session.php
@@ -10,7 +10,7 @@ class Session {
    */
   static $instance;
   /**
-   * @var \stdClass
+   * @var object
    */
   protected $data;
 
@@ -61,7 +61,7 @@ class Session {
   /**
    * Retrieves session data
    *
-   * @return \stdClass
+   * @return object
    */
   public static function getData() {
     $session = Session::instance();

--- a/php/Terminus/SitesCache.php
+++ b/php/Terminus/SitesCache.php
@@ -29,14 +29,21 @@ use Terminus\Session;
  *
  */
 class SitesCache {
+  /**
+   * @var FileCache
+   */
   protected $cache;
+  /**
+   * @var string
+   */
   protected $cachekey;
+  /**
+   * @var Request
+   */
   protected $request;
 
   /**
    * Object constructor, saves cache to cache property
-   *
-   * @return [SitesCache] $this
    */
   public function __construct() {
     $this->cache    = Terminus::getCache();
@@ -61,10 +68,10 @@ class SitesCache {
    *       )
    *     )
    *
-   * @param [array] $memberships_data Memberships of use to add to cache
-   * @return [array] $sites
+   * @param array $memberships_data Memberships of use to add to cache
+   * @return array
    */
-  public function add($memberships_data = array()) {
+  public function add(array $memberships_data = array()) {
     $cache = (array)$this->cache->getData(
       $this->cachekey,
       array('decode_array' => true)
@@ -102,7 +109,7 @@ class SitesCache {
   /**
    * Returns all cached site data
    *
-   * @return [array] $cache_data
+   * @return array
    */
   public function all() {
     $cache_data = $this->cache->getData(
@@ -119,7 +126,7 @@ class SitesCache {
   /**
    * Clears cache data
    *
-   * @return [void]
+   * @return void
    */
   public function clear() {
     $this->cache->putData($this->cachekey, array());
@@ -128,10 +135,10 @@ class SitesCache {
   /**
    * Finds the site of the given attributes within the cache
    *
-   * @param [string] $name    Name of site to retrieve
-   * @param [array]  $options Options to run array with
+   * @param string $name    Name of site to retrieve
+   * @param array  $options Options to run array with
    *        [boolean] rebuild True to rebuild cache when run
-   * @return [array] Found site's data
+   * @return array|null
    */
   private function find($name, $options = array()) {
     $defaults = array('rebuild' => true);
@@ -156,13 +163,13 @@ class SitesCache {
   }
 
   /**
-   * Searches the SitesCache for an ID, given a name
+   * Searches the SitesCache for a UUID, given a name
    *
-   * @param [string] $name    Name of site to retrieve UUID of
-   * @param [array]  $options Options with which to find array, passed to find
-   * @return [string] $site_id UUID of site
+   * @param string $name    Name of site to retrieve UUID of
+   * @param array  $options Options with which to find array, passed to find
+   * @return string|null
    */
-  public function findId($name, $options = array()) {
+  public function findId($name, array $options = array()) {
     $site_data = $this->find($name, $options);
     if ($site_data) {
       $site_id = $site_data['id'];
@@ -175,7 +182,7 @@ class SitesCache {
   /**
    * Rebuilds sites cache
    *
-   * @return [array] $cached_sites
+   * @return array
    */
   public function rebuild() {
     // Clear out the cache
@@ -198,8 +205,8 @@ class SitesCache {
   /**
    * Removes a site from the sites cache
    *
-   * @param [string] $sitename Name of site to remove from array
-   * @return [void'
+   * @param string $sitename Name of site to remove from array
+   * @return void
    */
   public function remove($sitename) {
     $cache = (array)$this->cache->getData(
@@ -213,9 +220,9 @@ class SitesCache {
   /**
    * Fetches organizational sites from API
    *
-   * @param [array] $org_data Properties below:
+   * @param array $org_data Properties below:
    *        [string] id Organizaiton UUID
-   * @return [array] $memberships_data
+   * @return array $memberships_data
    */
   private function fetchOrganizationSites($org_data) {
     $response = $this->request->pagedRequest(
@@ -235,7 +242,7 @@ class SitesCache {
   /**
    * Fetches organizational team-membership sites for user from API
    *
-   * @return [array] $memberships_data
+   * @return array
    */
   private function fetchUserSites() {
     $user_id  = Session::getValue('user_uuid');
@@ -260,7 +267,7 @@ class SitesCache {
   /**
    * Fetches organizational memberships for user
    *
-   * @return [array] $data Properties below:
+   * @return array $data Properties below:
    *         [string] id   UUID of membership join
    *         [string] name Name of organization
    *         [string] type Always "organization"
@@ -291,9 +298,9 @@ class SitesCache {
   /**
    * Formats site data from response for use
    *
-   * @param [array] $response_data   Data about the site from API
-   * @param [array] $membership_data Data about membership to this site
-   * @return [array] $membership_array
+   * @param array $response_data   Data about the site from API
+   * @param array $membership_data Data about membership to this site
+   * @return array
    */
   private function getSiteData($response_data, $membership_data = array()) {
     $site_data = array(

--- a/php/Terminus/SynopsisParser.php
+++ b/php/Terminus/SynopsisParser.php
@@ -7,8 +7,8 @@ class SynopsisParser {
   /**
    * Parses a command from documentation and command input
    *
-   * @param [string] $synopsis Command synopsis from the inline docs
-   * @return [array] $params List of parameters
+   * @param string $synopsis Command synopsis from the inline docs
+   * @return array List of parameters
    */
   static function parse($synopsis) {
     $tokens = array_filter(preg_split('/[\s\t]+/', $synopsis));
@@ -36,8 +36,8 @@ class SynopsisParser {
   /**
    * Decides type of token and sanitizes it appropriately.
    *
-   * @param [string] $token Token to check for brackets
-   * @return [array] $param Elements as follows:
+   * @param string $token Token to check for brackets
+   * @return array $param Elements as follows:
    *         [string]  type      Gives token type (e.g. generic, flag, etc)
    *         [string]  name      Regex'd out name of token
    *         [boolean] optional  True if param is optional
@@ -87,8 +87,8 @@ class SynopsisParser {
   /**
    * An optional parameter is surrounded by square brackets.
    *
-   * @param [string] $token Token to check for brackets
-   * @return [array] $array Elements as follows:
+   * @param string $token Token to check for brackets
+   * @return array $array Elements as follows:
    *         [boolean] True if optional, false if not
    *         [string]  $token if optional, without brackets if not
    */
@@ -104,8 +104,8 @@ class SynopsisParser {
   /**
    * A repeating parameter is followed by an ellipsis.
    *
-   * @param [string] $token Token to check for ellipses
-   * @return [array] $array Elements as follows:
+   * @param string $token Token to check for ellipses
+   * @return array $array Elements as follows:
    *         [boolean] True if repeating, false if not
    *         [string]  $token if not repeating, without ellipses if not
    */

--- a/php/Terminus/SynopsisValidator.php
+++ b/php/Terminus/SynopsisValidator.php
@@ -12,8 +12,7 @@ class SynopsisValidator {
   /**
    * Object constructor. Puts synopsis parsing into spec property
    *
-   * @param [string] $synopsis Synopsis from command's internal documentation
-   * @return [SynopsisValidator] $this
+   * @param string $synopsis Synopsis from command's internal documentation
    */
   public function __construct($synopsis) {
     $this->spec = SynopsisParser::parse($synopsis);
@@ -22,7 +21,7 @@ class SynopsisValidator {
   /**
    * Determines unknown positionals
    *
-   * @return [array] $array
+   * @return array
    */
   public function getUnknown() {
     $array = array_column(
@@ -35,8 +34,8 @@ class SynopsisValidator {
   /**
    * Determines whether the command has already had its fill of positional args
    *
-   * @param [args] $args The arguments to count against max args
-   * @return [boolean] $enough_positionals
+   * @param array $args The arguments to count against max args
+   * @return bool
    */
   public function enoughPositionals($args) {
     $positional = $this->querySpec(
@@ -53,8 +52,8 @@ class SynopsisValidator {
   /**
    * Returns invalid positionals, if any. False if not.
    *
-   * @param [array] $args The arguments to evaluate for invalid positionals
-   * @return [string|boolean] Returns the first invalid positional or false
+   * @param array $args The arguments to evaluate for invalid positionals
+   * @return string|bool Returns the first invalid positional or false
    */
   public function invalidPositionals($args) {
     $positionals = $this->querySpec(array('type' => 'positional'));
@@ -70,9 +69,9 @@ class SynopsisValidator {
         $positionals[$i]['token']
       );
       if (in_array(trim($token), array('commands', 'email'))) {
-        //We exit here because the wp and drush commands need to not have
-        //validation running since their commands are dependent on their
-        //respective code bases.
+        // We exit here because the wp and drush commands need to not have
+        // validation running since their commands are dependent on their
+        // respective code bases.
         return false;
       }
       $regex = "#^($token)$#s";
@@ -88,8 +87,8 @@ class SynopsisValidator {
   /**
    * Returns unknown associated arguments (flags and params)
    *
-   * @param [array] $assoc_args Params and flags to evaluate for unknowns
-   * @return [array] $unknowns
+   * @param array $assoc_args Params and flags to evaluate for unknowns
+   * @return array
    */
   public function unknownAssoc($assoc_args) {
     $generic = $this->querySpec(array('type' => 'generic'));
@@ -113,8 +112,8 @@ class SynopsisValidator {
   /**
    * Returns unknown positional arguments
    *
-   * @param [array] $args Positional args to evaluate for unknowns
-   * @return [array] $unknowns
+   * @param array $args Positional args to evaluate for unknowns
+   * @return array
    */
   public function unknownPositionals($args) {
     $positional_repeating = $this->querySpec(
@@ -142,8 +141,8 @@ class SynopsisValidator {
   /**
    * Checks that all required keys are present and that they have values.
    *
-   * @param [array] $assoc_args Params and flags to evaluate for unknowns
-   * @return [array] $feedback Elements as follows:
+   * @param array $assoc_args Params and flags to evaluate for unknowns
+   * @return array $feedback Elements as follows:
    *         [array] errors   Errors relating to any invalid associated args
    *         [array] to_unset The invalid arguments
    */
@@ -185,10 +184,10 @@ class SynopsisValidator {
    * Filters a list of associative arrays, based on a set of key => value
    * arguments.
    *
-   * @param [array]  $args     An array of key => value arguments to match
+   * @param array  $args     An array of key => value arguments to match
    *                             against
-   * @param [string] $operator AND, OR, or NOT
-   * @return [array] $filtered List filtered by operator
+   * @param string $operator AND, OR, or NOT
+   * @return array List filtered by operator
    */
   private function querySpec($args, $operator = 'AND') {
     $operator = strtoupper($operator);

--- a/php/dispatcher.php
+++ b/php/dispatcher.php
@@ -5,8 +5,8 @@ namespace Terminus\Dispatcher;
 /**
  * Get array of commands in object
  *
- * @param [Command] $command Chained command object
- * @return [array] $path Represents names of all commands in param
+ * @param \Terminus\Dispatcher\RootCommand $command Chained command object
+ * @return array Represents names of all commands in param
  */
 function getPath($command) {
   $path = array();

--- a/php/utils.php
+++ b/php/utils.php
@@ -16,8 +16,8 @@ if (!defined('JSON_PRETTY_PRINT')) {
 /**
  * Composes associative arguments into a command string
  *
- * @param [array] $assoc_args Arguments for command line in array form
- * @return [string] $return Command string form of param
+ * @param array $assoc_args Arguments for command line in array form
+ * @return string Command string form of param
  */
 function assocArgsToStr($assoc_args) {
   $return = '';
@@ -36,7 +36,7 @@ function assocArgsToStr($assoc_args) {
 /**
   * Retrieves current version number from repository and saves it to the cache
   *
-  * @return [string] $response->name The version number
+  * @return string The version number
   */
 function checkCurrentVersion() {
   $request  = new Request();
@@ -54,7 +54,7 @@ function checkCurrentVersion() {
 /**
   * Checks for new versions of Terminus once per week and saves to cache
   *
-  * @return [void]
+  * @return void
   */
 function checkForUpdate() {
   $cache_data = Terminus::getCache()->getData(
@@ -83,8 +83,8 @@ function checkForUpdate() {
 /**
  * Returns a colorized string
  *
- * @param [string] $string Message to colorize for output
- * @return [string] $colorized_string
+ * @param string $string Message to colorize for output
+ * @return string
  */
 function colorize($string) {
   $colorize = true;
@@ -101,7 +101,7 @@ function colorize($string) {
 /**
  * Sets constants necessary for the proper functioning of Terminus
  *
- * @return [void]
+ * @return void
  */
 function defineConstants() {
   define('Terminus', true);
@@ -140,9 +140,10 @@ function defineConstants() {
 /**
  * Ensures that the given destination is valid
  *
- * @param [string]  $destination Location of directory to ensure viability of
- * @param [boolean] $make        True to create destination if it does not exist
- * @return [string] $destination Same as the parameter
+ * @param string $destination Location of directory to ensure viability of
+ * @param bool   $make        True to create destination if it does not exist
+ * @return string Same as the parameter
+ * @throws TerminusException
  */
 function destinationIsValid($destination, $make = true) {
   if (file_exists($destination) AND !is_dir($destination)) {
@@ -166,8 +167,8 @@ function destinationIsValid($destination, $make = true) {
 /**
  * Get file name from a URL
  *
- * @param [string] $url A valid URL
- * @return [string] The file name from the given URL
+ * @param string $url A valid URL
+ * @return string The file name from the given URL
  */
 function getFilenameFromUrl($url) {
   $path     = parseUrl($url);
@@ -179,7 +180,7 @@ function getFilenameFromUrl($url) {
 /**
  * Return an array of paths where vendor autoload files may be located
  *
- * @return [array] $vendor_paths
+ * @return array
  */
 function getVendorPaths() {
   $vendor_paths = array(
@@ -192,12 +193,12 @@ function getVendorPaths() {
 /**
  * Imports environment variables
  *
- * @return [void]
+ * @return void
  */
 function importEnvironmentVariables() {
   //Load environment variables from __DIR__/.env
   if (file_exists(getcwd() . '/.env')) {
-    $env = new Dotenv\Dotenv(getcwd());
+    $env = new \Dotenv\Dotenv(getcwd());
     $env->load();
   }
 }
@@ -205,8 +206,8 @@ function importEnvironmentVariables() {
 /**
  * Checks given path for whether it is absolute
  *
- * @param [string] $path Path to check
- * @return [boolean] $is_root True if path is absolute
+ * @param string $path Path to check
+ * @return bool True if path is absolute
  */
 function isPathAbsolute($path) {
   $is_root = (isset($path[1]) && ($path[1] == ':') || ($path[0] == '/'));
@@ -216,8 +217,8 @@ function isPathAbsolute($path) {
 /**
  * Checks whether email is in a valid or not
  *
- * @param [string] $email String to be evaluated for email address format
- * @return [boolean] $is_email True if $email is in email address format
+ * @param string $email String to be evaluated for email address format
+ * @return bool True if $email is in email address format
  */
 function isValidEmail($email) {
   $is_email = !is_bool(filter_var($email, FILTER_VALIDATE_EMAIL));
@@ -227,7 +228,7 @@ function isValidEmail($email) {
 /**
  * Check whether Terminus is running in a Windows environment
  *
- * @return [boolean] $is_windows True if OS running Terminus is Windows
+ * @return bool True if OS running Terminus is Windows
  */
 function isWindows() {
   $is_windows = (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN');
@@ -237,7 +238,7 @@ function isWindows() {
 /**
  * Includes every command file in the commands directory
  *
- * @return [void]
+ * @return void
  */
 function loadAllCommands() {
   $cmd_dir = TERMINUS_ROOT . '/php/Terminus/Commands';
@@ -256,8 +257,8 @@ function loadAllCommands() {
 /**
  * Loads a file of the given name from the assets directory.
  *
- * @param [string] $file Relative file path from the assets dir
- * @return [string] $asset_location Contents of the asset file
+ * @param string $file Relative file path from the assets dir
+ * @return string Contents of the asset file
  */
 function loadAsset($file) {
   $asset_location = sprintf('%s/assets/%s', TERMINUS_ROOT, $file);
@@ -283,8 +284,8 @@ function loadAsset($file) {
 /**
  * Includes a single command file
  *
- * @param [string] $name Of command of which the class file will be included
- * @return [void]
+ * @param string $name Of command of which the class file will be included
+ * @return void
  */
 function loadCommand($name) {
   $path = sprintf(
@@ -301,7 +302,7 @@ function loadCommand($name) {
 /**
  * Requires inclusion of Composer's autoload file
  *
- * @return [void]
+ * @return void
  */
 function loadDependencies() {
   if (strpos(TERMINUS_ROOT, 'phar:') === 0) {
@@ -329,8 +330,8 @@ function loadDependencies() {
  * Using require() directly inside a class grants access to private methods
  * to the loaded code
  *
- * @param [string] $path Path to the file to be required
- * @return [void]
+ * @param string $path Path to the file to be required
+ * @return void
  */
 function loadFile($path) {
   require $path;
@@ -339,8 +340,8 @@ function loadFile($path) {
 /**
  * Takes a host string such as from wp-config.php and parses it into an array
  *
- * @param [string] $raw_host MySQL host string, as defined in wp-config.php
- * @return [array] $assoc_args Connection inforrmation for MySQL
+ * @param string $raw_host MySQL host string, as defined in wp-config.php
+ * @return array $assoc_args Connection inforrmation for MySQL
  */
 function mysqlHostToCliArgs($raw_host) {
   $assoc_args = array();
@@ -365,8 +366,8 @@ function mysqlHostToCliArgs($raw_host) {
 /**
  * Parses a URL and returns its components
  *
- * @param [string] $url URL to parse
- * @return [array] $url_parts An array of URL components
+ * @param string $url URL to parse
+ * @return array An array of URL components
  */
 function parseUrl($url) {
   $url_parts = parse_url($url);
@@ -381,8 +382,8 @@ function parseUrl($url) {
 /**
  * Sanitize the site name field
  *
- * @param [string] $string String to be sanitized
- * @return [string] $name Param string, sanitized
+ * @param string $string String to be sanitized
+ * @return string Param string, sanitized
  */
 function sanitizeName($string) {
   $name = $string;
@@ -398,8 +399,8 @@ function sanitizeName($string) {
 /**
  * Removes ".gz" from a filename
  *
- * @param [string] $filename Name of file from which to remove ".gz"
- * @return [string] $file Param string, ".gz" removed
+ * @param string $filename Name of file from which to remove ".gz"
+ * @return string Param string, ".gz" removed
  */
 function sqlFromZip($filename) {
   $file = preg_replace('#\.gz$#s', '', $filename);
@@ -409,9 +410,9 @@ function sqlFromZip($filename) {
 /**
   * Strips sensitive data out of the JSON printed in a request string
   *
-  * @param [string] $request   The string with a JSON with sensitive data
-  * @param [array]  $blacklist Array of string keys to remove from request
-  * @return [string] $result Sensitive data-stripped version of $request
+  * @param string $request   The string with a JSON with sensitive data
+  * @param array  $blacklist Array of string keys to remove from request
+  * @return string Sensitive data-stripped version of $request
   */
 function stripSensitiveData($request, $blacklist = array()) {
   //Locate the JSON in the string, turn to array
@@ -434,10 +435,10 @@ function stripSensitiveData($request, $blacklist = array()) {
 /**
  * Render PHP or other types of files using Twig templates
  *
- * @param [string] $template_name File name of the template to be used
- * @param [array]  $data          Context to pass through for template use
- * @param [array]  $options       Options to pass through for template use
- * @return [string] $rendered_template The rendered template
+ * @param string $template_name File name of the template to be used
+ * @param array  $data          Context to pass through for template use
+ * @param array  $options       Options to pass through for template use
+ * @return string The rendered template
  */
 function twigRender($template_name, $data, $options) {
   $loader            = new \Twig_Loader_Filesystem(TERMINUS_ROOT . '/templates');

--- a/utils/convert-docs.php
+++ b/utils/convert-docs.php
@@ -4,8 +4,8 @@
  * Converts a file to make it usable in a PHAR and writes it
  * @usage "php utils/convert-docs.php man-src/*.txt"
  *
- * @param [string] $path Path to file to convert
- * @return [void]
+ * @param string $path Path to file to convert
+ * @return void
  */
 function convertFile($path) {
   $out = file_get_contents($path);

--- a/utils/make-docs.php
+++ b/utils/make-docs.php
@@ -7,16 +7,16 @@ require(TERMINUS_ROOT . '/vendor/autoload.php');
 use Terminus\Utils;
 
 /**
- * Accepts the an array representing a tokenized PHP file and sifts out all
+ * Accepts an array representing a tokenized PHP file and sifts out all
  * sets of tokens meeting a specific pattern
  *
- * @param [array] $tokens  A tokenized PHP file
- * @param [array] $pattern Token name pattern to search out
- * @return [array] $matching_patterns
+ * @param array $tokens  A tokenized PHP file
+ * @param array $pattern Token name pattern to search out
+ * @return array
  */
 function findTokenPatterns(
-    $tokens,
-    $pattern   = array('T_DOC_COMMENT', 'T_PUBLIC', 'T_FUNCTION', 'T_STRING')
+    array $tokens,
+    array $pattern   = array('T_DOC_COMMENT', 'T_PUBLIC', 'T_FUNCTION', 'T_STRING')
   ) {
   $matching_patterns = array();
   while (!empty($tokens)) {
@@ -42,8 +42,8 @@ function findTokenPatterns(
 /**
  * Retrieves all file names from a directory
  *
- * @param [string] $dir_name Name of the directory from which to extract file names
- * @return [array <String>] $file_list
+ * @param string $dir_name Name of the directory from which to extract file names
+ * @return string[] $file_list
  */
 function getFiles($dir_name) {
   $dir_files = scandir($dir_name);
@@ -62,8 +62,8 @@ function getFiles($dir_name) {
 /**
  * Uses PHP Tokenizer to extract documentation from the PHP files
  *
- * @param [string] $file_name Name of the file to read and tokenize
- * @return [array] $tokens
+ * @param string $file_name Name of the file to read and tokenize
+ * @return array
  */
 function getTokens($file_name) {
   $file_contents = file_get_contents($file_name);
@@ -74,8 +74,8 @@ function getTokens($file_name) {
 /**
  * Parses PHP internal documentation into chunks
  *
- * @param [string] $doc_string The raw doc string from the PHP file
- * @return [array] $parsed_doc
+ * @param string $doc_string The raw doc string from the PHP file
+ * @return array
  */
 function parseDocs($doc_string) {
   $exploded_docs = explode("\n", $doc_string);
@@ -94,6 +94,11 @@ function parseDocs($doc_string) {
       $breakdown = explode(' ', $line);
       $current   = substr($breakdown[0], 1);
       unset($breakdown[0]);
+      if ($current == 'param' || $current == 'return') {
+        if (substr($breakdown[1], 0, 1) != '[') {
+          $breakdown[1] = '[' . $breakdown[1] . ']';
+        }
+      }
       $line = implode(' ', $breakdown);
     } else if ($current != 'description') {
       $line = "-$line";
@@ -106,9 +111,9 @@ function parseDocs($doc_string) {
 /**
  * Writes documentation to file
  *
- * @param [string]         $namespace Namespace to which the doc file will pertain
- * @param [array <string>] $docs      Documentation to add to file
- * @return [boolean] True if write was successful
+ * @param string   $namespace Namespace to which the doc file will pertain
+ * @param string[] $docs      Documentation to add to file
+ * @return bool    True if write was successful
  */
 function writeDocFile($namespace, $docs) {
   $filename    = TERMINUS_ROOT . '/docs/'


### PR DESCRIPTION
Removed square brackets around typehints in method/function docblocks. Altered make-docs.php to reinsert the brackets when creating documentation files. Re-ran make-docs.php.
