### PR TITLE
Uses authorization header for api authentication

### DIFF
--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -1,22 +1,16 @@
 <?php
 
-/**
- * Authenticate to Pantheon and store a local secret token.
- */
-
 namespace Terminus\Commands;
 
 use Terminus;
 use Terminus\Session;
-use Terminus\Utils;
 use Terminus\Commands\TerminusCommand;
 
+/**
+ * Authenticate to Pantheon and store a local secret token.
+ */
 class AuthCommand extends TerminusCommand {
   private $auth;
-  private $logged_in = false;
-  private $sessionid;
-  private $session_cookie_name = 'X-Pantheon-Session';
-  private $uuid;
 
   /**
    * Instantiates object, sets auth property

--- a/php/Terminus/Request.php
+++ b/php/Terminus/Request.php
@@ -193,12 +193,6 @@ class Request {
       );
     }
 
-    if (Session::getValue('session')) {
-      $options['cookies'] = array(
-        'X-Pantheon-Session' => Session::getValue('session')
-      );
-    }
-
     try {
       Terminus::getLogger()->debug('URL: {url}', compact('url'));
       $response = $this->send($url, $options['method'], $options);
@@ -234,7 +228,7 @@ class Request {
     );
 
     if ($session = Session::instance()->get('session', false)) {
-      $extra_params['headers']['Cookie'] = "X-Pantheon-Session=$session";
+      $extra_params['headers']['Authorization'] = "Bearer $session";
     }
     $params = array_merge_recursive($extra_params, $arg_params);
     if (isset($params['form_params'])) {
@@ -277,9 +271,6 @@ class Request {
   private function fillCookieJar($params) {
     $jar     = new CookieJar();
     $cookies = array();
-    if ($session = Session::instance()->get('session', false)) {
-      $cookies['X-Pantheon-Session'] = $session;
-    }
     if (isset($params['cookies'])) {
       $cookies = array_merge($cookies, $params['cookies']);
     }


### PR DESCRIPTION
The previous version spoofed the dashboard and sent a cookie header to authenticate. This change sends the session id as an 'Authorization: Bearer' header

This is just a redo of #713 which was pulled because the server side wasn't ready. It is now ready.
