### PR TITLE
Added commands to build script in order to remove dev Composer packages before building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Moved Terminus::prompt(), Terminus::promptSecret() to Terminus\Helpers\Input. (#768)
 - Removed duplicative Terminus::menu() in favor of Terminus\Helpers\Input::menu. (#768)
 - Moved Terminus::line() to Terminus\Outputters\Outputter. (#768)
+- Removed dev packages from PHAR file. (#774)
 - Updated Symfony to version 3.0.0. Minimum PHP version required to run Terminus is now 5.5.9. (#772)
 
 ### Fixed

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,10 @@ set -ex
 
 TERMINUS_BIN_DIR=${TERMINUS_BIN_DIR-builds}
 
+# Install Composer nearby for use
+curl -sS https://getcomposer.org/installer | php -- --filename=$TERMINUS_BIN_DIR/composer.phar
+# Remove dev packages for massive PHAR size reduction
+php $TERMINUS_BIN_DIR/composer.phar install --no-dev
 # the Behat test suite will pick up the executable found in $TERMINUS_BIN_DIR
 mkdir -p $TERMINUS_BIN_DIR
 php -dphar.readonly=0 utils/make-phar.php terminus.phar --quiet
@@ -11,3 +15,4 @@ mv terminus.phar $TERMINUS_BIN_DIR/terminus.phar
 cp $TERMINUS_BIN_DIR/terminus.phar $TERMINUS_BIN_DIR/terminus
 chmod +x $TERMINUS_BIN_DIR/terminus.phar
 chmod +x $TERMINUS_BIN_DIR/terminus
+php $TERMINUS_BIN_DIR/composer.phar update

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,8 @@ set -ex
 
 TERMINUS_BIN_DIR=${TERMINUS_BIN_DIR-builds}
 
+# Regenerate the internal documentation
+php utils/make-docs.php
 # Install Composer nearby for use
 curl -sS https://getcomposer.org/installer | php -- --filename=$TERMINUS_BIN_DIR/composer.phar
 # Remove dev packages for massive PHAR size reduction
@@ -16,3 +18,4 @@ cp $TERMINUS_BIN_DIR/terminus.phar $TERMINUS_BIN_DIR/terminus
 chmod +x $TERMINUS_BIN_DIR/terminus.phar
 chmod +x $TERMINUS_BIN_DIR/terminus
 php $TERMINUS_BIN_DIR/composer.phar update
+rm $TERMINUS_BIN_DIR/composer.phar


### PR DESCRIPTION
This results in a 4.5MB Terminus archive instead of 12.5MB. Seems like a clear win.

[terminus.phar.zip](https://github.com/pantheon-systems/cli/files/70115/terminus.phar.zip)
