### PR TITLE
Utils\checkForUpdate() now appropriately interpolates error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Help text when inputting an incomplete command has been repaired. (#919)
 - Automatic checking for the current version will no longer err unless GitHub is down. (#925)
 - Fixed strict standards issue occurring in `Environment#wake()`. (#928)
+- `Utils\checkForUpdate()` now appropriately interpolates error messages. (#929)
 
 ## [0.10.3] - 2016-02-12
 ### Added

--- a/php/utils.php
+++ b/php/utils.php
@@ -60,9 +60,11 @@ function checkForUpdate($logger) {
           ['version' => $current_version]
         );
       }
-    } catch (\Exception $e) {
-      $logger->info($e->getMessage());
-      $logger->info('Cannot retrieve current Terminus version.');
+    } catch (TerminusException $e) {
+      $logger->info(
+        "Cannot retrieve current Terminus version.\n{msg}",
+        $e->getReplacements()
+      );
     }
   }
 }


### PR DESCRIPTION
Closes #848 
It wasn't that all error messages weren't interpolating, but that one function was explicitly separating the message from its context.
