### PR TITLE
Removed "Backup URL:" label from the single-record output of `site backups get`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - `TERMINUS_USER` will be used to locate a matching saved machine token before user/password login is attempted. (#825)
 - If only one saved token is present, `auth login` will use it when it has no other arguments. (#825)
 - If a `drush` or `wp` command exits with any status except for 0, Terminus now exits with that status. (#827)
+- Removed "Backup URL:" label from the single-record output of `site backups get`. (#828)
 
 ### Fixed
 - Fixed bug in Input#orgId. (#812)

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -87,7 +87,7 @@ class SiteCommand extends TerminusCommand {
           break;
       case 'get':
         $url = $this->getBackup($assoc_args);
-        $this->output()->outputValue($url, 'Backup URL');
+        $this->output()->outputValue($url);
           break;
       case 'load':
         $this->loadBackup($assoc_args);


### PR DESCRIPTION
Closes #213 (See the last comment. The rest has already been changed.)
