### PR TITLE
Allow external plugins to define commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ## Master
 ### Added
 - New `Hostnames` collection and `Hostname` model. (#860)
+- Added 3rd Party plugin support (#857)
 
 ### Changed
 - When an object cannot be found by `TerminusModel#get`, it now throws an exception rather than issuing a notice. (#861)

--- a/php/Terminus.php
+++ b/php/Terminus.php
@@ -1,7 +1,7 @@
 <?php
 
 use Terminus\Dispatcher;
-use Terminus\DocParser;
+use Terminus\Dispatcher\CompositeCommand;
 use Terminus\FileCache;
 use Terminus\Runner;
 use Terminus\Session;
@@ -52,60 +52,6 @@ class Terminus {
   }
 
   /**
-   * Add a command to the terminus list of commands
-   *
-   * @param string $name  The name of the command that will be used in the CLI
-   * @param string $class The command implementation
-   * @return void
-   * @throws TerminusException
-   */
-  public static function addCommand($name, $class) {
-    $path      = preg_split('/\s+/', $name);
-    $leaf_name = array_pop($path);
-    $command   = self::getRootCommand();
-    $class     = "Terminus\\Commands\\$class";
-
-    while (!empty($path)) {
-      $subcommand_name = $path[0];
-      $subcommand      = $command->findSubcommand($path);
-      // Create an empty container
-      if (!$subcommand) {
-        $subcommand = new Dispatcher\CompositeCommand(
-          $command,
-          $subcommand_name,
-          new DocParser('')
-        );
-        $command->addSubcommand($subcommand_name, $subcommand);
-      }
-      $command = $subcommand;
-    }
-
-    $options = [
-      'cache'     => self::getCache(),
-      'logger'    => self::getLogger(),
-      'outputter' => self::getOutputter(),
-      'session'   => Session::instance(),
-    ];
-
-    $leaf_command = Dispatcher\CommandFactory::create(
-      $leaf_name,
-      $class,
-      $command,
-      $options
-    );
-
-    if (!$command->canHaveSubcommands()) {
-      throw new TerminusException(
-        sprintf(
-          "'%s' can't have subcommands.",
-          implode(' ', Dispatcher\getPath($command))
-        )
-      );
-    }
-    $command->addSubcommand($leaf_name, $leaf_command);
-  }
-
-  /**
    * Retrieves and returns the file cache
    *
    * @return FileCache
@@ -130,6 +76,60 @@ class Terminus {
     $cache->clean();
 
     return $cache;
+  }
+
+  /**
+   * Retrieves and returns the users local configuration directory (~/terminus)
+   *
+   * @return string
+   */
+  public static function getUserConfigDir() {
+    $terminus_config_dir = getenv('TERMINUS_CONFIG_DIR');
+
+    if (!$terminus_config_dir) {
+      $home = getenv('HOME');
+      if (!$home) {
+        // sometime in windows $HOME is not defined
+        $home = getenv('HOMEDRIVE') . '/' . getenv('HOMEPATH');
+      }
+      if ($home) {
+        $terminus_config_dir = getenv('HOME') . '/terminus';
+      }
+    }
+    return $terminus_config_dir;
+  }
+
+  /**
+   * Retrieves and returns the local config directory
+   *
+   * @return string
+   */
+  public static function getUserPluginsDir() {
+    if ($config = self::getUserConfigDir()) {
+      $plugins_dir = "$config/plugins";
+      if (file_exists($plugins_dir)) {
+        return $plugins_dir;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Retrieves and returns a list of plugin's base directories
+   *
+   * @return array
+   */
+  public static function getUserPlugins() {
+    $out = array();
+    if ($plugins_dir = self::getUserPluginsDir()) {
+      $plugin_iterator = new \DirectoryIterator($plugins_dir);
+      foreach ($plugin_iterator as $dir) {
+        if (!$dir->isDot()) {
+          $out[] = $dir->getPathname();
+        }
+      }
+    }
+    return $out;
   }
 
   /**
@@ -179,9 +179,62 @@ class Terminus {
 
     if (!$root) {
       $root = new Dispatcher\RootCommand;
+      self::loadAllCommands($root);
     }
 
     return $root;
+  }
+
+  /**
+   * Includes every command file in the commands directory
+   *
+   * @param CompositeCommand $parent The parent command to add the new commands to
+   *
+   * @return void
+   */
+  private static function loadAllCommands(CompositeCommand $parent) {
+    // Create a list of directories where commands might live.
+    $directories = array();
+
+    // Add the directory of core commands first.
+    $directories[] = TERMINUS_ROOT . '/php/Terminus/Commands';
+
+    // Find the command directories from the third party plugins directory.
+    foreach (self::getUserPlugins() as $dir) {
+      $directories[] = "$dir/Commands/";
+    }
+
+    // Include all class files in the command directories.
+    foreach ($directories as $cmd_dir) {
+      if ($cmd_dir && file_exists($cmd_dir)) {
+        $iterator = new \DirectoryIterator($cmd_dir);
+        foreach ($iterator as $file) {
+          if ($file->isFile() && $file->isReadable() && $file->getExtension() == 'php') {
+            include_once $file->getPathname();
+          }
+        }
+      }
+    }
+
+    // Find the defined command classes and add them to the given base command.
+    $classes = get_declared_classes();
+    $options = [
+      'cache'     => self::getCache(),
+      'logger'    => self::getLogger(),
+      'outputter' => self::getOutputter(),
+      'session'   => Session::instance(),
+    ];
+
+    foreach ($classes as $class) {
+      $reflection = new \ReflectionClass($class);
+      if ($reflection->isSubclassOf('Terminus\Commands\TerminusCommand')) {
+        Dispatcher\CommandFactory::create(
+          $reflection->getName(),
+          $parent,
+          $options
+        );
+      }
+    }
   }
 
   /**

--- a/php/Terminus/Commands/ArtCommand.php
+++ b/php/Terminus/Commands/ArtCommand.php
@@ -9,6 +9,8 @@ use Terminus\Exceptions\TerminusException;
 
 /**
  * Print the Pantheon art
+ *
+ * @command art
  */
 class ArtCommand extends TerminusCommand {
 
@@ -40,5 +42,3 @@ class ArtCommand extends TerminusCommand {
   }
 
 }
-
-Terminus::addCommand('art', 'ArtCommand');

--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -10,6 +10,8 @@ use Terminus\Helpers\Input;
 
 /**
  * Authenticate to Pantheon and store a local secret token.
+ *
+ * @command auth
  */
 class AuthCommand extends TerminusCommand {
   private $auth;
@@ -111,5 +113,3 @@ class AuthCommand extends TerminusCommand {
   }
 
 }
-
-Terminus::addCommand('auth', 'AuthCommand');

--- a/php/Terminus/Commands/CliCommand.php
+++ b/php/Terminus/Commands/CliCommand.php
@@ -11,6 +11,8 @@ use Terminus\Models\User;
 
 /**
  * Get information about Terminus itself.
+ *
+ * @command cli
  */
 class CliCommand extends TerminusCommand {
 
@@ -197,5 +199,3 @@ class CliCommand extends TerminusCommand {
   }
 
 }
-
-Terminus::addCommand('cli', 'CliCommand');

--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -5,6 +5,9 @@ namespace Terminus\Commands;
 use Terminus;
 use Terminus\Commands\CommandWithSSH;
 
+/**
+ * @command drush
+ */
 class DrushCommand extends CommandWithSSH {
   /**
    * {@inheritdoc}
@@ -53,5 +56,3 @@ class DrushCommand extends CommandWithSSH {
   }
 
 }
-
-Terminus::addCommand('drush', 'DrushCommand');

--- a/php/Terminus/Commands/HelpCommand.php
+++ b/php/Terminus/Commands/HelpCommand.php
@@ -10,6 +10,9 @@ use Terminus\Dispatcher\CompositeCommand;
 use Terminus\Dispatcher\RootCommand;
 use Terminus\Helpers\Input;
 
+/**
+ * @command help
+ */
 class HelpCommand extends TerminusCommand {
   private $recursive;
 
@@ -210,4 +213,3 @@ class HelpCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('help', 'HelpCommand');

--- a/php/Terminus/Commands/InstrumentsCommand.php
+++ b/php/Terminus/Commands/InstrumentsCommand.php
@@ -10,6 +10,8 @@ use Terminus\Models\User;
 
 /**
  * Show information for your Pantheon instruments
+ *
+ * @command instruments
  */
 class InstrumentsCommand extends TerminusCommand {
 
@@ -45,4 +47,3 @@ class InstrumentsCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('instruments', 'InstrumentsCommand');

--- a/php/Terminus/Commands/MachineTokensCommand.php
+++ b/php/Terminus/Commands/MachineTokensCommand.php
@@ -11,6 +11,8 @@ use Terminus\Helpers\Input;
 
 /**
  * Show information for your Pantheon machine tokens
+ *
+ * @command machine-tokens
  */
 class MachineTokensCommand extends TerminusCommand {
 
@@ -114,4 +116,3 @@ class MachineTokensCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('machine-tokens', 'MachineTokensCommand');

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -16,6 +16,7 @@ use Terminus\Models\Collections\UserOrganizationMemberships;
 /**
  * Show information for your Pantheon organizations
  *
+ * @command organizations
  */
 class OrganizationsCommand extends TerminusCommand {
 
@@ -298,4 +299,3 @@ class OrganizationsCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('organizations', 'OrganizationsCommand');

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -16,6 +16,8 @@ use Terminus\Models\Collections\Sites;
 
 /**
  * Actions to be taken on an individual site
+ *
+ * @command site
  */
 class SiteCommand extends TerminusCommand {
 
@@ -2266,4 +2268,3 @@ class SiteCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('site', 'SiteCommand');

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -17,6 +17,8 @@ use Terminus\Models\Collections\Sites;
 
 /**
  * Actions on multiple sites
+ *
+ * @command sites
  */
 class SitesCommand extends TerminusCommand {
   public $sites;
@@ -539,4 +541,3 @@ class SitesCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('sites', 'SitesCommand');

--- a/php/Terminus/Commands/UpstreamsCommand.php
+++ b/php/Terminus/Commands/UpstreamsCommand.php
@@ -8,6 +8,8 @@ use Terminus\Models\Collections\Upstreams;
 
 /**
  * Show Pantheon upstream information
+ *
+ * @command upstreams
  */
 class UpstreamsCommand extends TerminusCommand {
 
@@ -50,4 +52,3 @@ class UpstreamsCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('upstreams', 'UpstreamsCommand');

--- a/php/Terminus/Commands/WorkflowsCommand.php
+++ b/php/Terminus/Commands/WorkflowsCommand.php
@@ -15,6 +15,8 @@ define("WORKFLOWS_WATCH_INTERVAL", 5);
 
 /**
 * Actions to be taken on an individual site
+*
+* @command workflows
 */
 class WorkflowsCommand extends TerminusCommand {
   protected $_headers = false;
@@ -215,4 +217,3 @@ class WorkflowsCommand extends TerminusCommand {
 
 }
 
-Terminus::addCommand('workflows', 'WorkflowsCommand');

--- a/php/Terminus/Commands/WpCommand.php
+++ b/php/Terminus/Commands/WpCommand.php
@@ -5,6 +5,9 @@ namespace Terminus\Commands;
 use Terminus;
 use Terminus\Commands\CommandWithSSH;
 
+/**
+ * @command wp
+ */
 class WpCommand extends CommandWithSSH {
   /**
    * {@inheritdoc}
@@ -47,4 +50,3 @@ class WpCommand extends CommandWithSSH {
 
 }
 
-Terminus::addCommand('wp', 'WpCommand');

--- a/php/Terminus/Dispatcher/RootCommand.php
+++ b/php/Terminus/Dispatcher/RootCommand.php
@@ -27,7 +27,6 @@ class RootCommand extends CompositeCommand {
    */
   function findSubcommand(&$args) {
     $command = array_shift($args);
-    Utils\loadCommand($command);
 
     if (!isset($this->subcommands[$command])) {
       return false;
@@ -73,7 +72,6 @@ class RootCommand extends CompositeCommand {
    * @return Subcommand[]
    */
   function getSubcommands() {
-    Utils\loadAllCommands();
     $subcommands = parent::getSubcommands();
     return $subcommands;
   }

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -116,10 +116,6 @@ class Runner {
       $this->arguments[] = 'help';
     }
 
-    // Load bundled commands early, so that they're forced to use the same
-    // APIs as non-bundled commands.
-    Utils\loadCommand($this->arguments[0]);
-
     if (isset($this->config['require'])) {
       foreach ($this->config['require'] as $path) {
         Utils\loadFile($path);

--- a/php/utils.php
+++ b/php/utils.php
@@ -9,6 +9,11 @@ use Terminus\Request;
 use Terminus\Helpers\Input;
 use Terminus\Iterators\Transform;
 use Terminus\Exceptions\TerminusException;
+use Terminus\DocParser;
+use Terminus\Commands\TerminusCommand;
+use Terminus\Dispatcher;
+use Terminus\Dispatcher\CompositeCommand;
+use Terminus\Session;
 
 if (!defined('JSON_PRETTY_PRINT')) {
   define('JSON_PRETTY_PRINT', 128);
@@ -213,25 +218,6 @@ function isWindows() {
 }
 
 /**
- * Includes every command file in the commands directory
- *
- * @return void
- */
-function loadAllCommands() {
-  $cmd_dir = TERMINUS_ROOT . '/php/Terminus/Commands';
-
-  $iterator = new \DirectoryIterator($cmd_dir);
-
-  foreach ($iterator as $filename) {
-    if (substr($filename, -4) != '.php') {
-      continue;
-    }
-
-    include_once "$cmd_dir/$filename";
-  }
-}
-
-/**
  * Loads a file of the given name from the assets directory.
  *
  * @param string $file Relative file path from the assets dir
@@ -257,24 +243,6 @@ function loadAsset($file) {
     );
   }
   return $asset_file;
-}
-
-/**
- * Includes a single command file
- *
- * @param string $name Of command of which the class file will be included
- * @return void
- */
-function loadCommand($name) {
-  $path = sprintf(
-    '%s/php/Terminus/Commands/%sCommand.php',
-    TERMINUS_ROOT,
-    makeCamelCase($name)
-  );
-
-  if (is_readable($path)) {
-    include_once $path;
-  }
 }
 
 /**
@@ -313,22 +281,6 @@ function loadDependencies() {
  */
 function loadFile($path) {
   require $path;
-}
-
-/**
- * Converts a word to camel case
- *
- * @param string $string    Word to change to camel case
- * @param string $delimiter Character to split words up on
- * @return string
- */
-function makeCamelCase($string, $delimiter = '-') {
-  $words       = explode($delimiter, $string);
-  $camel_cased = '';
-  foreach ($words as $key => $word) {
-    $camel_cased .= ucwords($word);
-  }
-  return $camel_cased;
 }
 
 /**

--- a/tests/unit_tests/test-terminus.php
+++ b/tests/unit_tests/test-terminus.php
@@ -1,5 +1,7 @@
 <?php
 
+use Terminus\Dispatcher;
+
 /**
  * Testing class for Terminus
  */
@@ -8,10 +10,6 @@ class TerminusTest extends PHPUnit_Framework_TestCase {
   public function testConstruct() {
     $terminus = new Terminus();
     $this->assertTrue(get_class($terminus) == 'Terminus');
-  }
-
-  public function testAddCommand() {
-    Terminus::addCommand('auth', 'AuthCommand');
   }
 
   public function testGetCache() {
@@ -43,6 +41,19 @@ class TerminusTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(
       strpos(get_class($root_command), 'RootCommand') !== false
     );
+
+    // Make sure the core commands have loaded
+    $commands = array('art', 'auth', 'cli', 'drush', 'help', 'machine-tokens',
+      'organizations', 'site', 'sites', 'upstreams', 'workflows', 'wp');
+    foreach ($commands as $command) {
+      $args = array($command);
+      $this->assertTrue($root_command->findSubcommand($args) !== false);
+    }
+
+    // Make sure the correct number of parameters are configured.
+    $desc = $root_command->getLongdesc();
+    $this->assertTrue(count($desc['parameters']) == 4);
+
   }
 
   public function testGetRunner() {

--- a/tests/unit_tests/test-utils.php
+++ b/tests/unit_tests/test-utils.php
@@ -119,13 +119,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals(strpos($os, 'NT') !== false, $is_windows);
   }
 
-  public function testLoadAllCommands() {
-    $included_before = get_included_files();
-    Utils\loadAllCommands();
-    $included_after = get_included_files();
-    $this->assertTrue(count($included_before) < count($included_after));
-  }
-
   public function testLoadAsset() {
     $file = Utils\loadAsset('unicorn.txt');
     $this->assertTrue(strpos($file, 'ICAgICAg') === 0);
@@ -136,15 +129,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
       $message = $e->getMessage();
     }
     $this->assertTrue(isset($message));
-  }
-
-  public function testLoadCommand() {
-    $command_name = 'auth';
-    $file_name    = TERMINUS_ROOT . '/php/Terminus/Commands/AuthCommand.php';
-    Utils\loadCommand($command_name);
-    $included_files = get_included_files();
-    $is_included = array_search($file_name, $included_files) !== false;
-    $this->assertTrue($is_included);
   }
 
   public function testLoadDependencies() {
@@ -166,12 +150,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase {
       || (array_search("/private$file_name", $included_files) !== false)
     );
     $this->assertTrue($is_included);
-  }
-
-  public function testMakeCamelCase() {
-    $string      = 'camel-case';
-    $camel_cased = Utils\makeCamelCase($string);
-    $this->assertEquals($camel_cased, 'CamelCase');
   }
 
   public function testParseUrl() {


### PR DESCRIPTION
This is a proof of concept PR to collaborate on the task of allowing third party contributed command plugins in Terminus.

This early, rough version allows the installation of new commands in:

`~/terminus/plugins/`
