### PR TITLE
Adds list and delete commands for machine tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Added `--email=<email>` argument to `auth login` to retireve saved machine tokens. (#825)
 - Added `Environment#getParentEnvironment()`. (#831)
 - Added `Commits` collection and `Commit` model. (#831)
+- Added `machine-token list` and `machine-token delete` commands. (#798)
 
 ### Changed
 - `drush` and `wp` commands now issue a warning to change your connection mode to SFTP if it is in Git mode. (#807)

--- a/php/Terminus/Commands/MachineTokensCommand.php
+++ b/php/Terminus/Commands/MachineTokensCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Terminus\Commands;
+
+use Terminus;
+use Terminus\Auth;
+use Terminus\Session;
+use Terminus\Commands\TerminusCommand;
+use Terminus\Models\User;
+use Terminus\Helpers\Input;
+
+/**
+ * Show information for your Pantheon machine tokens
+ */
+class MachineTokensCommand extends TerminusCommand {
+
+  /**
+   * Instantiates object, ensures login
+   */
+  public function __construct() {
+    Auth::ensureLogin();
+    parent::__construct();
+  }
+
+  /**
+   * Show a list of your macnine tokens on Pantheon
+   *
+   * @subcommand list
+   * @alias show
+   */
+  public function index($args, $assoc_args) {
+    $user        = Session::getUser();
+
+    $machine_tokens = $user->machine_tokens->all();
+    $data        = array();
+    foreach ($machine_tokens as $id => $machine_token) {
+      $data[] = array(
+        'id'          => $machine_token->get('id'),
+        'device_name' => $machine_token->get('device_name'),
+      );
+    }
+
+    if (count($data) == 0) {
+      $this->log()->warning('You have no machine tokens.');
+    }
+
+    $this->output()->outputRecordList(
+      $data,
+      array(
+        'id'          => 'ID',
+        'device_name' => 'Device Name',
+      )
+    );
+  }
+
+  /**
+   * Delete a machine token from your account
+   *
+   * ## OPTIONS
+   * [--machine-token-id=<id>]
+   * : UUID or name of the site you want to delete
+   *
+   * [--force]
+   * : to skip the confirmations
+   */
+  public function delete($args, $assoc_args) {
+    $user        = Session::getUser();
+
+    $id = $assoc_args['machine-token-id'];
+    if (empty($id)) {
+      $this->failure(
+        'You must specify a machine token id to delete.'
+      );
+    }
+
+    // Find the token
+    $machine_token = $user->machine_tokens->get($assoc_args['machine-token-id']);
+    if (empty($machine_token)) {
+      $this->failure(
+        'There are no machine tokens with the id {id}.',
+        array('id' => $id)
+      );
+    }
+    $name = $machine_token->get('device_name');
+
+    if (!isset($assoc_args['force']) && (!Terminus::getConfig('yes'))) {
+      //If the force option isn't used, we'll ask you some annoying questions
+      Input::confirm(
+        array(
+          'message' => 'Are you sure you want to delete %s?',
+          'context' => $name
+        )
+      );
+    }
+    $this->log()->info(
+      'Deleting {name} ...',
+      array('name' => $name)
+    );
+    $response = $machine_token->delete();
+    if ($response['status_code'] == 200) {
+      $this->log()->info(
+        'Deleted {name}!',
+        array('name' => $name)
+      );
+    } else {
+      $this->failure(
+        'There was an problem deleting the machine token.'
+      );
+    }
+  }
+
+}
+
+Terminus::addCommand('machine-tokens', 'MachineTokensCommand');

--- a/php/Terminus/Models/Collections/MachineTokens.php
+++ b/php/Terminus/Models/Collections/MachineTokens.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Terminus\Models\Collections;
+
+use Terminus\Models\MachineToken;
+
+class MachineTokens extends TerminusCollection {
+  protected $user;
+
+  /**
+   * Give the URL for collection data fetching
+   *
+   * @return string URL to use in fetch query
+   */
+  protected function getFetchUrl() {
+    $url = 'users/' . $this->user->id . '/machine_tokens';
+    return $url;
+  }
+
+  /**
+   * Names the model-owner of this collection
+   *
+   * @return string
+   */
+  protected function getOwnerName() {
+    $owner_name = 'user';
+    return $owner_name;
+  }
+
+}

--- a/php/Terminus/Models/MachineToken.php
+++ b/php/Terminus/Models/MachineToken.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Terminus\Models;
+
+class MachineToken extends TerminusModel {
+
+  /**
+   * Deletes machine token
+   *
+   * @return array
+   */
+  public function delete() {
+    $response = $this->request->simpleRequest(
+      'users/' . $this->user->id . '/machine_tokens/' . $this->get('id'),
+      array('method' => 'delete')
+    );
+    return $response;
+  }
+
+}

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -5,6 +5,7 @@ namespace Terminus\Models;
 use Terminus\Models\Collections\UserOrganizationMemberships;
 use Terminus\Models\TerminusModel;
 use Terminus\Models\Collections\Instruments;
+use Terminus\Models\Collections\MachineTokens;
 use Terminus\Models\Collections\Workflows;
 use Terminus\Session;
 
@@ -18,6 +19,11 @@ class User extends TerminusModel {
    * @var Instruments
    */
   protected $instruments;
+
+  /**
+   * @var Instruments
+   */
+  protected $machine_tokens;
 
   /**
    * @var Workflows
@@ -52,6 +58,7 @@ class User extends TerminusModel {
       array('owner' => $this)
     );
     $this->instruments   = new Instruments(array('user' => $this));
+    $this->machine_tokens= new MachineTokens(array('user' => $this));
     $this->organizations = new UserOrganizationMemberships(
       array('user' => $this)
     );

--- a/php/utils.php
+++ b/php/utils.php
@@ -269,7 +269,7 @@ function loadCommand($name) {
   $path = sprintf(
     '%s/php/Terminus/Commands/%sCommand.php',
     TERMINUS_ROOT,
-    ucwords($name)
+    makeCamelCase($name)
   );
 
   if (is_readable($path)) {
@@ -313,6 +313,22 @@ function loadDependencies() {
  */
 function loadFile($path) {
   require $path;
+}
+
+/**
+ * Converts a word to camel case
+ *
+ * @param string $string    Word to change to camel case
+ * @param string $delimiter Character to split words up on
+ * @return string
+ */
+function makeCamelCase($string, $delimiter = '-') {
+  $words       = explode($delimiter, $string);
+  $camel_cased = '';
+  foreach ($words as $key => $word) {
+    $camel_cased .= ucwords($word);
+  }
+  return $camel_cased;
 }
 
 /**

--- a/tests/config/behat.yml
+++ b/tests/config/behat.yml
@@ -9,6 +9,7 @@ default:
               username:                'devuser@pantheon.io'
               user_uuid:               '25069e79-eae7-4d41-8925-1f728a114cb8'
               password:                'password1'
+              machine_token:           'EAJ08XqjxTbXD125qU9L5HSqlDdl9UnWHqpdB1nmt5f1x'
               host:                    'onebox'
               vcr_mode:                'new_episodes'
               test_site_name:          'behat-tests'
@@ -16,6 +17,8 @@ default:
               other_user:              'sara@getpantheon.com'
               php_site_domain:         'onebox.pantheon.io'
               payment_instrument_uuid: '8558e04f-3674-481e-b448-bccff73cb430'
+              machine_token_id:        'dcr_NVvFVvHaPrQRfMZX'
+              machine_token_device:    'Terminus on My Laptop'
               enterprise_org_uuid:     'bf200cbe-8995-4891-b5d4-1a8bdc292905'
               enterprise_org_name:     'EnterpriseOrg'
     ci:
@@ -33,6 +36,8 @@ default:
               other_user:              'sara@getpantheon.com'
               php_site_domain:         'onebox.pantheon.io'
               payment_instrument_uuid: '8558e04f-3674-481e-b448-bccff73cb430'
+              machine_token_id:        'dcr_NVvFVvHaPrQRfMZX'
+              machine_token_device:    'Terminus on My Laptop'
               enterprise_org_uuid:     'bf200cbe-8995-4891-b5d4-1a8bdc292905'
               enterprise_org_name:     'EnterpriseOrg'
     ci:

--- a/tests/features/machine-tokens.feature
+++ b/tests/features/machine-tokens.feature
@@ -1,0 +1,31 @@
+Feature: Machine Tokens command
+  In order to manage my devices
+  As a user
+  I need to be able to view and delete my machine tokens.
+
+  @vcr machine-tokens_list
+  Scenario: List machine tokens
+    Given I log in via machine token
+    When I run "terminus machine-tokens list"
+    Then I should get:
+    """
+    [[machine_token_id]]
+    """
+
+  @vcr machine-tokens_list_empty
+  Scenario: List machine tokens
+    Given I log in via machine token
+    When I run "terminus machine-tokens list"
+    Then I should get:
+    """
+    You have no machine tokens.
+    """
+
+  @vcr machine-tokens_delete
+  Scenario: Delete machine token
+    Given I log in via machine token
+    When I run "terminus machine-tokens delete --machine-token-id=[[machine_token_id]] --yes"
+    Then I should get:
+    """
+    Deleted [[machine_token_device]]!
+    """

--- a/tests/fixtures/machine-tokens_delete
+++ b/tests/fixtures/machine-tokens_delete
@@ -1,0 +1,130 @@
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: 'onebox'
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            verify: '1'
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"EAJ08XqjxTbXD125qU9L5HSqlDdl9UnWHqpdB1nmt5f1x","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: a7bbe360-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Vary: Accept-Encoding
+            Date: 'Wed, 13 Jan 2016 17:32:46 GMT'
+            Connection: keep-alive
+        body: '{"session":"25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe","expires_at":1455125566,"user_id":"25069e79-eae7-4d41-8925-1f728a114cb8"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/machine_tokens'
+        headers:
+            Host: 'onebox'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: '1'
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: aa48a8c0-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            transfer-encoding: chunked
+            date: 'Wed, 13 Jan 2016 17:32:49 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            connection: close
+            Content-Length: '143'
+            ETag: 'W/"kVEL/NW/uXzXhims6IO/aA=="'
+            Vary: Accept-Encoding
+        body: '[{"id": "dcr_NVvFVvHaPrQRfMZX", "device_name": "Terminus on My Laptop"}, {"id": "dcr_r6mnMfqoxrKlghGl", "device_name": "Terminus on CircleCI"}]'
+-
+    request:
+        method: DELETE
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/machine_tokens/dcr_NVvFVvHaPrQRfMZX'
+        headers:
+            Host: 'onebox'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: '1'
+            method: delete
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: 622790d0-ba23-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            transfer-encoding: chunked
+            date: 'Wed, 13 Jan 2016 18:28:05 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            connection: close
+            Content-Length: '5'
+            Vary: Accept-Encoding
+        body: '"OK."'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            date: 'Wed, 13 Jan 2016 18:28:05 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '855'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 0997b950-61a3-11e5-a139-c95d7f8f209a
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"357-deeb98da"'
+            Vary: Accept-Encoding
+        body: '{"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 52, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 55, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 55, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}'

--- a/tests/fixtures/machine-tokens_list
+++ b/tests/fixtures/machine-tokens_list
@@ -1,0 +1,92 @@
+
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: 'onebox'
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            verify: '1'
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"EAJ08XqjxTbXD125qU9L5HSqlDdl9UnWHqpdB1nmt5f1x","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: a7bbe360-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Vary: Accept-Encoding
+            Date: 'Wed, 13 Jan 2016 17:32:46 GMT'
+            Connection: keep-alive
+        body: '{"session":"a4308a68-e0e8-45be-aacd-f49933f37406:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe","expires_at":1455125566,"user_id":"25069e79-eae7-4d41-8925-1f728a114cb8"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/machine_tokens'
+        headers:
+            Host: 'onebox'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer a4308a68-e0e8-45be-aacd-f49933f37406:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer a4308a68-e0e8-45be-aacd-f49933f37406:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: '1'
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: aa48a8c0-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            transfer-encoding: chunked
+            date: 'Wed, 13 Jan 2016 17:32:49 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            connection: close
+            Content-Length: '143'
+            ETag: 'W/"kVEL/NW/uXzXhims6IO/aA=="'
+            Vary: Accept-Encoding
+        body: '[{"id": "dcr_NVvFVvHaPrQRfMZX", "device_name": "Terminus on My Laptop"}, {"id": "dcr_r6mnMfqoxrKlghGl", "device_name": "Terminus on CircleCI"}]'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8'
+        headers:
+            Host: onebox
+            Accept: null
+            User-Agent: 'Terminus/0.8.0 (php_version=5.5.27&script=boot-fs.php)'
+            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:08cf3ac0-61a3-11e5-a354-bc764e117665:wjBJ8JOSqT3QYx3C9imF5'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Wed, 23 Sep 2015 03:27:37 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '855'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 0997b950-61a3-11e5-a139-c95d7f8f209a
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"357-deeb98da"'
+            Vary: Accept-Encoding
+        body: '{"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 52, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 55, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 55, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}'

--- a/tests/fixtures/machine-tokens_list_empty
+++ b/tests/fixtures/machine-tokens_list_empty
@@ -1,0 +1,99 @@
+
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: 'onebox'
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            verify: '1'
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"EAJ08XqjxTbXD125qU9L5HSqlDdl9UnWHqpdB1nmt5f1x","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: a7bbe360-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Vary: Accept-Encoding
+            Date: 'Wed, 13 Jan 2016 17:32:46 GMT'
+            Connection: keep-alive
+        body: '{"session":"25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe","expires_at":1455125566,"user_id":"25069e79-eae7-4d41-8925-1f728a114cb8"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/machine_tokens'
+        headers:
+            Host: 'onebox'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: '1'
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            X-Pantheon-Trace-Id: aa48a8c0-ba1b-11e5-8741-6f31d4be4a35
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            transfer-encoding: chunked
+            date: 'Wed, 13 Jan 2016 17:32:49 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            connection: close
+            Content-Length: '143'
+            ETag: 'W/"kVEL/NW/uXzXhims6IO/aA=="'
+            Vary: Accept-Encoding
+        body: '[]'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.10.1 (php_version=5.5.26&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            headers: 'Bearer 25069e79-eae7-4d41-8925-1f728a114cb8:a9298202-ba1b-11e5-863c-bc764e105b01:UQoX70h0ZoX3LNyGSlkXe'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            date: 'Wed, 13 Jan 2016 18:28:05 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '855'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 0997b950-61a3-11e5-a139-c95d7f8f209a
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            ETag: 'W/"357-deeb98da"'
+            Vary: Accept-Encoding
+        body: '{"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 52, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 55, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 55, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}'

--- a/tests/unit_tests/test-utils.php
+++ b/tests/unit_tests/test-utils.php
@@ -168,6 +168,12 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue($is_included);
   }
 
+  public function testMakeCamelCase() {
+    $string      = 'camel-case';
+    $camel_cased = Utils\makeCamelCase($string);
+    $this->assertEquals($camel_cased, 'CamelCase');
+  }
+
   public function testParseUrl() {
     $url = 'https://pantheon.io';
     $parts = Utils\parseUrl($url);


### PR DESCRIPTION
Adds:

`terminus machinetokens list`

and

`terminus machinetokens delete --machine-token-id=<id> [--force]`

For managing machine tokens from within Terminus.

Still todo: This should probably issue some sort of warning if you attempt to delete the machine token you are using in the current Terminus session. If you delete the active machine token your Terminus session you will be logged out when your current access token expires.
