### PR TITLE
Rename 'refresh tokens' to 'machine tokens'

### DIFF
--- a/php/Terminus/Endpoint.php
+++ b/php/Terminus/Endpoint.php
@@ -8,11 +8,11 @@ namespace Terminus;
  **/
 class Endpoint {
   public $patterns = array(
-    'deprecated'   => '/Terminus.php?%s=%s',
-    'private'      => '/api/%s/%s',
-    'public'       => '/api/%s',
-    'login'        => '/api/authorize',
-    'auth/refresh' => '/auth/refresh',
+    'deprecated'  => '/Terminus.php?%s=%s',
+    'private'     => '/api/%s/%s',
+    'public'      => '/api/%s',
+    'login'       => '/api/authorize',
+    'authorize'   => '/api/authorize/machine-token',
   );
 
   private $public_realms = array(
@@ -61,8 +61,8 @@ class Endpoint {
       $this->target = 'login';
     }
 
-    if (isset($args['realm']) && ($args['realm'] == 'auth/refresh')) {
-      $this->target = 'auth/refresh';
+    if (isset($args['realm']) && ($args['realm'] == 'authorize')) {
+      $this->target = 'authorize';
     }
 
     //A substiution array to pass to the vsprintf

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -46,25 +46,25 @@ Feature: Authorization command
     You are authenticated as: [[user_uuid]]
     """
 
-  #Scenario: Logging in via refresh token
-    #@vcr auth_login_refresh
-    #When I run "terminus auth login --refresh=[[refresh_token]]"
+  #Scenario: Logging in via machine token
+    #@vcr auth_login_machine_token
+    #When I run "terminus auth login --machine-token=[[machine_token]]"
     #Then I should get:
     #"""
     #Logged in as [[user_uuid]]
     #"""
 
-  #Scenario: Failing to log in via invalid refresh token
-    #@vcr auth_login_refresh_invalid
-    #When I run "terminus auth login --refresh=invalid"
+  #Scenario: Failing to log in via invalid machine token
+    #@vcr auth_login_machine_token_invalid
+    #When I run "terminus auth login --machine-token=invalid"
     #Then I should get:
     #"""
     #Authorization failed
     #"""
 
   #Scenario: Logging in successfully after session has expired
-    #@vcr auth_login_refresh_expired
-    #When I log in via refresh token
+    #@vcr auth_login_machine_token_expired
+    #When I log in via machine token
     #And I expire my session
     #And I list the sites
     #Then I should get:

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -521,16 +521,16 @@ class FeatureContext implements Context {
 
   /**
    * Logs in user
-   * @When /^I log in via refresh token "([^"]*)"$/
-   * @When /^I log in via refresh token$/
+   * @When /^I log in via machine token "([^"]*)"$/
+   * @When /^I log in via machine token$/
    *
-   * @param [string] $token An Auth0 refresh token
+   * @param [string] $token A Pantheon machine token
    * @return [void]
    */
-  public function iLogInViaRefreshToken(
-      $token = '[[refresh_token]]'
+  public function iLogInViaMachineToken(
+      $token = '[[machine_token]]'
   ) {
-    $this->iRun("terminus auth login --refresh=$token");
+    $this->iRun("terminus auth login --machine-token=$token");
   }
 
   /**


### PR DESCRIPTION
To match the language policy. Also adds a client param to machine token authentication to help the API identify which client to issue authentication for (without parsing User-Agent)
