### PR TITLE
Added a site's frozen status to site info and organizations sites list outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project starting with the 0.6.0 release will be docu
 - Changed the `SynopsisValidator` so that any unnamed command argument between `<` and `>` may be given any name. (#1041)
 - When running `site deploy` and there are no changes to deploy, Terminus will now exit with status `0` rather than `1`. (#1054)
 - Moved log-out function out of `AuthCommand` and into the `Auth` model. (#1058)
+- A site's frozen status will appear now in both the `site info` output and when running `organizations sites list`. (#1091)
 
 ### Fixed
 - `wp` and `drush` commands both now use the object buffer and output the result of the operation without formatting. (#1023)

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -162,6 +162,7 @@ class OrganizationsCommand extends TerminusCommand {
             continue;
           }
           $site       = $membership->get('site');
+          var_dump($site);
           $data_array = array(
             'name'          => null,
             'id'            => null,
@@ -174,6 +175,9 @@ class OrganizationsCommand extends TerminusCommand {
             if (($value == null) && isset($site->$key)) {
               $data_array[$key] = $site->$key;
             }
+          }
+          if (isset($site->frozen) && (boolean)$site->frozen) {
+            $data_array['frozen'] = true;
           }
           $data_array['created'] = date(
             TERMINUS_DATE_FORMAT,

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -162,7 +162,6 @@ class OrganizationsCommand extends TerminusCommand {
             continue;
           }
           $site       = $membership->get('site');
-          var_dump($site);
           $data_array = array(
             'name'          => null,
             'id'            => null,

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1044,7 +1044,9 @@ class SiteCommand extends TerminusCommand {
    * : field to return
    */
   public function info($args, $assoc_args) {
-    $site = $this->sites->get($this->input()->siteName(array('args' => $assoc_args)));
+    $site = $this->sites->get(
+      $this->input()->siteName(['args' => $assoc_args,])
+    );
 
     // Fetch environment data for sftp/git connection info
     $site->environments->all();

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -283,7 +283,7 @@ class SitesCommand extends TerminusCommand {
         'created'       => date(TERMINUS_DATE_FORMAT, $site->get('created')),
         'memberships'   => $memberships,
       ];
-      if ($site->get('frozen')) {
+      if ((boolean)$site->get('frozen')) {
         $rows[$site->get('id')]['frozen'] = true;
       }
     }

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -485,6 +485,9 @@ class Site extends TerminusModel {
     if (!is_null($info['created'])) {
       $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
     }
+    if ((boolean)$this->get('frozen')) {
+      $info['frozen'] = true;
+    }
     if ($info['php_version'] == '55') {
       $info['php_version'] = '5.5';
     } else {


### PR DESCRIPTION
Closes #1089 

As with `sites list`, the frozen column does not appear if the organization hasn't any frozen sites.
![image](https://cloud.githubusercontent.com/assets/868204/15618115/e0eae2f0-243b-11e6-90a1-9361a3789649.png)

The field does not appear at all if the site is not frozen.
![image](https://cloud.githubusercontent.com/assets/868204/15618078/c0a4c948-243b-11e6-9bea-5b764c480e0d.png)
