### PR TITLE
Make Request::$blacklist static

### DIFF
--- a/php/Terminus/Request.php
+++ b/php/Terminus/Request.php
@@ -26,7 +26,7 @@ class Request {
    * @var array
    * TODO: Move this logic to the logger
    */
-  protected $blacklist = array('password');
+  protected static $blacklist = array('password');
 
   /**
    * Download file from target URL


### PR DESCRIPTION
When a Request throws a `\GuzzleHttp\Exception\RequestException`, the try/catch block attempts to filter the request using `self::$blacklist`, but because `blacklist` has not been declared static, the following error is thrown:

```
Error: Access to undeclared static property: Terminus\Request::$blacklist in Terminus\Request->request() (line 155 of /path/to/php/Terminus/Request.php).
```

Encountered in PHP 7.0.2, but almost certainly occurring in 5.x as well.
