### PR TITLE
Show git clone commandline on site info

### DIFF
--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -476,6 +476,7 @@ class Site extends TerminusModel {
       'holder_type'   => null,
       'holder_id'     => null,
       'owner'         => null,
+      'git_clone'     => null,
     ];
     foreach ($info as $info_key => $datum) {
       if ($datum == null) {
@@ -493,6 +494,8 @@ class Site extends TerminusModel {
     } else {
       $info['php_version'] = '5.3';
     }
+
+    $info['git_clone'] = "git clone ssh://codeserver.dev.{$info['id']}@codeserver.dev.{$info['id']}.drush.in:2222/~/repository.git {$info['name']}";
 
     if ($key) {
       if (isset($info[$key])) {

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -495,7 +495,9 @@ class Site extends TerminusModel {
       $info['php_version'] = '5.3';
     }
 
-    $info['git_clone'] = "git clone ssh://codeserver.dev.{$info['id']}@codeserver.dev.{$info['id']}.drush.in:2222/~/repository.git {$info['name']}";
+    $info['git_clone'] = "git clone ssh://codeserver.dev.{$info['id']}" .
+      "@codeserver.dev.{$info['id']}.drush.in:2222/~/repository.git " .
+      "{$info['name']}";
 
     if ($key) {
       if (isset($info[$key])) {


### PR DESCRIPTION
I think it's useful to have a quick way of copy paste the git clone url from the site info command. Useful for after terminus site create
