### PR TITLE
Specify exactly which branches to test, to avoid double-testing PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: php
 
+branches:
+  # Only test the master branch and SemVer tags.
+  only:
+    - master
+    - /^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+.*$/
+
 php:
   - 5.5
   - 5.6
@@ -43,7 +49,7 @@ script:
   - TERMINUS_TEST_MODE=1 vendor/bin/phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml
   - TERMINUS_TEST_MODE=1 ./scripts/test.sh
 
-after_success: 
+after_success:
   - php vendor/bin/coveralls -v -c tests/config/coveralls.xml
   - ./scripts/package.sh
 


### PR DESCRIPTION
Right now, Travis is testing all PRs twice.  This is because it tests every PR, and it also tests every branch.  Every PR has a branch, and ergo is tested twice.

The solution to this (preserve our precious free resources!) is to add a `branches:` directive to our .travis.yml file.  This specifies exactly which branches should be tested.  Because the `branches` directive is also applied to all tags, we also include a regular expression so that all of our SemVer-tagged releases will also be tested.
