### PR TITLE
Added framework cache clearing to site clear-cache command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - New field `frozen` appears in `sites list` when a site belonging to your user has been frozen. (#1015)
 - New command `site lookup` to look up sites by name. (#1027)
 - New command `site complete-migration`. (#1077)
+- `site clear-cache` now automatically clears the framework cache as well as the Varnish cache. (#1083)
 
 ### Changed
 - Removed the port number from the create-a-machine token URL seen when using `auth login` except for when the host is localhost. (#1034)

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -126,19 +126,18 @@ class SiteCommand extends TerminusCommand {
    * : Environment to clear
    *
    * ## EXAMPLES
-   *  terminus site clear-cache --site=test
+   *  terminus site clear-cache --site=mysite --env=live
    *
    * @subcommand clear-cache
    */
   public function clearCache($args, $assoc_args) {
-    $site     = $this->sites->get(
-      $this->input()->siteName(array('args' => $assoc_args))
+    $site        = $this->sites->get(
+      $this->input()->siteName(['args' => $assoc_args,])
     );
-    $env_id   = $this->input()->env(array('args' => $assoc_args, 'site' => $site));
-    $workflow = $site->workflows->create(
-      'clear_cache',
-      array('environment' => $env_id)
+    $environment = $site->environments->get(
+      $this->input()->env(['args' => $assoc_args, 'site' => $site,])
     );
+    $workflow    = $environment->clearCache();
     $workflow->wait();
     $this->workflowOutput($workflow);
   }

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -74,6 +74,22 @@ class Environment extends TerminusModel {
   }
 
   /**
+   * Clears an environment's cache
+   *
+   * @return Workflow
+   */
+  public function clearCache() {
+    $workflow = $this->site->workflows->create(
+      'clear_cache',
+      [
+        'environment' => $this->get('id'),
+        'params'      => ['framework_cache' => true,],
+      ]
+    );
+    return $workflow;
+  }
+
+  /**
    * Clones database from this environment to another
    *
    * @param string $to_env Environment to clone into

--- a/tests/features/site_clear-cache.feature
+++ b/tests/features/site_clear-cache.feature
@@ -8,10 +8,10 @@ Feature: Clearing a site's cache
     And a site named "[[test_site_name]]"
 
   @vcr site_clear-cache
-  Scenario: Clear Caches on a Site
+  Scenario: Clear the dev environment's cache
     When I run "terminus site clear-cache --site=[[test_site_name]] --env=dev"
     Then I should get "."
     Then I should get:
     """
-    Cleared caches for "dev"
+    Clearing caches for "dev"
     """

--- a/tests/fixtures/site_clear-cache
+++ b/tests/fixtures/site_clear-cache
@@ -6,9 +6,16 @@
         headers:
             Host: onebox
             Expect: null
-            Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
             Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:a946629c-2130-11e6-a77b-bc764e11227e:DwCmG5r2fZgky1cqH54Af'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:a946629c-2130-11e6-a77b-bc764e11227e:DwCmG5r2fZgky1cqH54Af'
+            verify: ''
+            method: post
+            absolute_url: ''
+            json: password1
+            Accept: null
         body: '{"email":"devuser@pantheon.io","password":"password1"}'
     response:
         status:
@@ -17,26 +24,34 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:19 GMT'
+            Date: 'Mon, 23 May 2016 21:55:33 GMT'
             Content-Type: 'application/json; charset=utf-8'
             Content-Length: '182'
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c185f900-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 128c2f70-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '{"session":"25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij","expires_at":1444260199,"user_id":"25069e79-eae7-4d41-8925-1f728a114cb8"}'
+            Strict-Transport-Security: max-age=31536000
+        body: '{"session":"fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S","expires_at":1466459733,"user_id":"fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734"}'
 -
     request:
         method: GET
-        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/profile'
+        url: 'https://onebox/api/users/fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734/memberships/sites?limit=100'
         headers:
             Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: get
+            absolute_url: ''
             Accept: null
-
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:
         status:
             http_version: '1.1'
@@ -44,53 +59,34 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:20 GMT'
-            Content-Type: 'application/json; charset=utf-8'
-            Content-Length: '855'
-            Connection: keep-alive
-            X-Pantheon-Trace-Id: c24f8a90-5749-11e5-a139-c95d7f8f209a
-            X-Frame-Options: deny
-            Access-Control-Allow-Methods: GET
-            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"357-53ecfca8"'
-            Vary: Accept-Encoding
-        body: '{"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}'
--
-    request:
-        method: GET
-        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/memberships/sites?limit=100'
-        headers:
-            Host: onebox
-            Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
-    response:
-        status:
-            http_version: '1.1'
-            code: '200'
-            message: OK
-        headers:
-            Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:21 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:33 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c2979010-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 12e1a270-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"Amp1v6HXuyf0cHBfueit9w=="'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '[{"archived": false, "invited_by_id": null, "role": "team_member", "id": "2818deff-34e7-44dd-a871-14fa640a2d84", "key": "25069e79-eae7-4d41-8925-1f728a114cb8", "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "site": {"created_by_user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "user_in_charge_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "product": {"id": "d4689428-3759-465b-95f6-57ba58471461", "longname": "WordPress"}, "holder_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "name": "behat-tests", "user_in_charge": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "created": 1441837874, "upstream_updates_by_environment": {"remote_head": "502047409f538633ae66f10805b5eb2cd07bb688", "ahead": 1, "remote_branch": "refs/remotes/origin/master", "dev": {"has_code": true, "is_up_to_date_with_upstream": false}, "behind": 3, "has_code": true, "test": {"has_code": false, "is_up_to_date_with_upstream": false}, "has_remote_head": false, "remote_url": "https://github.com/pantheon-systems/WordPress"}, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "branch": "master"}, "owner": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "attributes": {"label": "behat-tests"}, "holder": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "id": "2818deff-34e7-44dd-a871-14fa640a2d84", "preferred_zone": "onebox", "product_id": "d4689428-3759-465b-95f6-57ba58471461"}}, {"archived": false, "invited_by_id": null, "role": "team_member", "id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "key": "25069e79-eae7-4d41-8925-1f728a114cb8", "site_id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "site": {"created_by_user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "user_in_charge_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "product": {"id": "d4689428-3759-465b-95f6-57ba58471461", "longname": "WordPress"}, "holder_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "name": "tagtest", "user_in_charge": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "created": 1440005865, "upstream_updates_by_environment": {"has_code": false}, "purchased_at": 1441233536, "instrument": "c71d4869-08ff-4720-af02-7352a17a85ec", "holder_type": "organization", "service_level": "enterprise", "framework": "drupal", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "branch": "master"}, "owner": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "attributes": {"label": "Tagtest"}, "holder": {"profile": {"machine_name": null, "change_service_url": null, "example_url_3": null, "org_logo": null, "agency_url": null, "email_domain": null, "terms_of_service": null, "org_logo_height": null, "example_url_2": null, "example_url_1": null, "base_domain": null, "billing_url": null, "org_logo_width": null, "number_of_sites_launched": null, "country": null, "number_of_employees": null, "postal_code": null, "name": "EnterpriseOrg"}, "id": "bf200cbe-8995-4891-b5d4-1a8bdc292905"}, "id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "preferred_zone": "onebox", "product_id": "d4689428-3759-465b-95f6-57ba58471461"}}]'
+            Strict-Transport-Security: max-age=31536000
+        body: '[{"archived": false, "invited_by_id": null, "role": "team_member", "id": "8c5da3b7-b021-42fb-9eb3-298b604cd699", "key": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "site_id": "8c5da3b7-b021-42fb-9eb3-298b604cd699", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "site": {"created_by_user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "user_in_charge_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "product": {"id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "longname": "WordPress"}, "holder_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "name": "o-shit-waddup", "user_in_charge": {"profile": {"utm_content": "", "experiments": {"activation_walkme": "modified", "welcome_video": "shown"}, "full_name": "Dat Boi", "initial_identity_strategy": null, "utm_campaign": "", "tracking_first_site_create": 1463780040, "google_adwords_paid_for_site_do_send": 100, "verify": 1, "utm_device": "", "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1464030833, "google_adwords_account_registered_do_send": null, "firstname": "Dat", "utm_term": "", "lastname": "Boi", "pda_campaign": null, "utm_source": "", "last-org-spinup": "none", "web_services_business": null, "initial_identity_name": null, "guilty_of_abuse": null, "tracking_first_site_upgrade": 1464031584, "dtl": "", "modified": 1463779130, "maxdevsites": 2, "google_adwords_account_registered_sent": 1463779134, "organization": ""}, "id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "email": "devuser@pantheon.io"}, "created": 1463783804, "upstream_updates_by_environment": {"remote_head": "416283d2360809753f868ebee64f7c81c8b63f8e", "ahead": 1, "remote_branch": "refs/remotes/origin/master", "live": {}, "dev": {"has_code": true, "is_up_to_date_with_upstream": true}, "behind": 0, "has_code": true, "test": {}, "has_remote_head": true, "remote_url": "https://github.com/pantheon-systems/WordPress"}, "last_code_push": {"timestamp": "2016-05-20T22:36:53", "user_uuid": null}, "framework": "wordpress", "holder_type": "user", "service_level": "free", "php_version": 55, "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "branch": "master"}, "owner": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "attributes": {"label": "O Shit Waddup!"}, "holder": {"profile": {"utm_content": "", "experiments": {"activation_walkme": "modified", "welcome_video": "shown"}, "full_name": "Dat Boi", "initial_identity_strategy": null, "utm_campaign": "", "tracking_first_site_create": 1463780040, "google_adwords_paid_for_site_do_send": 100, "verify": 1, "utm_device": "", "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1464030833, "google_adwords_account_registered_do_send": null, "firstname": "Dat", "utm_term": "", "lastname": "Boi", "pda_campaign": null, "utm_source": "", "last-org-spinup": "none", "web_services_business": null, "initial_identity_name": null, "guilty_of_abuse": null, "tracking_first_site_upgrade": 1464031584, "dtl": "", "modified": 1463779130, "maxdevsites": 2, "google_adwords_account_registered_sent": 1463779134, "organization": ""}, "id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "email": "devuser@pantheon.io"}, "id": "8c5da3b7-b021-42fb-9eb3-298b604cd699", "preferred_zone": "onebox", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6"}}, {"archived": false, "invited_by_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "role": "team_member", "id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "key": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "site": {"user_in_charge_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "product": {"id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "longname": "WordPress"}, "service_level": "pro", "user_in_charge": {"profile": {"utm_content": "", "experiments": {"activation_walkme": "modified", "welcome_video": "shown"}, "full_name": "Dat Boi", "initial_identity_strategy": null, "utm_campaign": "", "tracking_first_site_create": 1463780040, "google_adwords_paid_for_site_do_send": 100, "verify": 1, "utm_device": "", "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1464030833, "google_adwords_account_registered_do_send": null, "firstname": "Dat", "utm_term": "", "lastname": "Boi", "pda_campaign": null, "utm_source": "", "last-org-spinup": "none", "web_services_business": null, "initial_identity_name": null, "guilty_of_abuse": null, "tracking_first_site_upgrade": 1464031584, "dtl": "", "modified": 1463779130, "maxdevsites": 2, "google_adwords_account_registered_sent": 1463779134, "organization": ""}, "id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "email": "devuser@pantheon.io"}, "upstream_updates_by_environment": {"remote_head": "416283d2360809753f868ebee64f7c81c8b63f8e", "ahead": 1, "remote_branch": "refs/remotes/origin/master", "live": {"has_code": true, "is_up_to_date_with_upstream": true}, "dev": {"has_code": true, "is_up_to_date_with_upstream": true}, "behind": 0, "has_code": true, "test": {"has_code": true, "is_up_to_date_with_upstream": true}, "has_remote_head": true, "remote_url": "https://github.com/pantheon-systems/WordPress"}, "purchased_at": 1464031584, "framework": "wordpress", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "branch": "master"}, "owner": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "attributes": {"label": "Behat Tests"}, "holder": {"profile": {"machine_name": null, "change_service_url": null, "name": "EnterpriseOrg", "email_domain": null, "base_domain": null, "billing_url": null, "terms_of_service": null}, "id": "8bc110ff-6ee5-480a-ae4e-065593aea70a"}, "id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "preferred_zone": "onebox", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "created_by_user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "holder_id": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "name": "behat-tests", "created": 1464030940, "instrument": "767d05f1-f216-4744-955e-9356ce8a1f25", "holder_type": "organization", "php_version": 55, "organization": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "last_code_push": {"timestamp": "2016-05-23T19:15:49", "user_uuid": null}}}]'
 -
     request:
         method: GET
-        url: 'https://onebox/api/users/25069e79-eae7-4d41-8925-1f728a114cb8/memberships/organizations?limit=100'
+        url: 'https://onebox/api/users/fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734/memberships/organizations?limit=100'
         headers:
             Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: get
+            absolute_url: ''
             Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:
         status:
             http_version: '1.1'
@@ -98,26 +94,34 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:21 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:34 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c2de8420-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 132a6b40-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"cvUm20200ZYYi7ky6P8bGg=="'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '[{"archived": false, "invited_by_id": null, "role": "admin", "id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "key": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "admin": true, "organization": {"profile": {"machine_name": "enterpriseorg", "change_service_url": null, "example_url_3": null, "org_logo": null, "agency_url": null, "email_domain": null, "terms_of_service": null, "org_logo_height": 85, "example_url_2": null, "example_url_1": null, "base_domain": null, "billing_url": null, "org_logo_width": 85, "number_of_sites_launched": null, "country": null, "number_of_employees": null, "postal_code": null, "name": "EnterpriseOrg"}, "id": "bf200cbe-8995-4891-b5d4-1a8bdc292905"}}, {"archived": false, "invited_by_id": null, "role": "admin", "id": "14cfb348-40de-4ffb-86ad-5d0f861a38d2", "key": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization_id": "14cfb348-40de-4ffb-86ad-5d0f861a38d2", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "admin": true, "organization": {"profile": {"machine_name": "agencyorg", "change_service_url": null, "example_url_3": null, "org_logo": null, "agency_url": null, "email_domain": null, "terms_of_service": null, "org_logo_height": 85, "example_url_2": null, "example_url_1": null, "base_domain": null, "billing_url": null, "org_logo_width": 85, "number_of_sites_launched": null, "country": null, "number_of_employees": null, "postal_code": null, "name": "AgencyOrg"}, "id": "14cfb348-40de-4ffb-86ad-5d0f861a38d2"}}]'
+            Strict-Transport-Security: max-age=31536000
+        body: '[{"archived": false, "invited_by_id": null, "role": "admin", "id": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "key": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "organization_id": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "admin": true, "organization": {"profile": {"machine_name": "enterpriseorg", "change_service_url": null, "name": "EnterpriseOrg", "email_domain": null, "org_logo_width": 85, "org_logo_height": 85, "base_domain": null, "billing_url": null, "terms_of_service": null, "org_logo": null}, "id": "8bc110ff-6ee5-480a-ae4e-065593aea70a"}}]'
 -
     request:
         method: GET
-        url: 'https://onebox/api/organizations/bf200cbe-8995-4891-b5d4-1a8bdc292905/memberships/sites?limit=100'
+        url: 'https://onebox/api/organizations/8bc110ff-6ee5-480a-ae4e-065593aea70a/memberships/sites?limit=100'
         headers:
             Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: get
+            absolute_url: ''
             Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:
         status:
             http_version: '1.1'
@@ -125,26 +129,35 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:22 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:34 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c322b910-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 135ec1b0-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"cY1y8t7NGGwnzyY8cqC6VQ=="'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '[{"archived": false, "invited_by_id": null, "role": "team_member", "id": "88a4668f-3413-417d-b044-6f4aee2e127e", "key": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "organization_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "site_id": "88a4668f-3413-417d-b044-6f4aee2e127e", "site": {"user_in_charge_id": "b22aa6cd-97aa-4a7c-9f28-3dc0cce08d68", "product": {"id": "d4689428-3759-465b-95f6-57ba58471461", "longname": "WordPress"}, "service_level": "enterprise", "user_in_charge": {"profile": {"utm_term": "", "tracking_first_organization_invite": 1434485371, "invites_to_nonuser": 2, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "not_shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1434483367, "verify": 1, "google_adwords_account_registered_sent": 1434056527, "invites_to_user": 2, "utm_medium": "", "job_function": "developer", "tracking_first_workflow_in_live": 1435078673, "tracking_first_team_invite": 1434487173, "firstname": "Sa''ra", "invites_to_site": 2, "lastname": "McCutcheon", "pda_campaign": null, "utm_source": "", "invites_sent": 4, "google_adwords_paid_for_site_sent": 1434489223, "last-org-spinup": "none", "web_services_business": null, "invites_to_org": 2, "tracking_first_site_upgrade": 1434488696, "modified": 1434056524, "maxdevsites": 2, "lead_type": "", "organization": " Pantheon"}, "id": "b22aa6cd-97aa-4a7c-9f28-3dc0cce08d68", "email": "user@pantheon.io"}, "upstream_updates_by_environment": {"remote_head": "502047409f538633ae66f10805b5eb2cd07bb688", "ahead": 1, "remote_branch": "refs/remotes/origin/master", "dev": {"has_code": true, "is_up_to_date_with_upstream": false}, "behind": 1, "has_code": true, "test": {"has_code": false, "is_up_to_date_with_upstream": false}, "has_remote_head": false, "remote_url": "https://github.com/pantheon-systems/WordPress"}, "purchased_at": 1434488696, "framework": "unknown", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "branch": "master"}, "owner": "b22aa6cd-97aa-4a7c-9f28-3dc0cce08d68", "attributes": {"label": "enterprisetest"}, "holder": {"profile": {"machine_name": null, "change_service_url": null, "example_url_3": null, "org_logo": null, "agency_url": null, "email_domain": null, "terms_of_service": null, "org_logo_height": null, "example_url_2": null, "example_url_1": null, "base_domain": null, "billing_url": null, "org_logo_width": null, "number_of_sites_launched": null, "country": null, "number_of_employees": null, "postal_code": null, "name": "EnterpriseOrg"}, "id": "bf200cbe-8995-4891-b5d4-1a8bdc292905"}, "id": "88a4668f-3413-417d-b044-6f4aee2e127e", "preferred_zone": "onebox", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "created_by_user_id": "b22aa6cd-97aa-4a7c-9f28-3dc0cce08d68", "holder_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "name": "enterprisetest", "created": 1434487064, "instrument": "c71d4869-08ff-4720-af02-7352a17a85ec", "holder_type": "organization", "php_version": 55, "organization": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "last_code_push": {"timestamp": "2015-08-13T00:05:46", "user_uuid": null}}, "tags": ["torg"]}, {"archived": false, "invited_by_id": null, "role": "team_member", "id": "2818deff-34e7-44dd-a871-14fa640a2d84", "key": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "organization_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "site": {"created_by_user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "user_in_charge_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "product": {"id": "d4689428-3759-465b-95f6-57ba58471461", "longname": "WordPress"}, "holder_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "name": "behat-tests", "user_in_charge": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "created": 1441837874, "upstream_updates_by_environment": {"remote_head": "502047409f538633ae66f10805b5eb2cd07bb688", "ahead": 1, "remote_branch": "refs/remotes/origin/master", "dev": {"has_code": true, "is_up_to_date_with_upstream": false}, "behind": 3, "has_code": true, "test": {"has_code": false, "is_up_to_date_with_upstream": false}, "has_remote_head": false, "remote_url": "https://github.com/pantheon-systems/WordPress"}, "framework": "unknown", "holder_type": "user", "service_level": "free", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "branch": "master"}, "owner": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "attributes": {"label": "behat-tests"}, "holder": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "id": "2818deff-34e7-44dd-a871-14fa640a2d84", "preferred_zone": "onebox", "product_id": "d4689428-3759-465b-95f6-57ba58471461"}, "tags": []}, {"archived": false, "invited_by_id": null, "role": "team_member", "id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "key": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "organization_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "site_id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "site": {"created_by_user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "user_in_charge_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "product": {"id": "d4689428-3759-465b-95f6-57ba58471461", "longname": "WordPress"}, "holder_id": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "name": "tagtest", "user_in_charge": {"profile": {"utm_term": "", "invites_to_nonuser": 3, "seen_first_time_user_popover": true, "utm_content": "", "experiments": {"welcome_video": "shown"}, "utm_device": "", "utm_campaign": "", "tracking_first_site_create": 1435803893, "verify": "b2d0bce5948360151624defd1a5362ac", "google_adwords_account_registered_sent": 1435781184, "invites_to_user": 49, "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1436916029, "tracking_first_team_invite": 1438207771, "firstname": "Dev", "invites_to_site": 52, "lastname": "User", "pda_campaign": null, "utm_source": "", "google_adwords_paid_for_site_sent": 1437064646, "last-org-spinup": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "web_services_business": null, "invites_sent": 52, "tracking_first_site_upgrade": 1436915774, "modified": 1435781178, "maxdevsites": 2, "lead_type": "", "organization": ""}, "id": "25069e79-eae7-4d41-8925-1f728a114cb8", "email": "devuser@pantheon.io"}, "created": 1440005865, "upstream_updates_by_environment": {"has_code": false}, "purchased_at": 1441233536, "instrument": "c71d4869-08ff-4720-af02-7352a17a85ec", "holder_type": "organization", "service_level": "enterprise", "framework": "drupal", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "d4689428-3759-465b-95f6-57ba58471461", "branch": "master"}, "owner": "25069e79-eae7-4d41-8925-1f728a114cb8", "organization": "bf200cbe-8995-4891-b5d4-1a8bdc292905", "attributes": {"label": "Tagtest"}, "holder": {"profile": {"machine_name": null, "change_service_url": null, "example_url_3": null, "org_logo": null, "agency_url": null, "email_domain": null, "terms_of_service": null, "org_logo_height": null, "example_url_2": null, "example_url_1": null, "base_domain": null, "billing_url": null, "org_logo_width": null, "number_of_sites_launched": null, "country": null, "number_of_employees": null, "postal_code": null, "name": "EnterpriseOrg"}, "id": "bf200cbe-8995-4891-b5d4-1a8bdc292905"}, "id": "7339c114-8aca-48e2-a88a-fe3c10f24a9f", "preferred_zone": "onebox", "product_id": "d4689428-3759-465b-95f6-57ba58471461"}, "tags": ["tag1", "tag2"]}]'
+            Strict-Transport-Security: max-age=31536000
+        body: '[{"archived": false, "invited_by_id": null, "role": "team_member", "id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "key": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "organization_id": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "site": {"user_in_charge_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "product": {"id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "longname": "WordPress"}, "service_level": "pro", "user_in_charge": {"profile": {"utm_content": "", "experiments": {"activation_walkme": "modified", "welcome_video": "shown"}, "full_name": "Dat Boi", "initial_identity_strategy": null, "utm_campaign": "", "tracking_first_site_create": 1463780040, "google_adwords_paid_for_site_do_send": 100, "verify": 1, "utm_device": "", "utm_medium": "", "job_function": "", "tracking_first_workflow_in_live": 1464030833, "google_adwords_account_registered_do_send": null, "firstname": "Dat", "utm_term": "", "lastname": "Boi", "pda_campaign": null, "utm_source": "", "last-org-spinup": "none", "web_services_business": null, "initial_identity_name": null, "guilty_of_abuse": null, "tracking_first_site_upgrade": 1464031584, "dtl": "", "modified": 1463779130, "maxdevsites": 2, "google_adwords_account_registered_sent": 1463779134, "organization": ""}, "id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "email": "devuser@pantheon.io"}, "purchased_at": 1464031584, "framework": "wordpress", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "branch": "master"}, "owner": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "attributes": {"label": "Behat Tests"}, "holder": {"profile": {"machine_name": null, "change_service_url": null, "name": "EnterpriseOrg", "email_domain": null, "base_domain": null, "billing_url": null, "terms_of_service": null}, "id": "8bc110ff-6ee5-480a-ae4e-065593aea70a"}, "id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "preferred_zone": "onebox", "product_id": "ebd3ecfc-ff8d-4e3b-aead-eb4202045ce6", "created_by_user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "holder_id": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "name": "behat-tests", "created": 1464030940, "instrument": "767d05f1-f216-4744-955e-9356ce8a1f25", "holder_type": "organization", "php_version": 55, "organization": "8bc110ff-6ee5-480a-ae4e-065593aea70a", "last_code_push": {"timestamp": "2016-05-23T19:15:49", "user_uuid": null}}, "tags": []}]'
 -
     request:
         method: GET
-        url: 'https://onebox/api/organizations/14cfb348-40de-4ffb-86ad-5d0f861a38d2/memberships/sites?limit=100'
+        url: 'https://onebox/api/sites/f8cdfc1b-d63c-449c-ab2f-8cb20715d95f/environments'
         headers:
             Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
             Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:
         status:
             http_version: '1.1'
@@ -152,56 +165,37 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:22 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:34 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c368c2c0-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 13b2fc30-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"2-d4cbb29"'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '[]'
--
-    request:
-        method: GET
-        url: 'https://onebox/api/sites/2818deff-34e7-44dd-a871-14fa640a2d84/environments'
-        headers:
-            Host: onebox
-            Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
-    response:
-        status:
-            http_version: '1.1'
-            code: '200'
-            message: OK
-        headers:
-            Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:24 GMT'
-            Content-Type: 'application/json; charset=utf-8'
-            Transfer-Encoding: chunked
-            Connection: keep-alive
-            X-Pantheon-Trace-Id: c434c550-5749-11e5-a139-c95d7f8f209a
-            X-Frame-Options: deny
-            Access-Control-Allow-Methods: GET
-            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"37b-4e4c5e5f"'
-            Vary: Accept-Encoding
-        body: '{"live": {"environment_created": 1441837875, "dns_zone": "onebox.pantheon.io", "randseed": "F24SUNN1KCV77XSXFTAWHJZMGCNQ4XF6", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-sara-onebox1.onebox.pantheon.io"}, "dev": {"watchers": 1, "diffstat": {}, "on_server_development": true, "environment_created": 1441837874, "dns_zone": "onebox.pantheon.io", "randseed": "L11IUOSLLOJWV5QS2CIQGO35G6VOSHZN", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-onebox.onebox.pantheon.io"}, "test": {"environment_created": 1441837874, "dns_zone": "onebox.pantheon.io", "randseed": "UY920PTXUTOPNTNSKB7U8GWEE4N6OVWS", "target_ref": "refs/tags/pantheon_test_1", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "8e50d684d8a905a89ac70380e9a93a8b9641ced4", "styx_cluster": "styx-onebox.onebox.pantheon.io"}}'
+            Strict-Transport-Security: max-age=31536000
+        body: '{"live": {"ssl_enabled": true, "dedicated_ip": true, "environment_created": 1464030941, "dns_zone": "onebox.pantheon.io", "randseed": "TWYGHAV2TERIMN5RGMVOJDB6EDWKCY0X", "target_ref": "refs/tags/pantheon_live_1", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "2bfea5f155ac0bf46f5abd5cf7465c540c51faf7", "pingdom": 0, "styx_cluster": "styx-sara-onebox6.onebox.pantheon.io"}, "test": {"environment_created": 1464030941, "dns_zone": "onebox.pantheon.io", "randseed": "J6ZNIJDEXVY7TC3BMLORD3VEBVM0GJLS", "target_ref": "refs/tags/pantheon_test_1", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "2bfea5f155ac0bf46f5abd5cf7465c540c51faf7", "styx_cluster": "styx-sara-onebox6.onebox.pantheon.io"}, "dev": {"watchers": 1, "diffstat": {}, "on_server_development": true, "environment_created": 1464030940, "dns_zone": "onebox.pantheon.io", "randseed": "TGUSR4HSRKKUUES3SB2F2T7CZ1XVRPGF", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "2bfea5f155ac0bf46f5abd5cf7465c540c51faf7", "styx_cluster": "styx-sara-onebox6.onebox.pantheon.io"}}'
 -
     request:
         method: POST
-        url: 'https://onebox/api/sites/2818deff-34e7-44dd-a871-14fa640a2d84/environments/dev/workflows'
+        url: 'https://onebox/api/sites/f8cdfc1b-d63c-449c-ab2f-8cb20715d95f/environments/dev/workflows'
         headers:
             Host: onebox
             Expect: null
-            Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
             Content-type: application/json
-        body: '{"type":"clear_cache","params":{}}'
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: post
+            absolute_url: ''
+            json: ''
+            Accept: null
+        body: '{"type":"clear_cache","params":{"framework_cache":true}}'
     response:
         status:
             http_version: '1.1'
@@ -209,25 +203,34 @@
             message: Accepted
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:26 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:36 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c50d9920-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 1405d720-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '{"environment_id": "dev", "params": {}, "role": "owner", "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "task_ids": ["c511dcf6-5749-11e5-beec-bc764e117665", "c513374a-5749-11e5-beec-bc764e117665"], "trace_id": "c50d9920-5749-11e5-a139-c95d7f8f209a", "type": "clear_cache", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "id": "c5114b38-5749-11e5-beec-bc764e117665", "key": "1441839600", "waiting_for_task_id": "c511dcf6-5749-11e5-beec-bc764e117665", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1441841005.51422, "reason": "", "environment": "dev", "final_task_id": null, "result": null, "total_time": null, "active_description": "Clear cache for \"dev\"", "description": "Clear cache for \"dev\"", "step": 1, "number_of_tasks": 2, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=c50d9920-5749-11e5-a139-c95d7f8f209a&from_iso_date=2015-09-09T23:18:25.514220Z&to_iso_date=now", "user": {"created_at": 1435781178, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "25069e79-eae7-4d41-8925-1f728a114cb8"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "dev", "fn_name": "trigger_task", "params": {"paths": null, "hostnames": null, "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "task_type": "ban_varnish_routes", "environment_id": "dev"}, "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "trace_id": "c50d9920-5749-11e5-a139-c95d7f8f209a", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "workflow_id": "c5114b38-5749-11e5-beec-bc764e117665", "id": "c511dcf6-5749-11e5-beec-bc764e117665", "key": "1441839600", "responses": [], "created_at": 1441841005.517951, "queued_time": null, "run_time": null, "phase": "created", "allow_concurrent": false, "result": null, "total_time": null, "internal_reason": "", "build_url": null, "messages": {}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=c50d9920-5749-11e5-a139-c95d7f8f209a&from_iso_date=2015-09-09T23:18:25.517951Z&to_iso_date=now", "type": "ban_varnish_routes"}}'
+        body: '{"environment_id": "dev", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "trace_id": "1405d720-2131-11e6-a18a-5b359b7a5af1", "params": {"framework_cache": true, "varnish_cache": true}, "task_ids": ["140f6e2a-2131-11e6-820f-bc764e11227e", "1410a4f2-2131-11e6-820f-bc764e11227e", "1411a906-2131-11e6-820f-bc764e11227e"], "role": "owner", "type": "clear_cache", "id": "140bda08-2131-11e6-820f-bc764e11227e", "key": "1464037200", "waiting_for_task_id": "140f6e2a-2131-11e6-820f-bc764e11227e", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1464040535.481396, "reason": "", "environment": "dev", "final_task_id": null, "result": null, "total_time": null, "active_description": "Clear cache for \"dev\"", "description": "Clear cache for \"dev\"", "step": 1, "has_operation_log_output": false, "number_of_tasks": 3, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=1405d720-2131-11e6-a18a-5b359b7a5af1&from_iso_date=2016-05-23T21:50:35.481396Z&to_iso_date=now", "user": {"user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "created_at": 1463779128, "destination_organization_id": null, "is_registered": true, "created_organization_id": null, "password": "SCRUBBED", "email": "devuser@pantheon.io"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"environment": "dev", "fn_name": "queue_jenkins_task", "params": {"host": "162.242.168.42", "task_type": "endpoint_clear_framework_cache", "job_id": "140f6e2a-2131-11e6-820f-bc764e11227e", "binding_id": "7e148f347a9f4cd0aff6a3760ee136f2"}, "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "trace_id": "1405d720-2131-11e6-a18a-5b359b7a5af1", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "workflow_id": "140bda08-2131-11e6-820f-bc764e11227e", "id": "140f6e2a-2131-11e6-820f-bc764e11227e", "key": "1464037200", "responses": [], "queued_time": null, "host": "162.242.168.42", "result": null, "phase": "created", "created_at": 1464040535.504849, "allow_concurrent": false, "run_time": null, "total_time": null, "reason": "", "error_details": "", "internal_reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=1405d720-2131-11e6-a18a-5b359b7a5af1&from_iso_date=2016-05-23T21:50:35.504849Z&to_iso_date=now", "type": "endpoint_clear_framework_cache", "build_url": null, "messages": {}}}'
 -
     request:
         method: GET
-        url: 'https://onebox/api/sites/2818deff-34e7-44dd-a871-14fa640a2d84/workflows/c5114b38-5749-11e5-beec-bc764e117665'
+        url: 'https://onebox/api/sites/f8cdfc1b-d63c-449c-ab2f-8cb20715d95f/workflows/140bda08-2131-11e6-820f-bc764e11227e'
         headers:
             Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.1 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            headers: 'Bearer fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734:129307e6-2131-11e6-ad93-bc764e11227e:CiWGQnuXwxB9cszEMdS4S'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
             Accept: null
-            User-Agent: 'Terminus/0.7.1 (php_version=5.5.27&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
     response:
         status:
             http_version: '1.1'
@@ -235,43 +238,16 @@
             message: OK
         headers:
             Server: nginx
-            Date: 'Wed, 09 Sep 2015 23:23:27 GMT'
-            Content-Type: 'application/json; charset=utf-8'
+            Date: 'Mon, 23 May 2016 21:55:36 GMT'
+            Content-Type: application/json
             Transfer-Encoding: chunked
             Connection: keep-alive
-            X-Pantheon-Trace-Id: c5f253d0-5749-11e5-a139-c95d7f8f209a
+            X-Pantheon-Trace-Id: 14e49e60-2131-11e6-a18a-5b359b7a5af1
             X-Frame-Options: deny
             Access-Control-Allow-Methods: GET
             Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            ETag: 'W/"sihqxj2rT9Hk7gRxhXphFA=="'
+            Cache-Control: no-cache
+            Pragma: no-cache
             Vary: Accept-Encoding
-        body: '{"environment_id": "dev", "final_task_id": "c513374a-5749-11e5-beec-bc764e117665", "finished_at": 1441841006.752224, "params": {}, "reason": "", "result": "succeeded", "role": "owner", "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "started_at": 1441841005.569708, "task_ids": ["c511dcf6-5749-11e5-beec-bc764e117665", "c513374a-5749-11e5-beec-bc764e117665"], "trace_id": "c50d9920-5749-11e5-a139-c95d7f8f209a", "type": "clear_cache", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "waiting_for_task_id": null, "id": "c5114b38-5749-11e5-beec-bc764e117665", "key": "2818deff-34e7-44dd-a871-14fa640a2d84", "keep_forever": false, "phase": "finished", "queued_time": null, "run_time": 1.1825158596038818, "created_at": 1441841005.51422, "environment": "dev", "total_time": 1.2380039691925049, "active_description": "Cleared caches for \"dev\"", "description": "Clear cache for \"dev\"", "step": 2, "number_of_tasks": 2, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=c50d9920-5749-11e5-a139-c95d7f8f209a&from_iso_date=2015-09-09T23:18:25.514220Z&to_iso_date=2015-09-09T23:28:26.752224Z", "user": {"created_at": 1435781178, "email": "devuser@pantheon.io", "password": "SCRUBBED", "id": "25069e79-eae7-4d41-8925-1f728a114cb8"}, "user_email": "devuser@pantheon.io", "final_task": {"build": {"url": "job/take_screenshot/334/", "number": 334, "phase": "STARTED", "estimated_duration": 18854, "duration": 0, "full_url": "https://162.242.168.41:8090/jenkins/job/take_screenshot/334/"}, "environment": "dev", "finished_at": 1441841006.735094, "fn_name": "queue_jenkins_task", "params": {"site_hostname": "dev-behat-tests.onebox.pantheon.io", "task_type": "take_screenshot", "job_id": "c513374a-5749-11e5-beec-bc764e117665", "envs": "dev", "host": "162.242.168.41", "site_uuid": "2818deff-34e7-44dd-a871-14fa640a2d84", "pool": ["162.242.168.41"]}, "queued_at": 1441841006.573646, "responses": [{"code": 302, "body": "Successfully queued take_screenshot"}], "result": "succeeded", "site_id": "2818deff-34e7-44dd-a871-14fa640a2d84", "started_at": 1441841006.73509, "trace_id": "c50d9920-5749-11e5-a139-c95d7f8f209a", "user_id": "25069e79-eae7-4d41-8925-1f728a114cb8", "workflow_id": "c5114b38-5749-11e5-beec-bc764e117665", "id": "c513374a-5749-11e5-beec-bc764e117665", "key": "1441839600", "created_at": 1441841005.526817, "queued_time": 0.16144394874572754, "run_time": 4.0531158447265625e-06, "phase": "finished", "allow_concurrent": false, "total_time": 1.2082769870758057, "internal_reason": "", "build_url": "https://162.242.168.41:8090/jenkins/job/take_screenshot/334/", "messages": {"2015-09-09T23:23:27.020561": {"message": "Successfully queued take_screenshot", "level": "INFO"}}, "reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=c50d9920-5749-11e5-a139-c95d7f8f209a&from_iso_date=2015-09-09T23:18:25.526817Z&to_iso_date=2015-09-09T23:28:26.735094Z", "type": "take_screenshot"}}'
--
-    request:
-        method: POST
-        url: 'https://onebox/api/sites/2818deff-34e7-44dd-a871-14fa640a2d84/environments/dev/workflows'
-        headers:
-            Host: onebox
-            Expect: null
-            Accept: null
-            User-Agent: 'Terminus/0.9.2 (php_version=5.6.14&script=boot-fs.php)'
-            Cookie: 'X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij; X-Pantheon-Session=25069e79-eae7-4d41-8925-1f728a114cb8:c18ab5da-5749-11e5-a354-bc764e117665:Qf8DH30VlqgfqCYaQBcij'
-            Content-type: application/json
-        body: '"{\"type\":\"clear_cache\",\"params\":{}}"'
-    response:
-        status:
-            http_version: '1.1'
-            code: '401'
-            message: Unauthorized
-        headers:
-            Server: nginx
-            Date: 'Thu, 05 Nov 2015 23:32:15 GMT'
-            Content-Type: 'application/json; charset=utf-8'
-            Content-Length: '57'
-            Connection: keep-alive
-            X-Pantheon-Trace-Id: 728b2750-8415-11e5-9b12-15e5db30055d
-            X-Frame-Options: deny
-            Access-Control-Allow-Methods: GET
-            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
-            Vary: Accept-Encoding
-        body: '"Invalid or expired session header: X-Pantheon-Session\n"'
+            Strict-Transport-Security: max-age=31536000
+        body: '{"environment_id": "dev", "params": {"framework_cache": true, "varnish_cache": true}, "role": "owner", "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "started_at": 1464040535.555916, "task_ids": ["140f6e2a-2131-11e6-820f-bc764e11227e", "1410a4f2-2131-11e6-820f-bc764e11227e", "1411a906-2131-11e6-820f-bc764e11227e"], "trace_id": "1405d720-2131-11e6-a18a-5b359b7a5af1", "type": "clear_cache", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "id": "140bda08-2131-11e6-820f-bc764e11227e", "key": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "waiting_for_task_id": "140f6e2a-2131-11e6-820f-bc764e11227e", "keep_forever": false, "phase": "started", "queued_time": null, "run_time": null, "created_at": 1464040535.481396, "reason": "", "environment": "dev", "final_task_id": null, "result": "succeeded", "total_time": null, "active_description": "Clearing caches for \"dev\"", "description": "Clear cache for \"dev\"", "step": 1, "has_operation_log_output": false, "number_of_tasks": 3, "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=1405d720-2131-11e6-a18a-5b359b7a5af1&from_iso_date=2016-05-23T21:50:35.481396Z&to_iso_date=now", "user": {"user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "created_at": 1463779128, "destination_organization_id": null, "is_registered": true, "created_organization_id": null, "password": "SCRUBBED", "email": "devuser@pantheon.io"}, "user_email": "devuser@pantheon.io", "waiting_for_task": {"build": {"url": "job/endpoint_clear_framework_cache/1/", "number": 1, "phase": "STARTED", "estimated_duration": -1, "duration": 0, "full_url": "https://162.242.168.42:8090/jenkins/job/endpoint_clear_framework_cache/1/"}, "environment": "dev", "fn_name": "queue_jenkins_task", "params": {"host": "162.242.168.42", "task_type": "endpoint_clear_framework_cache", "job_id": "140f6e2a-2131-11e6-820f-bc764e11227e", "binding_id": "7e148f347a9f4cd0aff6a3760ee136f2"}, "queued_at": 1464040535.556028, "responses": [{"code": 201, "body": "Successfully queued endpoint_clear_framework_cache", "error_details": "", "internal_reason": ""}], "site_id": "f8cdfc1b-d63c-449c-ab2f-8cb20715d95f", "started_at": 1464040536.642466, "trace_id": "1405d720-2131-11e6-a18a-5b359b7a5af1", "user_id": "fb4cd9c9-bea4-4733-a5e4-9b5f3e3d2734", "workflow_id": "140bda08-2131-11e6-820f-bc764e11227e", "id": "140f6e2a-2131-11e6-820f-bc764e11227e", "key": "1464037200", "queued_time": 1.0864381790161133, "host": "162.242.168.42", "result": null, "phase": "started", "created_at": 1464040535.504849, "allow_concurrent": false, "run_time": null, "total_time": null, "reason": "", "error_details": "", "internal_reason": "", "trace_log_url": "https://logs.onebox.getpantheon.com:9443//#/dashboard/file/Trace_Id.json?trace_id=1405d720-2131-11e6-a18a-5b359b7a5af1&from_iso_date=2016-05-23T21:50:35.504849Z&to_iso_date=now", "type": "endpoint_clear_framework_cache", "build_url": "https://162.242.168.42:8090/jenkins/job/endpoint_clear_framework_cache/1/", "messages": {"2016-05-23T21:55:36.946506": {"message": "Successfully queued endpoint_clear_framework_cache", "level": "INFO"}}}}'


### PR DESCRIPTION
Closes #1078 

@ari-gold All of these options are available via the API, but this PR exposes only two of those options. Does it make sense to enable more of them, or to not enable framework and varnish cache clearing?

```
        ========================= =========  ============================================
        Key                       Required   Description
        ========================= =========  ============================================
        varnish_cache             False      Whether or not to ban Varnish routes
        framework_cache           False      Whether or not to clear drupal/drupal8/wordpress's cache
        apc_cache                 False      Whether or not to clear APC caches
        styx_cache                False      Whether or not to flush Styx routes
        styx_cache_clear_bindings False      Whether or not to flush bindings routes
                                             from the Styx cache
        hostnames                 False      The hostnames to operate on
        paths                     False      The paths to flush
        get_screenshot            False      Whether or not to take a screenshot after
        ========================= =========  ============================================
```
