### PR TITLE
Added site new-relic enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - New command `site solr enable` to enable Solr indexing. (#814)
 - New command `site solr disable` to disable Solr indexing. (#814)
 - Added `--email=<email>` argument to `auth login` to retireve saved machine tokens. (#825)
+- Added `site new-relic enable` to enable New Relic. (#830)
 
 ### Changed
 - `drush` and `wp` commands now issue a warning to change your connection mode to SFTP if it is in Git mode. (#807)
@@ -20,6 +21,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - If only one saved token is present, `auth login` will use it when it has no other arguments. (#825)
 - If a `drush` or `wp` command exits with any status except for 0, Terminus now exits with that status. (#827)
 - Removed "Backup URL:" label from the single-record output of `site backups get`. (#828)
+- The command that was `site new-relic` has become `site new-relic info`. (#830)
 
 ### Fixed
 - Fixed bug in Input#orgId. (#812)

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1270,18 +1270,30 @@ class SiteCommand extends TerminusCommand {
    *
    * ## OPTIONS
    *
+   * <enable|info>
+   * : Options are enable and info.
+   *
    * [--site=<site>]
-   * : site for which to retreive notifications
+   * : Site for which to access New Relic
    *
    * @subcommand new-relic
    */
   public function newRelic($args, $assoc_args) {
-    $site = $this->sites->get(Input::siteName(array('args' => $assoc_args)));
-    $data = $site->newRelic();
-    if (!empty($data->account)) {
-      $this->output()->outputRecord($data->account);
-    } else {
-      $this->log()->warning('New Relic is not enabled.');
+    $action = array_shift($args);
+    $site = $this->sites->get(Input::siteName(['args' => $assoc_args]));
+    switch ($action) {
+      case 'enable':
+        $site->enableNewRelic(); 
+          break;
+      default:
+      case 'info':
+        $data = $site->getNewRelicData();
+        if (!empty($data->account)) {
+          $this->output()->outputRecord($data->account);
+        } else {
+          $this->log()->warning('New Relic is not enabled.');
+        }
+          break;
     }
   }
 

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -3,6 +3,7 @@
 namespace Terminus\Models;
 
 use Terminus;
+use Terminus\Session;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Organization;
 use Terminus\Models\TerminusModel;
@@ -299,11 +300,12 @@ class Site extends TerminusModel {
    * @return array
    */
   public function enableNewRelic() {
-    $response = $this->request->simpleRequest(
+    $enable = $this->request->simpleRequest(
       'sites/' . $this->get('id') . '/new-relic',
       ['method' => 'put']
     );
-    return (array)$response['data'];
+    $this->convergeBindings();
+    return (array)$deploy['data'];
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -42,6 +42,11 @@ class Site extends TerminusModel {
   /**
    * @var array
    */
+  private $addons;
+
+  /**
+   * @var array
+   */
   private $features;
 
   /**
@@ -341,6 +346,29 @@ class Site extends TerminusModel {
       return $this->attributes->$attribute;
     }
     return null;
+  }
+
+  /**
+   * Returns the add-ons for a site
+   *
+   * @param string $addon The title of a specific add-on to check for
+   * @return string[]|string
+   */
+  public function getAddons($addon = null) {
+    if (!isset($this->addons)) {
+      $response = $this->request->simpleRequest(
+        sprintf('sites/%s/add-ons', $this->get('id'))
+      );
+      $addons = [];
+      foreach ($response['data'] as $addon) {
+        $addons[$addon->id] = (array)$addon;
+      }
+      $this->addons = $addons;
+    }
+    if (isset($this->addons[$addon])) {
+      return $this->addons[$addon];
+    }
+    return $this->addons;
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -294,6 +294,19 @@ class Site extends TerminusModel {
   }
 
   /**
+   * Enables New Relic
+   *
+   * @return array
+   */
+  public function enableNewRelic() {
+    $response = $this->request->simpleRequest(
+      'sites/' . $this->get('id') . '/new-relic',
+      ['method' => 'put']
+    );
+    return (array)$response['data'];
+  }
+
+  /**
    * Enables Redis caching
    *
    * @return array
@@ -388,6 +401,18 @@ class Site extends TerminusModel {
       return $this->features[$feature];
     }
     return null;
+  }
+
+  /**
+   * Retrieve New Relic Info
+   *
+   * @return \stdClass
+   */
+  public function getNewRelicData() {
+    $response = $this->request->simpleRequest(
+      'sites/' . $this->get('id') . '/new-relic'
+    );
+    return $response['data'];
   }
 
   /**
@@ -551,18 +576,6 @@ class Site extends TerminusModel {
     } else {
       return $info;
     }
-  }
-
-  /**
-   * Retrieve New Relic Info
-   *
-   * @return \stdClass
-   */
-  public function newRelic() {
-    $response = $this->request->simpleRequest(
-      'sites/' . $this->get('id') . '/new-relic'
-    );
-    return $response['data'];
   }
 
   /**


### PR DESCRIPTION
I tried to add the ability to enable New Relic the [same way the Dashboard does](https://github.com/pantheon-systems/dashboard/blob/master/app/workshops/site/views/admin_pages/add_ons_view.coffee#L67), but it's not working. Request is 500 on production, 404 on Onebox (as with Dashboard). Do you have any idea what I'm doing wrong, @bensheldon?

It also seems impossible to disable New Relic once enabled, right? API didn't have a DELETE response.
