### PR TITLE
Fixes #756: Nontrivial calls to Drush failing

### DIFF
--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -38,7 +38,7 @@ class DrushCommand extends CommandWithSSH {
    *
    */
   public function __invoke($args, $assoc_args) {
-    $command = array_pop($args);
+    $command = implode(' ', array_map('escapeshellarg', $args));
     $this->checkCommand($command);
 
     $sites = new Sites();

--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -40,9 +40,19 @@ class DrushCommand extends CommandWithSSH {
   public function __invoke($args, $assoc_args) {
     // Escape any argument that contains non-alphanumeric values (dash and underscore also allowed.
     // Leave simple arguments unchanged.
-    $command = implode(' ', array_map(function ($item) {
-        return preg_match('#[^a-zA-Z0-9_-]#', $item) ? escapeshellarg($item) : $item;
-      }, $args));
+    $command = implode(
+      ' ',
+      array_map(
+        function ($item) {
+          if (preg_match('#[^a-zA-Z0-9_-]#', $item)) {
+            return escapeshellarg($item);
+          } else {
+            return $item;
+          }
+        },
+        $args
+      )
+    );
     $this->checkCommand($command);
 
     $sites = new Sites();

--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -38,7 +38,11 @@ class DrushCommand extends CommandWithSSH {
    *
    */
   public function __invoke($args, $assoc_args) {
-    $command = implode(' ', array_map('escapeshellarg', $args));
+    // Escape any argument that contains non-alphanumeric values (dash and underscore also allowed.
+    // Leave simple arguments unchanged.
+    $command = implode(' ', array_map(function ($item) {
+        return preg_match('#[^a-zA-Z0-9_-]#', $item) ? escapeshellarg($item) : $item;
+      }, $args));
     $this->checkCommand($command);
 
     $sites = new Sites();


### PR DESCRIPTION
Terminus was taking last argument only, and discarding the rest when calling Drush.

This might be too much shell-escaping, but it seems to work.
