### PR TITLE
Added a warning to drush and wp commands if run in git mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - New command `site solr disable` to disable Solr indexing. (#814)
 
 ### Changed
+- `drush` and `wp` commands now issue a warning to change your connection mode to SFTP if it is in Git mode. (#807)
 - Removed field name in reply of `site info --field=<field_name>`. (#811)
 - `site redis clear` no longer complains of an inability to find hosts. (#813)
 

--- a/php/Terminus/Commands/CommandWithSSH.php
+++ b/php/Terminus/Commands/CommandWithSSH.php
@@ -56,6 +56,22 @@ abstract class CommandWithSSH extends TerminusCommand {
   }
 
   /**
+   * Checks the site's mode and suggests SFTP if it is not set.
+   *
+   * @param Environment $environment Environment object to check mode of
+   * @return void
+   */
+  protected function checkConnectionMode($environment) {
+    if ($environment->getConnectionMode() != 'sftp') {
+      $message  = 'Note: This environment is in read-only Git mode. If you ';
+      $message .= 'want to make changes to the codebase of this site ';
+      $message .= '(e.g. updating modules or plugins), you will need to ';
+      $message .= 'toggle into read/write SFTP mode first.';
+      $this->log()->warning($message);
+    }
+  }
+
+  /**
    * Verifies that there is only one argument given and no extaneous params
    *
    * @param string[] $args       Command(s) given in the command line
@@ -142,6 +158,9 @@ abstract class CommandWithSSH extends TerminusCommand {
     }
 
     $env_id = Input::env(array('args' => $assoc_args, 'site' => $site));
+    if (!in_array($env_id, ['test', 'live'])) {
+      $this->checkConnectionMode($site->environments->get($env_id));
+    }
 
     $elements = array(
       'site'    => $site,


### PR DESCRIPTION
Closes #141 

This adds a few API calls to every Drush or WP-CLI use. Might it be better if we issue an info log to advise?
