### PR TITLE
Removed port number from machine-token generation URL for non-localhost hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 ### Added
 - New field `frozen` appears in `sites list` when a site belonging to your user has been frozen. (#1015)
 
+### Changed
+- Removed the port number from the create-a-machine token URL seen when using `auth login` except for when the host is localhost. (#1034)
+
 ### Fixed
 - `wp` and `drush` commands both now use the object buffer and output the result of the operation without formatting. (#1023)
-
 ## [0.11.1] - 2016-03-30
+
 ### Added
 - New command `site drush-version` to check the Drush version number of any or all environments. (#1001)
 - New command `site set-drush-version` to set the Drush version number of any or all environments. (#1001)

--- a/php/Terminus/Models/Auth.php
+++ b/php/Terminus/Models/Auth.php
@@ -44,12 +44,13 @@ class Auth extends TerminusModel {
    * @return string
    */
   public function getMachineTokenCreationUrl() {
-    $url = sprintf(
-      '%s://%s:%s/machine-token/create/%s',
-      TERMINUS_PROTOCOL,
-      TERMINUS_HOST,
-      TERMINUS_PORT,
-      gethostname()
+    $port = '';
+    if (TERMINUS_HOST == 'localhost') {
+      $port = ':' . TERMINUS_PORT;
+    }
+    $url = vsprintf(
+      '%s://%s%s/machine-token/create/%s',
+      [TERMINUS_PROTOCOL, TERMINUS_HOST, $port, gethostname(),]
     );
     return $url;
   }


### PR DESCRIPTION
Closes #1030 

I still need the URL to have the port number if I'm working between Terminus and a local copy of Hermes.
![image](https://cloud.githubusercontent.com/assets/868204/14511668/0eac2b70-018e-11e6-8dfa-6e16c1086bac.png)
