### PR TITLE
Add New Relic enable|disable commands

### DIFF
--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1407,24 +1407,47 @@ class SiteCommand extends TerminusCommand {
   }
 
   /**
-   * Get information on New Relic
+   * Interacts with New Relic
    *
    * ## OPTIONS
    *
+   * <enable|disable|info>
+   * : Options are enable, disable, and info
+   *
    * [--site=<site>]
-   * : site for which to retreive notifications
+   * : site name
+   *
+   * ## Examples
+   *
+   *    terminus site new-relic info --site=behat-tests
+   *    terminus site new-relic enable --site=behat-tests
+   *    terminus site new-relic disable --site=behat-tests
    *
    * @subcommand new-relic
    */
   public function newRelic($args, $assoc_args) {
-    $site = $this->sites->get(
-      $this->input()->siteName(['args' => $assoc_args])
-    );
-    $data = $site->newRelic();
-    if (!empty($data->account)) {
-      $this->output()->outputRecord($data->account);
-    } else {
-      $this->log()->warning('New Relic is not enabled.');
+    $action = array_shift($args);
+    $site   = $this->sites->get($this->input()->siteName(['args' => $assoc_args]));
+    switch ($action) {
+      case 'enable':
+        $workflow = $site->enableNewRelicPro();
+        $workflow->wait();
+        $this->workflowOutput($workflow);
+          break;
+      case 'disable':
+        $workflow = $site->disableNewRelicPro();
+        $workflow->wait();
+        $this->workflowOutput($workflow);
+          break;
+      case 'info':
+      default:
+        $data = $site->newRelic();
+        if (!empty($data->{'primary admin'})) {
+          $this->output()->outputRecord($data->{'primary admin'});
+        } else {
+          $this->log()->warning('New Relic is not enabled.');
+        }
+          break;
     }
   }
 
@@ -1873,36 +1896,6 @@ class SiteCommand extends TerminusCommand {
         if ($solr) {
           $this->log()->info('Solr disabled. Converging bindings...');
         }
-          break;
-    }
-  }
-
-  /**
-   * Enable or disable New Relic Pro
-   *
-   * ## OPTIONS
-   *
-   * <enable|disable>
-   * : Options are enable and disable
-   *
-   * [--site=<site>]
-   * : Site on which to change New Relic Pro
-   *
-   * @subcommand new-relic-pro
-   */
-  public function newRelicPro($args, $assoc_args) {
-    $action = array_shift($args);
-    $site   = $this->sites->get($this->input()->siteName(['args' => $assoc_args]));
-    switch ($action) {
-      case 'enable':
-        $workflow = $site->enableNewRelicPro();
-        $workflow->wait();
-        $this->workflowOutput($workflow);
-          break;
-      case 'disable':
-        $workflow = $site->disableNewRelicPro();
-        $workflow->wait();
-        $this->workflowOutput($workflow);
           break;
     }
   }

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1898,12 +1898,12 @@ class SiteCommand extends TerminusCommand {
         $workflow = $site->enableNewRelicPro();
         $workflow->wait();
         $this->workflowOutput($workflow);
-        break;
+          break;
       case 'disable':
         $workflow = $site->disableNewRelicPro();
         $workflow->wait();
         $this->workflowOutput($workflow);
-        break;
+          break;
     }
   }
 

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -1878,6 +1878,36 @@ class SiteCommand extends TerminusCommand {
   }
 
   /**
+   * Enable or disable New Relic Pro
+   *
+   * ## OPTIONS
+   *
+   * <enable|disable>
+   * : Options are enable and disable
+   *
+   * [--site=<site>]
+   * : Site on which to change New Relic Pro
+   *
+   * @subcommand new-relic-pro
+   */
+  public function newRelicPro($args, $assoc_args) {
+    $action = array_shift($args);
+    $site   = $this->sites->get($this->input()->siteName(['args' => $assoc_args]));
+    switch ($action) {
+      case 'enable':
+        $workflow = $site->enableNewRelicPro();
+        $workflow->wait();
+        $this->workflowOutput($workflow);
+        break;
+      case 'disable':
+        $workflow = $site->disableNewRelicPro();
+        $workflow->wait();
+        $this->workflowOutput($workflow);
+        break;
+    }
+  }
+
+  /**
    * Manage site organization tags
    *
    * ## OPTIONS

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -269,6 +269,17 @@ class Site extends TerminusModel {
   }
 
   /**
+   * Disables New Relic Pro
+   */
+  public function disableNewRelicPro() {
+    $workflow = $this->workflows->create(
+      'disable_new_relic_for_site',
+      ['site' => $this->get('id'),]
+    );
+    return $workflow;
+  }
+
+  /**
    * Enables Redis caching
    *
    * @return array
@@ -294,6 +305,17 @@ class Site extends TerminusModel {
     );
     $this->convergeBindings();
     return $response['data'];
+  }
+
+  /**
+   * Enables New Relic Pro
+   */
+  public function enableNewRelicPro() {
+    $workflow = $this->workflows->create(
+      'enable_new_relic_for_site',
+      ['site' => $this->get('id'),]
+    );
+    return $workflow;
   }
 
   /**

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -270,6 +270,8 @@ class Site extends TerminusModel {
 
   /**
    * Disables New Relic Pro
+   *
+   * @return Workflow
    */
   public function disableNewRelicPro() {
     $workflow = $this->workflows->create(
@@ -309,6 +311,8 @@ class Site extends TerminusModel {
 
   /**
    * Enables New Relic Pro
+   *
+   * @return Workflow
    */
   public function enableNewRelicPro() {
     $workflow = $this->workflows->create(

--- a/tests/features/site_new-relic.feature
+++ b/tests/features/site_new-relic.feature
@@ -9,20 +9,20 @@ Feature: New Relic
 
   @vcr site_new-relic
   Scenario: Accessing New Relic data
-    When I run "terminus site new-relic --site=[[test_site_name]]"
+    When I run "terminus site new-relic info --site=[[test_site_name]]"
     Then I should get: "New Relic is not enabled."
 
-  @vcr site_new-relic-pro_enable
+  @vcr site_new-relic_enable
   Scenario: Enabling New Relic Pro
-    When I run "terminus site new-relic-pro enable --site=[[test_site_name]]"
+    When I run "terminus site new-relic enable --site=[[test_site_name]]"
     Then I should get:
     """
     Enabled New Relic
     """
 
-  @vcr site_new-relic-pro_disable
+  @vcr site_new-relic_disable
   Scenario: Disabling New Relic Pro
-    When I run "terminus site new-relic-pro disable --site=[[test_site_name]]"
+    When I run "terminus site new-relic disable --site=[[test_site_name]]"
     Then I should get:
     """
     Disabled New Relic

--- a/tests/features/site_new-relic.feature
+++ b/tests/features/site_new-relic.feature
@@ -1,7 +1,7 @@
 Feature: New Relic
   In order to monitor my site's performance
   As a user
-  I need to be able to view my New Relic data
+  I need to be able to manipulate my New Relic data
 
   Background: I am authenticated and have a site named [[test_site_name]]
     Given I am authenticated
@@ -11,3 +11,19 @@ Feature: New Relic
   Scenario: Accessing New Relic data
     When I run "terminus site new-relic --site=[[test_site_name]]"
     Then I should get: "New Relic is not enabled."
+
+  @vcr site_new-relic-pro_enable
+  Scenario: Enabling New Relic Pro
+    When I run "terminus site new-relic-pro enable --site=[[test_site_name]]"
+    Then I should get:
+    """
+    Enabled New Relic
+    """
+
+  @vcr site_new-relic-pro_disable
+  Scenario: Disabling New Relic Pro
+    When I run "terminus site new-relic-pro disable --site=[[test_site_name]]"
+    Then I should get:
+    """
+    Disabled New Relic
+    """


### PR DESCRIPTION
Adds commands for enabling/disabling New Relic which follows the structure of enabling/disabling Solr.  I pulled the workflows from what I could find in the Dashboard Javascript so I'm hoping the workflows are the right ones to use in Terminus..  I also added some test features for the new commands but was unable to test the tests.  I can confirm that the actual commands in Terminus work for me.

Reference:  #102 
