### PR TITLE
Streamlined the site-creation process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - New parameter `--owner` added to `sites list` to filter the list just for the sites the current user owns. (#1003)
 - New option to filter for organization sites via `sites list --org=all`. (#1003)
 
+### Changed
+- `InputHelper#upstream()` now returns the UUID of the chosen upstream rather than an upstream object. (#1013)
+- `InputHelper#upstream()` will not check upstream data if it has been given a UUID in the $args[$key]. (#1013)
+- `InputHelper#orgId()` will not check organizational data if it has been given a UUID in the $args[$key]. (#1013)
+- Running `Sites#addSiteToCache` while the cache is empty will no longer trigger a full cache sync. (#1013)
+
 ### Fixed
 - Alternate command suggestion for `drush "sql-connect"` corrected to `site connection-info --field=mysql_command`. (#1005)
 

--- a/php/Terminus/Caches/FileCache.php
+++ b/php/Terminus/Caches/FileCache.php
@@ -138,11 +138,11 @@ class FileCache {
    *        [bool] ttl          TTL for file read
    * @return bool|string The file contents or false
    */
-  public function getData($key, array $options = array()) {
-    $defaults = array(
+  public function getData($key, array $options = []) {
+    $defaults = [
       'decode_array' => false,
-      'ttl'          => null
-    );
+      'ttl'          => null,
+    ];
     $options  = array_merge($defaults, $options);
 
     try {
@@ -151,7 +151,7 @@ class FileCache {
       return false;
     }
 
-    $data = false;
+    $data = [];
     if ($contents) {
       $data = json_decode($contents, $options['decode_array']);
     }

--- a/php/Terminus/Caches/SitesCache.php
+++ b/php/Terminus/Caches/SitesCache.php
@@ -72,15 +72,18 @@ class SitesCache {
    * @param array $memberships_data Memberships of use to add to cache
    * @return array
    */
-  public function add(array $memberships_data = array()) {
+  public function add(array $memberships_data = []) {
     $cache = (array)$this->cache->getData(
       $this->cachekey,
-      array('decode_array' => true)
+      ['decode_array' => true,]
     );
+    if (!$cache) {
+      $cache = [];
+    }
 
     //If a single site item is passed in, wrap it in an array
     if (isset($memberships_data['id'])) {
-      $memberships_data = array($memberships_data);
+      $memberships_data = [$memberships_data,];
     }
 
     foreach ($memberships_data as $membership_data) {
@@ -96,7 +99,7 @@ class SitesCache {
       //Then add the membership
       $cache[$site_name] = array_merge(
         $cache[$site_name],
-        array('memberships' => array($membership_id => $membership))
+        ['memberships' => [$membership_id => $membership,],]
       );
     }
 
@@ -328,7 +331,7 @@ class SitesCache {
    * @return array
    */
   private function getSiteData($response_data, $membership_data = array()) {
-    $site_data = array(
+    $site_data = [
       'id'            => null,
       'name'          => null,
       'label'         => null,
@@ -341,8 +344,8 @@ class SitesCache {
       'holder_type'   => null,
       'holder_id'     => null,
       'owner'         => null,
-      'membership'    => array(),
-    );
+      'membership'    => [],
+    ];
     foreach ($site_data as $index => $value) {
       if (($value == null) && isset($response_data[$index])) {
         $site_data[$index] = $response_data[$index];

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -119,13 +119,11 @@ class SitesCommand extends TerminusCommand {
    *
    */
   public function create($args, $assoc_args) {
-    $options  = $this->getSiteCreateOptions($assoc_args);
-    $upstream = $this->input()->upstream(['args' => $assoc_args]);
-    $options['upstream_id'] = $upstream->get('id');
-    $this->log()->info(
-      'Creating new {upstream} installation ... ',
-      array('upstream' => $upstream->get('longname'))
+    $options                = $this->getSiteCreateOptions($assoc_args);
+    $options['upstream_id'] = $this->input()->upstream(
+      ['args' => $assoc_args,]
     );
+    $this->log()->info('Creating new site installation ... ');
 
     $workflow = $this->sites->addSite($options);
     $workflow->wait();
@@ -137,9 +135,9 @@ class SitesCommand extends TerminusCommand {
 
     $this->helpers->launch->launchSelf(
       [
-        'command' => 'site',
-        'args' => ['info'],
-        'assoc_args' => ['site' => $options['name']]
+        'command'    => 'site',
+        'args'       => ['info',],
+        'assoc_args' => ['site' => $options['name'],],
       ]
     );
 

--- a/php/Terminus/Models/Collections/Sites.php
+++ b/php/Terminus/Models/Collections/Sites.php
@@ -75,39 +75,34 @@ class Sites extends TerminusCollection {
    * @return Site The newly created site object
    */
   public function addSiteToCache($site_id, $org_id = null) {
-    if (count($this->models) == 0) {
-      $this->rebuildCache();
-      $site = $this->get($site_id);
-    } else {
-      $site = new Site(
-        $this->objectify(array('id' => $site_id)),
-        array('collection' => $this)
-      );
-      $site->fetch();
-      $cache_membership = $site->info();
+    $site = new Site(
+      (object)['id' => $site_id,],
+      ['collection' => $this,]
+    );
+    $site->fetch();
+    $cache_membership = $site->info();
 
-      if (!is_null($org_id)) {
-        $org = new Organization(null, array('id' => $org_id));
-        $cache_membership['membership'] = array(
-          'id' => $org_id,
-          'name' => $org->profile->name,
-          'type' => 'organization'
-        );
-      } else {
-        $user_id = Session::getValue('user_uuid');
-        $cache_membership['membership'] = array(
-          'id' => $user_id,
-          'name' => 'Team',
-          'type' => 'team'
-        );
-      }
-      $this->sites_cache->add($cache_membership);
+    if (!is_null($org_id)) {
+      $org = new Organization(null, ['id' => $org_id,]);
+      $cache_membership['membership'] = [
+        'id' => $org_id,
+        'name' => $org->profile->name,
+        'type' => 'organization',
+      ];
+    } else {
+      $user_id = Session::getValue('user_uuid');
+      $cache_membership['membership'] = [
+        'id' => $user_id,
+        'name' => 'Team',
+        'type' => 'team',
+      ];
     }
+    $this->sites_cache->add($cache_membership);
     return $site;
   }
 
   /**
-   * Removes site with given site ID from cache
+    * Removes site with given site ID from cache
    *
    * @param string $site_name Name of site to remove from cache
    * @return void
@@ -130,7 +125,7 @@ class Sites extends TerminusCollection {
         $cache = $this->sites_cache->all();
       }
       foreach ($cache as $name => $model) {
-        $this->add($this->objectify($model));
+        $this->add((object)$model);
       }
     }
     return $this;

--- a/tests/features/cli.feature
+++ b/tests/features/cli.feature
@@ -53,7 +53,7 @@ Feature: CLI Commands
     And I run "terminus cli session-dump --format=json"
     Then I should get:
     """
-    false
+    []
     """
 
   @vcr cli_session-dump

--- a/tests/unit_tests/caches/test-file-cache.php
+++ b/tests/unit_tests/caches/test-file-cache.php
@@ -67,7 +67,7 @@ class FileCacheTest extends PHPUnit_Framework_TestCase {
 
     //Trying to get data when the file is not there
     $data = $this->file_cache->getData($this->test_file_name);
-    $this->assertFalse($data);
+    $this->assertInternalType('array', $data);
   }
 
   public function testGetRoot() {


### PR DESCRIPTION
As seen on https://sprint.ly/product/27143/item/1333

Creating sites when you're in an org with a large number of sites is time-consuming. Here are the three scenarios:
# Experiment

Cycle through this method for each of the three scenarios, alternating.
1. Clear cache
2. Log in via machine token
3. Time the creation of a WP site called 'saras-other-test-site'
4. Save the time
5. Delete created site to reset, start at 1.

Each scenario was run 10 times and the numbers averaged.
##### No org, no sites `sites create` time:

real 1m55.579s
user 0m0.387s
sys 0m0.088s
Actions:
- Checks product list
- Starts site-creation workflow
- Checks on the status of that workflow 23 times
- Gets a full list of the user's sites
- Pulls in basic info for the new site
##### Pantheon Employees org member, many sites, not adding site to org `sites create` time:

real 2m15.851s
user 0m0.566s
sys 0m0.210s
Actions:
- Checks product list
- Starts site-creation workflow
- Checks on the status of that workflow 26 times
- Gets a full list of the user's sites
- Pulls in basic info for the new site
##### Pantheon Employees org member, many sites, adding site to org `sites create` time:

real 3m37.987s
user 0m0.677s
sys 0m0.218s
Actions:
- Checks all organizational memberships to see that user is a member and can add to that organization.
- Checks product list
- Starts site-creation workflow
- Checks on the status of that workflow 37 times
- Gets a full list of the user's sites
- Pulls in basic info for the new site
# Proposed Solution

So there are three things slowing org members down when they create sites:
1. Only if they are creating a site belonging to an org, we must look for all organization memberships to ensure they can add to it.
2. We have to look up the UUID of the upstream to use.
3. Creating the sites list at the end will certainly slow down the creator.

We can stop #3 entirely and ameliorate 1 and 2 by allowing the user to put in a UUID for either the org or the upstream, which will then skip the checks required when a name is given instead.
# Re-testing

Each scenario was run 10 times and the numbers averaged.
##### No org, no sites `sites create` time:

real 1m53.251s
user 0m0.351s
sys 0m0.090s
Actions:
- Starts site-creation workflow
- Checks the status of that workflow 24 times
- Pulls in basic info for the new site
##### Pantheon Employees org member, many sites, not adding site to org `sites create` time:

real    1m32.016s
user    0m0.320s
sys 0m0.093s
Actions:
- Starts site-creation workflow
- Checks the status of that workflow 17 times
- Pulls in basic info for the new site
##### Pantheon Employees org member, many sites, adding site to org `sites create` time:

real    1m41.214s
user    0m0.344s
sys 0m0.096s
Actions:
-Starts site-creation workflow
-Checks the status of that workflow 21 times
-Pulls in basic info for the new site
