### PR TITLE
Don't attempt to create an alias for broken environments.

### DIFF
--- a/docs/examples/PantheonAliases.php
+++ b/docs/examples/PantheonAliases.php
@@ -94,6 +94,7 @@ class PantheonAliases {
     $user     = new User();
     $path     = 'drush_aliases';
     $method   = 'GET';
+    $logger = Terminus::getLogger();
     $response = $request->request(
       'users',
       Session::getValue('user_uuid'),
@@ -110,6 +111,10 @@ class PantheonAliases {
         $key = $site->get('name') . '.'. $environment->get('id');
         if (isset($aliases[$key])) {
           break;
+        }
+        if (!isset($environment->bindings)) {
+          $logger->error("An alias could not be created for $key");
+          continue;
         }
         try {
           $formatted_aliases .= PHP_EOL . "  \$aliases['$key'] = ";


### PR DESCRIPTION
I tried the new "Generate all the aliases" script and received the following error:

``` bash
{"date":"2016-01-28 18:10:26","level":"INFO","message":"Logged in as 94f7f8d7-5b27-4586-8651-53b3db9bba40."}
{"date":"2016-01-28 18:10:26","level":"INFO","message":"Saving session data"}

Notice: Undefined property: Terminus\Models\Environment::$bindings in /Users/dave/.composer/vendor/pantheon-systems/cli/php/Terminus/Models/TerminusModel.php on line 46

Fatal error: Call to a member function getByType() on null in /Users/dave/.composer/vendor/pantheon-systems/cli/docs/examples/PantheonAliases.php on line 48
```

Here's a possible fix. 

The offenders are things like:
- Beta D8 sites that no longer work
- WP sites
- brand new sites that don't have environments
