### PR TITLE
Cut Travis' workload in half

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ script:
 
 after_success: ./scripts/package.sh
 
+branches:
+  only:
+    - master
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Prevent duplicate builds from running on pull requests by only
triggering branch builds on master.
