### PR TITLE
Switched ssh-key add request method from delete to post

### DIFF
--- a/php/Terminus/Models/Collections/SshKeys.php
+++ b/php/Terminus/Models/Collections/SshKeys.php
@@ -25,7 +25,7 @@ class SshKeys extends TerminusCollection {
       'users/' . $this->user->id . '/keys',
       [
         'form_params' => file_get_contents($key_file),
-        'method'      => 'delete',
+        'method'      => 'post',
       ]
     );
     return (array)$response['data'];


### PR DESCRIPTION
Stumbled on a somewhat serious issue while working on https://github.com/kalabox/kalabox/issues/1396.

Looks like `terminus ssh-key add` is actually removing **ALL** your `ssh` keys from the Dashboard. 

:( 
