### PR TITLE
Removed formatting of CommandWithSSH command results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ### Added
 - New field `frozen` appears in `sites list` when a site belonging to your user has been frozen. (#1015)
 
+### Fixed
+- `wp` and `drush` commands both now use the object buffer and output the result of the operation without formatting. (#1023)
+
 ## [0.11.1] - 2016-03-30
 ### Added
 - New command `site drush-version` to check the Drush version number of any or all environments. (#1001)

--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -42,14 +42,11 @@ class DrushCommand extends CommandWithSSH {
    */
   public function __invoke($args, $assoc_args) {
     $elements = $this->getElements($args, $assoc_args);
-
     if ($this->log()->getOptions('logFormat') != 'normal') {
-      $elements['command'] .= ' --pipe';
+      $elements['command']   .= ' --pipe';
     }
     $result = $this->sendCommand($elements);
-    if ($this->log()->getOptions('logFormat') != 'normal') {
-      $this->output()->outputRecordList($result);
-    }
+    $this->output()->outputDump($result);
   }
 
 }

--- a/php/Terminus/Commands/WpCommand.php
+++ b/php/Terminus/Commands/WpCommand.php
@@ -40,11 +40,8 @@ class WpCommand extends CommandWithSSH {
    */
   public function __invoke($args, $assoc_args) {
     $elements = $this->getElements($args, $assoc_args);
-    $result   = $this->sendCommand($elements);
-    if ($this->log()->getOptions('logFormat') != 'normal') {
-      $this->output()->outputRecordList($result);
-    }
+    $results  = $this->sendCommand($elements);
+    $this->output()->outputDump($results);
   }
 
 }
-


### PR DESCRIPTION
The issues that often plague the Terminus CommandWithSSH-descendant commands is usually the result of the formatting it is trying to apply to the results of the commands it issues. I have removed it.
