### PR TITLE
Missing creation dates in site data while using organizations site list command will no longer cause errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Removed duplicative Terminus::menu() in favor of Terminus\Helpers\Input::menu. (#768)
 - Moved Terminus::line() to Terminus\Outputters\Outputter. (#768)
 
+### Fixed
+- Missing creation dates in site data while using organizations site list command will no longer cause errors. (#766)
+
 ## [0.10.0] - 2015-12-15
 ### Added
 - New command `workflows show` displays details about a workflow (#687)

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -163,7 +163,10 @@ class OrganizationsCommand extends TerminusCommand {
               $data_array[$key] = $site->$key;
             }
           }
-          $data_array['created'] = date('Y-m-dTH:i:s', $data_array['created']);
+          $data_array['created'] = date(
+            'Y-m-dTH:i:s',
+            strtotime($data_array['created'])
+          );
           $data[] = $data_array;
         }
         $this->output()->outputRecordList($data);

--- a/tests/features/organizations_sites.feature
+++ b/tests/features/organizations_sites.feature
@@ -8,10 +8,8 @@ Feature: Organization sites
     Given I am authenticated
     And a site named "[[test_site_name]]" belonging to "[[enterprise_org_name]]"
     When I run "terminus organizations sites list --org=[[enterprise_org_name]]"
-    Then I should get:
-    """
-    [[test_site_name]]
-    """
+    Then I should get: "[[test_site_name]]"
+    And I should not get: "PHP Notice"
 
   @vcr organizations_sites_add
   Scenario: Add a site to an organization


### PR DESCRIPTION
Closes #765 
