### PR TITLE
Fixed unidentified index email warning which appeared when logging in via saved machine token by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ### Changed
 - WP-CLI function `import` has been removed from the command blacklist. [See the documentation for more information.](https://github.com/pantheon-systems/documentation/blob/master/source/docs/guides/create-a-wordpress-site-from-the-commandline-with-terminus-and-wp-cli.md) (#979)
 
+### Fixed
+- Fixed unidentified index email warning which appeared when logging in via saved machine token by email. (#983)
+
 ## [0.10.6] - 2016-03-07
 ### Changed
 - `Terminus\Helpers\AuthHelper` has become `Terminus\Models\Auth`. (#971)

--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -48,7 +48,7 @@ class AuthCommand extends TerminusCommand {
       // Try to log in using a machine token, if the account email was provided.
       $this->log()->info(
         'Found a machine token for "{email}".',
-        ['email' => $args['email'],]
+        compact('email')
       );
       $auth->logInViaMachineToken(compact('email'));
       $this->log()->info('Logging in via machine token');


### PR DESCRIPTION
Fixed #980 
