### PR TITLE
Fixed headers in session login, Deduplicated login header in Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 
 ### Fixed
 - Missing creation dates in site data while using organizations site list command will no longer cause errors. (#766)
+- Fixed headers in session token-based login. (#764)
 
 ## [0.10.0] - 2015-12-15
 ### Added

--- a/php/Terminus/Auth.php
+++ b/php/Terminus/Auth.php
@@ -118,8 +118,10 @@ class Auth {
    */
   public function logInViaSessionToken($token) {
     $options = array(
-      'headers' => array('Content-type' => 'application/json'),
-      'cookies' => array('X-Pantheon-Session' => $token),
+      'headers' => array(
+        'Content-type' => 'application/json',
+        'Cookie'       => "X-Pantheon-Session=$token",
+      )
     );
     $this->logger->info('Validating session token');
     $response = $this->request->request('user', '', '', 'GET', $options);


### PR DESCRIPTION
There was an error wherein the session token-setting was never setting the correct request header, and so Request was setting it with the current user session. This caused sessions to continue for a previous user.
