### PR TITLE
Fixed erroneous, old --[no-]format tag listing in help, replacing it with current --format=<json|bash|silent> option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Fixed error appearing in `organizations sites list` when there are no results. (#812)
 - Fixed missing-variable error in Request#request which appeared when attempting to sanitize error messages. (#835) 
 - Fixed log-in admonition if a machine token, TERMINUS_USER, or TEMRINUS_MACHINE_TOKEN are present. (#849)
+- Fixed erroneous, old `--[no-]format` tag listing in `help`, replacing it with current `--format=<json|bash|silent>` option. (#854)
 
 ### Removed
 - `--session=<session_id>` argument has been removed from `auth login`. (#826)

--- a/php/Terminus/Commands/HelpCommand.php
+++ b/php/Terminus/Commands/HelpCommand.php
@@ -111,16 +111,18 @@ class HelpCommand extends TerminusCommand {
       $options_list = explode("\n\n", $longdesc);
       foreach ($options_list as $option) {
         $drilldown = explode("\n", $option);
-        $key       = str_replace(array('[', ']'), '', $drilldown[0]);
-        if (!in_array($key, $synopses)) {
-          continue;
+        if (count($drilldown) > 1) {
+          $key       = str_replace(array('[', ']'), '', $drilldown[0]);
+          if (!in_array($key, $synopses)) {
+            continue;
+          }
+          $value     = str_replace(
+            array(': ', "\n"),
+            array('', ' '),
+            $drilldown[1]
+          );
+          $options[$key] = $value;
         }
-        $value     = str_replace(
-          array(': ', "\n"),
-          array('', ' '),
-          $drilldown[1]
-        );
-        $options[$key] = $value;
       }
     } elseif (isset($longdesc['parameters'])) {
       foreach ($longdesc['parameters'] as $parameter) {

--- a/php/Terminus/Dispatcher/RootCommand.php
+++ b/php/Terminus/Dispatcher/RootCommand.php
@@ -51,8 +51,6 @@ class RootCommand extends CompositeCommand {
         || (isset($details['hidden']))
       ) {
         continue;
-      } if ($details['runtime']) {
-        $synopsis = "--[no-]$key";
       } else {
         $synopsis = "--$key" . $details['runtime'];
       }

--- a/php/config-spec.php
+++ b/php/config-spec.php
@@ -23,6 +23,6 @@ return array(
     'runtime' => '=<json|bash|silent>',
     'file'    => '=<json|bash|silent>',
     'default' => 'normal',
-    'desc'    => 'Force json output',
+    'desc'    => 'Change the output type to JSON, bash, or silent',
   ),
 );


### PR DESCRIPTION
Closes #853 
