### PR TITLE
Adding missing ENV variable for diffstat case

### DIFF
--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -318,6 +318,9 @@ class SiteCommand extends TerminusCommand {
         $data = true;
           break;
       case 'diffstat':
+        $env     = $site->environments->get(
+          $this->input()->env(['args' => $assoc_args, 'site' => $site])
+        );
         $diff = (array)$env->diffstat();
         if (empty($diff)) {
           $this->log()->info('No changes on server.');


### PR DESCRIPTION
Oops looks like someone forgot to set the env for diffstat. I've pulled from the other cases around diffstat. Haven't tested since I don't have access to the pantheon backend. 
