### PR TITLE
Added @non-command tag for command functions which are public but not a command

### DIFF
--- a/php/Terminus/Commands/TerminusCommand.php
+++ b/php/Terminus/Commands/TerminusCommand.php
@@ -73,6 +73,7 @@ abstract class TerminusCommand {
    * Retrieves the logger for use
    *
    * @return Logger
+   * @non-command
    */
   public function log() {
     return $this->logger;
@@ -82,6 +83,7 @@ abstract class TerminusCommand {
    * Retrieves the outputter for use
    *
    * @return OutputterInterface
+   * @non-command
    */
   public function output() {
     return $this->outputter;

--- a/php/Terminus/Dispatcher/CommandFactory.php
+++ b/php/Terminus/Dispatcher/CommandFactory.php
@@ -149,7 +149,8 @@ class CommandFactory {
   private static function isGoodMethod(\ReflectionMethod $method) {
     $is_good_method = $method->isPublic()
       && !$method->isConstructor()
-      && !$method->isStatic();
+      && !$method->isStatic()
+      && (strpos($method->getDocComment(), '@non-command') === false);
     return $is_good_method;
   }
 


### PR DESCRIPTION
Currently, the dispatcher decides that all public functions within command classes are subcommands that the user may access. I added a tag to identify which public functions are not commands, thus fixing a long-standing problem with the users being offered useless commands by the help menu.
