### PR TITLE
Don't inject session id into every User;  `auth whoami` returns user profile

### DIFF
--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -91,10 +91,11 @@ class AuthCommand extends TerminusCommand {
    */
   public function whoami() {
     if (Session::getValue('user_uuid')) {
-      $this->output()->outputValue(
-        Session::getValue('user_uuid'),
-        'You are authenticated as'
-      );
+      $user = Session::getUser();
+      $user->fetch();
+
+      $data = $user->serialize();
+      $this->output()->outputRecord($data);
     } else {
       $this->failure('You are not logged in.');
     }

--- a/php/Terminus/Commands/CliCommand.php
+++ b/php/Terminus/Commands/CliCommand.php
@@ -3,6 +3,7 @@
 namespace Terminus\Commands;
 
 use Terminus;
+use Terminus\Session;
 use Terminus\SitesCache;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Models\Site;
@@ -76,7 +77,7 @@ class CliCommand extends TerminusCommand {
    * @subcommand console
    */
   public function console($args, $assoc_args) {
-    $user = new User();
+    $user = Session::getUser();
     if (isset($assoc_args['site'])) {
       $sitename = $assoc_args['site'];
       $site_id  = $this->sitesCache->findId($sitename);

--- a/php/Terminus/Commands/InstrumentsCommand.php
+++ b/php/Terminus/Commands/InstrumentsCommand.php
@@ -4,6 +4,7 @@ namespace Terminus\Commands;
 
 use Terminus;
 use Terminus\Auth;
+use Terminus\Session;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Models\User;
 
@@ -26,7 +27,7 @@ class InstrumentsCommand extends TerminusCommand {
    * @subcommand list
    */
   public function all($args, $assoc_args) {
-    $user        = new User();
+    $user        = Session::getUser();
     $instruments = $user->instruments->all();
     $data        = array();
     foreach ($instruments as $id => $instrument) {

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -4,6 +4,7 @@ namespace Terminus\Commands;
 
 use Terminus;
 use Terminus\Auth;
+use Terminus\Session;
 use Terminus\Helpers\Input;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Models\User;
@@ -30,7 +31,7 @@ class OrganizationsCommand extends TerminusCommand {
    * @subcommand list
    */
   public function all($args, $assoc_args) {
-    $user          = new User();
+    $user          = Session::getUser();
     $data          = array();
     $organizations = $user->getOrganizations();
     foreach ($organizations as $id => $org) {

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -5,6 +5,7 @@ namespace Terminus\Commands;
 use Terminus;
 use Terminus\Auth;
 use Terminus\Request;
+use Terminus\Session;
 use Terminus\Utils;
 use Terminus\Commands\TerminusCommand;
 use Terminus\Helpers\Input;
@@ -1447,7 +1448,7 @@ class SiteCommand extends TerminusCommand {
    *  terminus site set-instrument --site=sitename
    */
   public function setInstrument($args, $assoc_args) {
-    $user        = new User();
+    $user        = Session::getUser();
     $instruments = $user->instruments->getMemberList('id', 'label');
     if (!isset($assoc_args['instrument'])) {
       $instrument_id = Input::menu(
@@ -2021,7 +2022,7 @@ class SiteCommand extends TerminusCommand {
    * @return bool True if this organization is accessible
    */
   private function isOrgAccessible($org_id) {
-    $user  = new User();
+    $user  = Session::getUser();
     $org   = $user->organizations->get($org_id);
     $is_ok = is_object($org);
     return $is_ok;

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -44,7 +44,7 @@ class SitesCommand extends TerminusCommand {
    *   '~/.drush/pantheon.aliases.drushrc.php' will be used.
    */
   public function aliases($args, $assoc_args) {
-    $user     = new User();
+    $user     = Session::getUser();
     $print    = Input::optional(
       array(
         'key'     => 'print',

--- a/php/Terminus/Helpers/Input.php
+++ b/php/Terminus/Helpers/Input.php
@@ -3,6 +3,7 @@
 namespace Terminus\Helpers;
 
 use Terminus;
+use Terminus\Session;
 use Terminus\Utils;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Site;
@@ -357,7 +358,7 @@ class Input {
     if ($options['allow_none']) {
       $org_list = array('-' => 'None');
     }
-    $user          = new User();
+    $user          = Session::getUser();
     $organizations = $user->organizations->all();
     foreach ($organizations as $id => $org) {
       $org_data                  = $org->get('organization');

--- a/php/Terminus/Models/Collections/Sites.php
+++ b/php/Terminus/Models/Collections/Sites.php
@@ -29,7 +29,7 @@ class Sites extends TerminusCollection {
   public function __construct(array $options = array()) {
     parent::__construct($options);
     $this->sites_cache = new SitesCache();
-    $this->user        = new User();
+    $this->user        = Session::getUser();
   }
 
   /**

--- a/php/Terminus/Models/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Models/Collections/UserOrganizationMemberships.php
@@ -2,6 +2,8 @@
 
 namespace Terminus\Models\Collections;
 
+use Terminus\Models\Collections\TerminusCollection;
+use Terminus\Session;
 use Terminus\Models\User;
 use Terminus\Models\UserOrganizationMembership;
 
@@ -16,7 +18,7 @@ class UserOrganizationMemberships extends TerminusCollection {
   public function __construct($options = array()) {
     parent::__construct($options);
     if (!isset($this->user)) {
-      $this->user = new User();
+      $this->user = Session::getUser();
     }
   }
 

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -2,6 +2,8 @@
 
 namespace Terminus\Models;
 
+use Terminus\Session;
+use Terminus\Models\TerminusModel;
 use Terminus\Models\Collections\OrganizationSiteMemberships;
 use Terminus\Models\Collections\OrganizationUserMemberships;
 use Terminus\Models\Collections\Workflows;
@@ -33,7 +35,7 @@ class Organization extends TerminusModel {
   public function __construct($attributes = null, array $options = array()) {
     parent::__construct($attributes, $options);
     if (!isset($this->user)) {
-      $this->user = new User();
+      $this->user = Session::getUser();
     }
     $this->site_memberships = new OrganizationSiteMemberships(
       array(
@@ -49,7 +51,6 @@ class Organization extends TerminusModel {
         'owner_type'   => 'organization',
       )
     );
-    //$this->user_memberships = new OrganizationUserMemberships($params);
     $this->workflows = new Workflows(
       array(
         'owner'      => $this,

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -82,8 +82,21 @@ abstract class TerminusModel {
       $options
     );
 
-    $this->attributes = $results['data'];
+    $data = $results['data'];
+    $data = $this->parseAttributes($data);
+    $this->attributes = $data;
+
     return $this;
+  }
+
+  /**
+   * Modify response data between fetch and assignment
+   *
+   * @param [object] $data attributes received from API response
+   * @return [object] $data
+   */
+  public function parseAttributes($data) {
+    return $data;
   }
 
   /**

--- a/php/Terminus/Session.php
+++ b/php/Terminus/Session.php
@@ -3,6 +3,8 @@
 namespace Terminus;
 
 use Terminus;
+use Terminus\Request;
+use Terminus\Models\User;
 
 class Session {
   /**
@@ -111,6 +113,17 @@ class Session {
     foreach ($data as $k => $v) {
       $session->set($k, $v);
     }
+  }
+
+  /**
+   * Returns a user with the current session user id
+   *
+   * @return [user] $session user
+   */
+  public static function getUser() {
+    $user_uuid = Session::getValue('user_uuid');
+    $user = new User((object)array('id' => $user_uuid));
+    return $user;
   }
 
 }

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -25,7 +25,7 @@ Feature: Authorization command
     When I run "terminus auth whoami"
     Then I should get:
     """
-    You are authenticated as: [[user_uuid]]
+    [[user_uuid]]
     """
 
   @vcr auth_logout

--- a/tests/fixtures/auth_whoami
+++ b/tests/fixtures/auth_whoami
@@ -30,7 +30,7 @@
 -
     request:
         method: GET
-        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/profile'
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8'
         headers:
             Host: onebox
             Accept: null


### PR DESCRIPTION
Fixes #745.

Discovered almost everywhere that it assumes that instantiating a `User` should imply the User for the session. I cleaned that up, though it seems like some memberships (like UserOrganizationMemberships) also assumes the memberships are for the session. Instead, we should be explicit about walking these relationships down, e.g. `$sessionUser->organizationMemberships->etc` instead of instantiating  `OrganizationMemberships` and expecting it to belong to the sessionUser.
