### PR TITLE
Allow for string date format on site info

### DIFF
--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -482,10 +482,8 @@ class Site extends TerminusModel {
         $info[$info_key] = $this->get($info_key);
       }
     }
-    if (!is_null($info['created'])) {
-      if (is_numeric($info['created'])) {
-        $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
-      }
+    if (!is_null($info['created']) && is_numeric($info['created'])) {
+      $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
     }
     if ((boolean)$this->get('frozen')) {
       $info['frozen'] = true;

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -483,7 +483,9 @@ class Site extends TerminusModel {
       }
     }
     if (!is_null($info['created'])) {
-      $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
+      if (is_numeric($info['created'])) {
+        $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
+      }
     }
     if ((boolean)$this->get('frozen')) {
       $info['frozen'] = true;


### PR DESCRIPTION
site info brings in a string date format, making temrinus to show a php notice as well as a wrong date.

Attached is a patch that allows for both formats, and both are used when you terminus site create.
