### PR TITLE
site set-service-level now accepts levels of "professional", "sandbox", and "personal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Extracted launching functions from `Terminus` (base class) and moved them into new `LaunchHelper` class. (#882)
 - Extracted template function from `Utils` and moved it into new `TemplateHelper` class. (#884)
 - Changed the site-DNE message to instruct the user to run `sites list`. (#895)
+- `site set-service-level` now also accepts levels of "professional", "sandbox", and "personal". (#894)
 
 ### Removed
 - `addHostnames`, `deleteHostnames()`, and `getHostnames()` has been removed from `Environment`. Use new hostnames property (contains Hostnames collection) instead. (#860)

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1610,14 +1610,13 @@ class SiteCommand extends TerminusCommand {
    * : Site to check
    *
    * [--level=<value>]
-   * : new service level to set
+   * : New service level to set. Options are free, basic, pro, and business.
    *
    * @subcommand set-service-level
    */
   public function setServiceLevel($args, $assoc_args) {
     $site  = $this->sites->get($this->input()->siteName(array('args' => $assoc_args)));
-    $info  = $site->get('service_level');
-    $level = $assoc_args['level'];
+    $level = $this->input()->serviceLevel(['args' => $assoc_args]);
     $data  = $site->updateServiceLevel($level);
     $this->log()->info("Service level has been updated to '$level'");
   }

--- a/php/Terminus/Helpers/InputHelper.php
+++ b/php/Terminus/Helpers/InputHelper.php
@@ -475,7 +475,7 @@ class InputHelper extends TerminusHelper {
    * Helper function to get role
    *
    * @param array $arg_options Elements as follow:
-   *        array  assoc_args Argument array passed from commands
+   *        array  args Argument array passed from commands
    *        string message    Prompt to STDOUT
    * @return string Name of role
    */
@@ -502,6 +502,48 @@ class InputHelper extends TerminusHelper {
       )]
     );
     return $role;
+  }
+
+  /**
+   * Helper function to select a service level
+   *
+   * @param array $arg_options Elements as follow:
+   *        array  args    The args passed in from argv
+   *        string key     Args key to search for
+   *        string message    Prompt to STDOUT
+   * @return string
+   */
+  public function serviceLevel(array $arg_options = []) {
+    $default_options = [
+      'args'    => [],
+      'key'     => 'level',
+      'message' => 'Select a service level',
+    ];
+    $options         = array_merge($default_options, $arg_options);
+    $levels          = ['free', 'basic', 'pro', 'business',];
+    $customer_levels = [
+      'sandbox'      => 'free',
+      'personal'     => 'basic',
+      'professional' => 'pro',
+    ];
+    if (isset($options['key']) && isset($options['args'][$options['key']])) {
+      $level_candidate = strtolower($options['args'][$options['key']]);
+      if (in_array($level_candidate, $levels)) {
+        $level = $level_candidate;
+      }
+      if (isset($customer_levels[$level_candidate])) {
+        $level = $customer_levels[$level_candidate];
+      }
+    }
+    if (!isset($level)) {
+      $level = $levels[$this->menu(
+        [
+          'choices' => $levels,
+          'message' => $options['message'],
+        ]
+      )];
+    }
+    return $level;
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -623,17 +623,6 @@ class Site extends TerminusModel {
    * @throws TerminusException
    */
   public function updateServiceLevel($level) {
-    if (!in_array(
-      $level,
-      array('free', 'basic', 'pro', 'business', 'elite')
-    )
-    ) {
-      throw new TerminusException(
-        'Service level "{level}" is invalid.',
-        compact('level'),
-        1
-      );
-    }
     $path        = 'service-level';
     $method      = 'PUT';
     $form_params = $level;

--- a/tests/features/site_set-service-level.feature
+++ b/tests/features/site_set-service-level.feature
@@ -22,13 +22,3 @@ Feature: Set a site's service level
     """
     Instrument required to increase service level
     """
-
-  @vcr site_set-service-level_wrong
-  Scenario: Changing to incorrect service level
-    Given I am authenticated
-    And a site named "[[test_site_name]]"
-    When I run "terminus site set-service-level --site=[[test_site_name]] --level=professional"
-    Then I should get:
-    """
-    Service level "professional" is invalid.
-    """

--- a/tests/unit_tests/helpers/test-input-helper.php
+++ b/tests/unit_tests/helpers/test-input-helper.php
@@ -141,6 +141,16 @@ class InputHelperTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('admin', $role);
   }
 
+  public function testServiceLevel() {
+    //From args
+    $args = ['args' => ['level' => 'pro']];
+    $this->assertEquals('pro', $this->inputter->serviceLevel($args));
+
+    //Customer-name service level from args
+    $args = ['args' => ['level' => 'sandbox']];
+    $this->assertEquals('free', $this->inputter->serviceLevel($args));
+  }
+
   public function testSiteName() {
   }
 


### PR DESCRIPTION
Closes #891
