### PR TITLE
Fixed site backups get --latest bug wherein it was returning the oldest backup instead of the latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ### Fixed
 - Missing creation dates in site data while using organizations site list command will no longer cause errors. (#766)
 - Fixed headers in session token-based login. (#764)
-- `sites backups load --element=database` no longer errs upon calling the renamed function "backup". (#767)
+- `site backups load --element=database` no longer errs upon calling the renamed function "backup". (#767)
+- `site backups get --latest` bug wherein it was returning the oldest backup, rather than the most recent. (#770)
 
 ## [0.10.0] - 2015-12-15
 ### Added

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1910,7 +1910,7 @@ class SiteCommand extends TerminusCommand {
       $backups = $env->backups->getFinishedBackups($element);
 
       if ($latest) {
-        $backup = array_pop($backups);
+        $backup = array_shift($backups);
       } else {
         $context = array(
           'site' => $site->get('name'),

--- a/php/Terminus/Models/Collections/Backups.php
+++ b/php/Terminus/Models/Collections/Backups.php
@@ -180,12 +180,21 @@ class Backups extends TerminusCollection {
       );
     }
 
-    $backups = array_filter(
+    $finished_backups = array_filter(
       $all_backups,
       function($backup) {
         return $backup->backupIsFinished();
       }
     );
+    $ordered_backups  = array();
+    foreach ($finished_backups as $id => $backup) {
+      $ordered_backups[$id] = $backup->get('start_time');
+    }
+    arsort($ordered_backups);
+    $backups = array();
+    foreach ($ordered_backups as $id => $start_time) {
+      $backups[] = $finished_backups[$id];
+    }
 
     return $backups;
   }

--- a/tests/features/site_backups_list.feature
+++ b/tests/features/site_backups_list.feature
@@ -17,7 +17,7 @@ Feature: List Backups for a Site
   Scenario: Show only the latest backup for an environment
     When I run "terminus site backups list --site=[[test_site_name]] --env=dev --latest --format=json"
     Then I should have "1" records
-    And I should get: "files.tar.gz"
+    And I should get: "database.sql.gz"
 
   @vcr site_backups_list
   Scenario: Filter backups by element


### PR DESCRIPTION
Closes #759
