### PR TITLE
Fixed spurious warning about not having site aliases when none of their domains use 'pantheon.io'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Fixed headers in session token-based login. (#764)
 - `site backups load --element=database` no longer errs upon calling the renamed function "backup". (#767)
 - `site backups get --latest` bug wherein it was returning the oldest backup, rather than the most recent. (#770)
+- `sites aliases` will no longer tell you you have no sites when none of your domains include 'pantheon.io'. (#782)
 
 ## [0.10.0] - 2015-12-15
 ### Added

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -76,7 +76,7 @@ class SitesCommand extends TerminusCommand {
     if ($file_exists) {
       $message = 'Pantheon aliases updated';
     }
-    if (strpos($content, 'pantheon.io') === false) {
+    if (strpos($content, 'array') === false) {
       $message .= ', although you have no sites';
     }
     $this->log()->info($message);


### PR DESCRIPTION
Closes #778 
