### PR TITLE
AL-553 - Added Config class to use in lieu of constants

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,36 +7,37 @@
 ---
 
 # App
-TERMINUS_VERSION:      '0.12.0'
+TERMINUS_VERSION:       '0.12.0'
 
 # Connectivity
-TERMINUS_HOST:         'dashboard.pantheon.io'
-TERMINUS_PORT:         443
-TERMINUS_PROTOCOL:     'https'
-TERMINUS_SSH_HOST:     null
+TERMINUS_HOST:          'dashboard.pantheon.io'
+TERMINUS_PORT:          443
+TERMINUS_PROTOCOL:      'https'
+TERMINUS_SSH_HOST:      null
 
 # Localization
-TERMINUS_DATE_FORMAT:  'Y-m-d H:i:s'
-TERMINUS_TIME_ZONE:    'UTC'
+TERMINUS_DATE_FORMAT:   'Y-m-d H:i:s'
+TERMINUS_TIME_ZONE:     'UTC'
 
 # File Storage
-TERMINUS_CACHE_DIR:    '~/.terminus/cache'
-TERMINUS_CONFIG_DIR:   '~/terminus'
-TERMINUS_LOG_DIR:      '/tmp'
-TERMINUS_PLUGINS_DIR:  '[[ TERMINUS_CONFIG_DIR ]]/plugins'
-TERMINUS_TOKENS_DIR:   '[[ TERMINUS_CACHE_DIR ]]/tokens'
-TERMINUS_ASSETS_DIR:   '[[ TERMINUS_ROOT ]]/php/assets'
+TERMINUS_CACHE_DIR:     '~/.terminus/cache'
+TERMINUS_CONFIG_DIR:    '~/terminus'
+TERMINUS_LOG_DIR:       '/tmp'
+TERMINUS_PLUGINS_DIR:   '[[ TERMINUS_CONFIG_DIR ]]/plugins'
+TERMINUS_TOKENS_DIR:    '[[ TERMINUS_CACHE_DIR ]]/tokens'
+TERMINUS_ASSETS_DIR:    '[[ TERMINUS_ROOT ]]/php/assets'
+TERMINUS_TEMPLATES_DIR: '[[ TERMINUS_ROOT ]]/templates'
 
 # Helpers
-TERMINUS_USER:         null
-TERMINUS_SITE:         null
-TERMINUS_ENV:          null
-TERMINUS_ORG:          null
+TERMINUS_USER:          null
+TERMINUS_SITE:          null
+TERMINUS_ENV:           null
+TERMINUS_ORG:           null
 
 # Testing
-TERMINUS_TEST_MODE:    false
-TERMINUS_VCR_CASSETTE: null
-TERMINUS_VCR_MODE:     null
+TERMINUS_TEST_MODE:     false
+TERMINUS_VCR_CASSETTE:  null
+TERMINUS_VCR_MODE:      null
 
 # Set by Terminus - DO NOT USE
 # Terminus

--- a/php/Terminus/Caches/FileCache.php
+++ b/php/Terminus/Caches/FileCache.php
@@ -14,7 +14,7 @@
 namespace Terminus\Caches;
 
 use Symfony\Component\Finder\Finder;
-use Terminus\Exceptions\TerminusException;
+use Terminus\Config;
 
 /**
  * Reads/writes to a filesystem cache
@@ -53,7 +53,7 @@ class FileCache {
    */
   public function __construct(array $arg_options = []) {
     $default_options = [
-      'cache_dir' => TERMINUS_CACHE_DIR,
+      'cache_dir' => Config::get('cache_dir'),
       'ttl'       => 832040,
       'max_size'  => 267914296,
       'whitelist' => 'a-z0-9._-',
@@ -89,7 +89,7 @@ class FileCache {
       $expire->modify('-' . $ttl . ' seconds');
 
       $finder = $this->getFinder()->date(
-        'before ' . $expire->format(TERMINUS_DATE_FORMAT)
+        'before ' . $expire->format(Config::get('date_format'))
       );
       foreach ($finder as $file) {
         unlink($file->getRealPath());
@@ -328,7 +328,7 @@ class FileCache {
    * @return bool True if write was successful
    */
   protected function write($key, $contents) {
-    $filename = TERMINUS_CACHE_DIR . "/$key";
+    $filename = Config::get('cache_dir') . "/$key";
 
     $written = false;
     if ($filename) {

--- a/php/Terminus/Caches/TokensCache.php
+++ b/php/Terminus/Caches/TokensCache.php
@@ -2,6 +2,7 @@
 
 namespace Terminus\Caches;
 
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
 
 /**
@@ -67,7 +68,8 @@ class TokensCache {
    * @return string
    */
   public function getCacheDir() {
-    return TERMINUS_TOKENS_DIR;
+    $tokens_dir = Config::get('tokens_dir');
+    return $tokens_dir;
   }
 
   /**

--- a/php/Terminus/Collections/Backups.php
+++ b/php/Terminus/Collections/Backups.php
@@ -40,8 +40,8 @@ class Backups extends TerminusCollection {
   public function cancelBackupSchedule() {
     $path_root = sprintf(
       'sites/%s/environments/%s/backups/schedule',
-      $this->environment->site->get('id'),
-      $this->environment->get('id')
+      $this->environment->site->id,
+      $this->environment->id
     );
     $params = ['method' => 'delete',];
     for ($day = 0; $day < 7; $day++) {
@@ -145,8 +145,8 @@ class Backups extends TerminusCollection {
   public function getBackupSchedule() {
     $path     = sprintf(
       'sites/%s/environments/%s/backups/schedule',
-      $this->environment->site->get('id'),
-      $this->environment->get('id')
+      $this->environment->site->id,
+      $this->environment->id
     );
     $response      = $this->request->request($path);
     $response_data = (array)$response['data'];
@@ -192,7 +192,7 @@ class Backups extends TerminusCollection {
         $message,
         [
           'site' => $this->environment->site->get('name'),
-          'env'  => $this->environment->get('id')
+          'env'  => $this->environment->id
         ],
         1
       );

--- a/php/Terminus/Collections/Backups.php
+++ b/php/Terminus/Collections/Backups.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Workflow;

--- a/php/Terminus/Collections/Bindings.php
+++ b/php/Terminus/Collections/Bindings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Models\Binding;
 

--- a/php/Terminus/Collections/Bindings.php
+++ b/php/Terminus/Collections/Bindings.php
@@ -5,6 +5,25 @@ namespace Terminus\Collections;
 use Terminus\Models\Binding;
 
 class Bindings extends TerminusCollection {
+  /**
+   * @var Environment
+   */
+  public $environment;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Binding';
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->environment = $options['environment'];
+    $this->url = "sites/{$this->environment->site->id}/bindings";
+  }
 
   /**
    * Get bindings by type
@@ -27,26 +46,6 @@ class Bindings extends TerminusCollection {
 
     $bindings = array_values($models);
     return $bindings;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = sprintf('sites/%s/bindings', $this->environment->site->get('id'));
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection.
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'environment';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/Commits.php
+++ b/php/Terminus/Collections/Commits.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
-class Instruments extends TerminusCollection {
+class Commits extends TerminusCollection {
 
   /**
    * Give the URL for collection data fetching
@@ -10,7 +10,11 @@ class Instruments extends TerminusCollection {
    * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
-    $url = 'users/' . $this->user->id . '/instruments';
+    $url = sprintf(
+      'sites/%s/environments/%s/code-log',
+      $this->environment->site->get('id'),
+      $this->environment->get('id')
+    );
     return $url;
   }
 
@@ -20,7 +24,7 @@ class Instruments extends TerminusCollection {
    * @return string
    */
   protected function getOwnerName() {
-    $owner_name = 'user';
+    $owner_name = 'environment';
     return $owner_name;
   }
 

--- a/php/Terminus/Collections/Commits.php
+++ b/php/Terminus/Collections/Commits.php
@@ -3,29 +3,28 @@
 namespace Terminus\Collections;
 
 class Commits extends TerminusCollection {
+  /**
+   * @var Environment
+   */
+  public $environment;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Commit';
 
   /**
-   * Give the URL for collection data fetching
+   * Object constructor
    *
-   * @return string URL to use in fetch query
+   * @param array $options Options to set as $this->key
    */
-  protected function getFetchUrl() {
-    $url = sprintf(
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->environment = $options['environment'];
+    $this->url = sprintf(
       'sites/%s/environments/%s/code-log',
-      $this->environment->site->get('id'),
-      $this->environment->get('id')
+      $this->environment->site->id,
+      $this->environment->id
     );
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'environment';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/Environments.php
+++ b/php/Terminus/Collections/Environments.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Models\Environment;
 use Terminus\Models\Workflow;

--- a/php/Terminus/Collections/Environments.php
+++ b/php/Terminus/Collections/Environments.php
@@ -3,9 +3,27 @@
 namespace Terminus\Collections;
 
 use Terminus\Models\Environment;
-use Terminus\Models\Workflow;
 
 class Environments extends TerminusCollection {
+  /**
+   * @var Site
+   */
+  public $site;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Environment';
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->site = $options['site'];
+    $this->url = "sites/{$this->site->id}/environments";
+  }
 
   /**
    * Creates a multidev environment
@@ -17,19 +35,19 @@ class Environments extends TerminusCollection {
   public function create($to_env_id, Environment $from_env) {
     $workflow = $this->site->workflows->create(
       'create_cloud_development_environment',
-      array(
-        'params' => array(
+      [
+        'params' => [
           'environment_id' => $to_env_id,
-          'deploy'         => array(
-            'clone_database' => array('from_environment' => $from_env->id),
-            'clone_files'    => array('from_environment' => $from_env->id),
+          'deploy'         => [
+            'clone_database' => ['from_environment' => $from_env->id,],
+            'clone_files'    => ['from_environment' => $from_env->id,],
             'annotation'     => sprintf(
               'Create the "%s" environment.',
               $to_env_id
-            )
-          )
-        )
-      )
+            ),
+          ],
+        ],
+      ]
     );
     return $workflow;
   }
@@ -64,26 +82,6 @@ class Environments extends TerminusCollection {
       }
     );
     return $environments;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'sites/' . $this->site->get('id') . '/environments';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'site';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/Hostnames.php
+++ b/php/Terminus/Collections/Hostnames.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 class Hostnames extends TerminusCollection {
 

--- a/php/Terminus/Collections/Hostnames.php
+++ b/php/Terminus/Collections/Hostnames.php
@@ -3,11 +3,34 @@
 namespace Terminus\Collections;
 
 class Hostnames extends TerminusCollection {
-
+  /**
+   * @var Environment
+   */
+  public $environment;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Hostname';
   /**
    * @var bool Use to hydrate the data with additional information
    */
   protected $hydrate = false;
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->environment = $options['environment'];
+    $this->url = sprintf(
+      'sites/%s/environments/%s/hostnames?hydrate=%s',
+      $this->environment->site->id,
+      $this->environment->id,
+      $this->hydrate
+    );
+  }
 
   /**
    * Add hostname to environment
@@ -18,14 +41,11 @@ class Hostnames extends TerminusCollection {
   public function addHostname($hostname) {
     $url = sprintf(
       'sites/%s/environments/%s/hostnames/%s',
-      $this->environment->site->get('id'),
-      $this->environment->get('id'),
+      $this->environment->site->id,
+      $this->environment->id,
       rawurlencode($hostname)
     );
-    $response = $this->request->request(
-      $url,
-      ['method' => 'put']
-    );
+    $response = $this->request->request($url, ['method' => 'put',]);
     return $response['data'];
   }
 
@@ -37,31 +57,6 @@ class Hostnames extends TerminusCollection {
    */
   public function setHydration($value) {
     $this->hydrate = $value;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = sprintf(
-      'sites/%s/environments/%s/hostnames?hydrate=%s',
-      $this->environment->site->get('id'),
-      $this->environment->get('id'),
-      $this->hydrate
-    );
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'environment';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/Instruments.php
+++ b/php/Terminus/Collections/Instruments.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
-class Commits extends TerminusCollection {
+class Instruments extends TerminusCollection {
 
   /**
    * Give the URL for collection data fetching
@@ -10,11 +10,7 @@ class Commits extends TerminusCollection {
    * @return string URL to use in fetch query
    */
   protected function getFetchUrl() {
-    $url = sprintf(
-      'sites/%s/environments/%s/code-log',
-      $this->environment->site->get('id'),
-      $this->environment->get('id')
-    );
+    $url = 'users/' . $this->user->id . '/instruments';
     return $url;
   }
 
@@ -24,7 +20,7 @@ class Commits extends TerminusCollection {
    * @return string
    */
   protected function getOwnerName() {
-    $owner_name = 'environment';
+    $owner_name = 'user';
     return $owner_name;
   }
 

--- a/php/Terminus/Collections/Instruments.php
+++ b/php/Terminus/Collections/Instruments.php
@@ -3,25 +3,24 @@
 namespace Terminus\Collections;
 
 class Instruments extends TerminusCollection {
+  /**
+   * @var User
+   */
+  public $user;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Instrument';
 
   /**
-   * Give the URL for collection data fetching
+   * Object constructor
    *
-   * @return string URL to use in fetch query
+   * @param array $options Options to set as $this->key
    */
-  protected function getFetchUrl() {
-    $url = 'users/' . $this->user->id . '/instruments';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'user';
-    return $owner_name;
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->user = $options['user'];
+    $this->url = "users/{$this->user->id}/instruments";
   }
 
 }

--- a/php/Terminus/Collections/MachineTokens.php
+++ b/php/Terminus/Collections/MachineTokens.php
@@ -3,26 +3,24 @@
 namespace Terminus\Collections;
 
 class MachineTokens extends TerminusCollection {
-  protected $user;
+  /**
+   * @var User
+   */
+  public $user;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\MachineToken';
 
   /**
-   * Give the URL for collection data fetching
+   * Object constructor
    *
-   * @return string URL to use in fetch query
+   * @param array $options Options to set as $this->key
    */
-  protected function getFetchUrl() {
-    $url = 'users/' . $this->user->id . '/machine_tokens';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'user';
-    return $owner_name;
+  public function __construct ($options = []) {
+    parent::__construct($options);
+    $this->user = $options['user'];
+    $this->url = "users/{$this->user->id}/machine_tokens";
   }
 
 }

--- a/php/Terminus/Collections/MachineTokens.php
+++ b/php/Terminus/Collections/MachineTokens.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
-
-use Terminus\Models\MachineToken;
+namespace Terminus\Collections;
 
 class MachineTokens extends TerminusCollection {
   protected $user;

--- a/php/Terminus/Collections/OrganizationSiteMemberships.php
+++ b/php/Terminus/Collections/OrganizationSiteMemberships.php
@@ -51,10 +51,7 @@ class OrganizationSiteMemberships extends TerminusCollection {
    * @return OrganizationSiteMembership
    */
   public function get($id) {
-    if (empty($this->models)) {
-      $this->fetch();
-    }
-    $models = $this->models;
+    $models = $this->getMembers();
     if (isset($models[$id])) {
       return $models[$id];
     } else {
@@ -77,7 +74,7 @@ class OrganizationSiteMemberships extends TerminusCollection {
   public function getSite($site_id) {
     if (is_null($membership = $this->get($site_id))) {
       throw new TerminusException(
-        'This user does is not a member of an organization identified by {id}.',
+        'This user is not a member of an organization identified by {id}.',
         ['id' => $site_id,]
       );
     }

--- a/php/Terminus/Collections/OrganizationSiteMemberships.php
+++ b/php/Terminus/Collections/OrganizationSiteMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 class OrganizationSiteMemberships extends TerminusCollection {
   /**

--- a/php/Terminus/Collections/OrganizationUserMemberships.php
+++ b/php/Terminus/Collections/OrganizationUserMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\OrganizationUserMembership;

--- a/php/Terminus/Collections/OrganizationUserMemberships.php
+++ b/php/Terminus/Collections/OrganizationUserMemberships.php
@@ -3,8 +3,6 @@
 namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\OrganizationUserMembership;
-use Terminus\Models\Workflow;
 
 class OrganizationUserMemberships extends TerminusCollection {
   /**
@@ -12,8 +10,12 @@ class OrganizationUserMemberships extends TerminusCollection {
    */
   public $organization;
   /**
-   * @var boolean
+   * @var string
    */
+  protected $collected_class = 'Terminus\Models\OrganizationUserMembership';
+   /**
+    * @var boolean
+    */
   protected $paged = true;
 
   /**
@@ -25,22 +27,6 @@ class OrganizationUserMemberships extends TerminusCollection {
     parent::__construct($options);
     $this->organization = $options['organization'];
     $this->url = "organizations/{$this->organization->id}/memberships/users";
-  }
-
-  /**
-   * Adds a model to this collection
-   *
-   * @param object $model_data  Data to feed into attributes of new model
-   * @param array  $arg_options Data to make properties of the new model
-   * @return void
-   */
-  public function add($model_data, array $arg_options = []) {
-    $default_options = [
-      'id'         => $model_data->id,
-      'collection' => $this,
-    ];
-    $options         = array_merge($default_options, $arg_options);
-    parent::add($model_data, $options);
   }
 
   /**
@@ -81,16 +67,6 @@ class OrganizationUserMemberships extends TerminusCollection {
       compact('id'),
       1
     );
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'organization';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/SiteAuthorizations.php
+++ b/php/Terminus/Collections/SiteAuthorizations.php
@@ -10,7 +10,7 @@ class SiteAuthorizations extends TerminusCollection {
   /**
    * @var string
    */
-  protected $collected_class = 'Terminus\Models\SiteAuthorizations';
+  protected $collected_class = 'Terminus\Models\SiteAuthorization';
 
   /**
    * Object constructor

--- a/php/Terminus/Collections/SiteAuthorizations.php
+++ b/php/Terminus/Collections/SiteAuthorizations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 class SiteAuthorizations extends TerminusCollection {
 

--- a/php/Terminus/Collections/SiteAuthorizations.php
+++ b/php/Terminus/Collections/SiteAuthorizations.php
@@ -3,6 +3,25 @@
 namespace Terminus\Collections;
 
 class SiteAuthorizations extends TerminusCollection {
+  /**
+   * @var Site
+   */
+  public $site;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\SiteAuthorizations';
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->site = $options['site'];
+    $this->url = "sites/{$this->site->id}/authorizations";
+  }
 
   /**
    * Adds a model to this collection
@@ -12,19 +31,12 @@ class SiteAuthorizations extends TerminusCollection {
    * @return SiteAuthorization
    */
   public function add($model_data, array $options = []) {
-    $model   = $this->getMemberName();
-    $owner   = $this->getOwnerName();
     $options = array_merge(
-      [
-        'id'         => $model_data->id,
-        'collection' => $this,
-      ],
+      ['id' => $model_data->id, 'collection' => $this,],
       $options
     );
 
-    $options[$owner] = $this->$owner;
-
-    $model    = new $model($model_data, $options);
+    $model = new $this->collected_class($model_data, $options);
     $model_id = $model_data->id;
     if (property_exists($model_data, 'environment')) {
       $model_id .= '_' . $model_data->environment;
@@ -32,26 +44,6 @@ class SiteAuthorizations extends TerminusCollection {
 
     $this->models[$model_id] = $model;
     return $model;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'sites/' . $this->site->get('id') . '/authorizations';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'site';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/SiteOrganizationMemberships.php
+++ b/php/Terminus/Collections/SiteOrganizationMemberships.php
@@ -2,19 +2,30 @@
 
 namespace Terminus\Collections;
 
-use Terminus\Models\Site;
-use Terminus\Models\SiteOrganizationMembership;
-use Terminus\Models\Workflow;
-
 class SiteOrganizationMemberships extends TerminusCollection {
   /**
    * @var Site
    */
-  protected $site;
+  public $site;
   /**
-   * @var Workflows
+   * @var string
    */
-  protected $workflows;
+  protected $collected_class = 'Terminus\Models\SiteOrganizationMembership';
+  /**
+   * @var boolean
+   */
+  protected $paged = true;
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->site = $options['site'];
+    $this->url = "sites/{$this->site->id}/memberships/organizations";
+  }
 
   /**
    * Adds this org as a member to the site
@@ -26,24 +37,9 @@ class SiteOrganizationMemberships extends TerminusCollection {
   public function addMember($name, $role) {
     $workflow = $this->site->workflows->create(
       'add_site_organization_membership',
-      array('params' => array('organization_name' => $name, 'role' => $role))
+      ['params' => ['organization_name' => $name, 'role' => $role,],]
     );
     return $workflow;
-  }
-
-  /**
-   * Fetches model data from API and instantiates its model instances
-   *
-   * @param array $options params to pass to url request
-   * @return SiteOrganizationMemberships
-   */
-  public function fetch(array $options = array()) {
-    if (!isset($options['paged'])) {
-      $options['paged'] = true;
-    }
-
-    parent::fetch($options);
-    return $this;
   }
 
   /**
@@ -60,26 +56,6 @@ class SiteOrganizationMemberships extends TerminusCollection {
       }
     }
     return null;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'site';
-    return $owner_name;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'sites/' . $this->site->get('id') . '/memberships/organizations';
-    return $url;
   }
 
 }

--- a/php/Terminus/Collections/SiteOrganizationMemberships.php
+++ b/php/Terminus/Collections/SiteOrganizationMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Models\Site;
 use Terminus\Models\SiteOrganizationMembership;

--- a/php/Terminus/Collections/SiteOrganizationMemberships.php
+++ b/php/Terminus/Collections/SiteOrganizationMemberships.php
@@ -34,7 +34,7 @@ class SiteOrganizationMemberships extends TerminusCollection {
    * @param string $role Role for supporting organization to take
    * @return Workflow
    **/
-  public function addMember($name, $role) {
+  public function create($name, $role) {
     $workflow = $this->site->workflows->create(
       'add_site_organization_membership',
       ['params' => ['organization_name' => $name, 'role' => $role,],]

--- a/php/Terminus/Collections/SiteUserMemberships.php
+++ b/php/Terminus/Collections/SiteUserMemberships.php
@@ -3,15 +3,31 @@
 namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\Site;
-use Terminus\Models\SiteUserMembership;
-use Terminus\Models\Workflow;
 
 class SiteUserMemberships extends TerminusCollection {
   /**
    * @var Site
    */
-  protected $site;
+  public $site;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\SiteUserMembership';
+  /**
+   * @var boolean
+   */
+  protected $paged = true;
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->site = $options['site'];
+    $this->url = "sites/{$this->site->id}/memberships/users";
+  }
 
   /**
    * Adds this user as a member to the site
@@ -23,23 +39,9 @@ class SiteUserMemberships extends TerminusCollection {
   public function addMember($email, $role) {
     $workflow = $this->site->workflows->create(
       'add_site_user_membership',
-      array('params' => array('user_email' => $email, 'role' => $role))
+      ['params' => ['user_email' => $email, 'role' => $role,],]
     );
     return $workflow;
-  }
-
-  /**
-   * Fetches model data from API and instantiates its model instances
-   *
-   * @param array $options params to pass to url request
-   * @return SiteUserMemberships
-   */
-  public function fetch(array $options = array()) {
-    if (!isset($options['paged'])) {
-      $options['paged'] = true;
-    }
-    parent::fetch($options);
-    return $this;
   }
 
   /**
@@ -70,25 +72,6 @@ class SiteUserMemberships extends TerminusCollection {
       compact('id'),
       1
     );
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'sites/' . $this->site->get('id') . '/memberships/users';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    return 'site';
   }
 
 }

--- a/php/Terminus/Collections/SiteUserMemberships.php
+++ b/php/Terminus/Collections/SiteUserMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Site;

--- a/php/Terminus/Collections/SiteUserMemberships.php
+++ b/php/Terminus/Collections/SiteUserMemberships.php
@@ -36,7 +36,7 @@ class SiteUserMemberships extends TerminusCollection {
    * @param string $role  Role to assign to the new user
    * @return Workflow
    **/
-  public function addMember($email, $role) {
+  public function create($email, $role) {
     $workflow = $this->site->workflows->create(
       'add_site_user_membership',
       ['params' => ['user_email' => $email, 'role' => $role,],]

--- a/php/Terminus/Collections/Sites.php
+++ b/php/Terminus/Collections/Sites.php
@@ -3,12 +3,13 @@
 namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\Site;
-use Terminus\Models\User;
-use Terminus\Models\Workflow;
 use Terminus\Session;
 
 class Sites extends TerminusCollection {
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Site';
   /**
    * @var User
    */
@@ -185,7 +186,7 @@ class Sites extends TerminusCollection {
           1
         );
       }
-      $site = new Site(
+      $site = new $this->collected_class(
         (object)['id' => $uuid,],
         ['id' => $uuid, 'collection' => $this,]
       );

--- a/php/Terminus/Collections/Sites.php
+++ b/php/Terminus/Collections/Sites.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
-use Terminus\Session;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Site;
 use Terminus\Models\User;
 use Terminus\Models\Workflow;
+use Terminus\Session;
 
 class Sites extends TerminusCollection {
   /**

--- a/php/Terminus/Collections/SshKeys.php
+++ b/php/Terminus/Collections/SshKeys.php
@@ -2,9 +2,26 @@
 
 namespace Terminus\Collections;
 
-use Terminus\Exceptions\TerminusException;
-
 class SshKeys extends TerminusCollection {
+  /**
+   * @var User
+   */
+  public $user;
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\SshKey';
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->user = $options['user'];
+    $this->url = "users/{$this->user->id}/keys";
+  }
 
   /**
    * Adds an SSH key to the user's Pantheon account
@@ -50,9 +67,9 @@ class SshKeys extends TerminusCollection {
    * @param array $options params to pass to url request
    * @return SshKeys $this
    */
-  public function fetch(array $options = array()) {
+  public function fetch(array $options = []) {
     $results = $this->getCollectionData($options);
-    $data    = $this->objectify($results['data']);
+    $data    = (object)$results['data'];
 
     foreach (get_object_vars($data) as $uuid => $ssh_key) {
       $model_data = (object)['id' => $uuid, 'key' => $ssh_key,];
@@ -60,26 +77,6 @@ class SshKeys extends TerminusCollection {
     }
 
     return $this;
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'users/' . $this->user->id . '/keys';
-    return $url;
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'user';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/SshKeys.php
+++ b/php/Terminus/Collections/SshKeys.php
@@ -69,9 +69,7 @@ class SshKeys extends TerminusCollection {
    */
   public function fetch(array $options = []) {
     $results = $this->getCollectionData($options);
-    $data    = (object)$results['data'];
-
-    foreach (get_object_vars($data) as $uuid => $ssh_key) {
+    foreach ($results['data'] as $uuid => $ssh_key) {
       $model_data = (object)['id' => $uuid, 'key' => $ssh_key,];
       $this->add($model_data);
     }

--- a/php/Terminus/Collections/SshKeys.php
+++ b/php/Terminus/Collections/SshKeys.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
 

--- a/php/Terminus/Collections/TerminusCollection.php
+++ b/php/Terminus/Collections/TerminusCollection.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
-use Terminus\Request;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Models\TerminusModel;
+use Terminus\Request;
 
 abstract class TerminusCollection extends TerminusModel {
   /**

--- a/php/Terminus/Collections/TerminusCollection.php
+++ b/php/Terminus/Collections/TerminusCollection.php
@@ -26,35 +26,10 @@ abstract class TerminusCollection {
   /**
    * Instantiates the collection, sets param members as properties
    *
-   * @param array $options To be set to $this->key
+   * @param array $options Options with which to configure this collection
    */
   public function __construct(array $options = []) {
     $this->request = new Request();
-  }
-
-  /**
-   * Handles requests for inaccessible properties
-   *
-   * @param string $property Name of property being requested
-   * @return mixed $this->$property
-   * @throws TerminusException
-   */
-  public function __get($property) {
-    if (property_exists($this, $property)) {
-      return $this->$property;
-    }
-
-    $trace = debug_backtrace();
-    throw new TerminusException(
-      'Undefined property $var->${property} in {file} on line {line}',
-      [
-        'property' => $property,
-        'file' => $trace[0]['file'],
-        'line' => $trace[0]['line']
-      ],
-      1
-    );
-    return null;
   }
 
   /**

--- a/php/Terminus/Collections/Upstreams.php
+++ b/php/Terminus/Collections/Upstreams.php
@@ -2,9 +2,27 @@
 
 namespace Terminus\Collections;
 
-use Terminus\Models\Upstream;
+use Terminus\Session;
 
 class Upstreams extends TerminusCollection {
+  /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\Upstream';
+  /**
+   * @var string
+   */
+  protected $url = 'products';
+
+  /**
+   * Object constructor
+   *
+   * @param array $options Options to set as $this->key
+   */
+  public function __construct($options = []) {
+    parent::__construct($options);
+    $this->user = Session::getUser();
+  }
 
   /**
    * Search available upstreams by UUID or name
@@ -31,18 +49,8 @@ class Upstreams extends TerminusCollection {
    * @param array  $options    Data to make properties of the new model
    * @return void
    */
-  public function add($model_data, array $options = array()) {
+  public function add($model_data, array $options = []) {
     parent::add($model_data->attributes, $options);
-  }
-
-  /**
-   * Give the URL for collection data fetching
-   *
-   * @return string URL to use in fetch query
-   */
-  protected function getFetchUrl() {
-    $url = 'products';
-    return $url;
   }
 
 }

--- a/php/Terminus/Collections/Upstreams.php
+++ b/php/Terminus/Collections/Upstreams.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Models\Upstream;
 

--- a/php/Terminus/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Collections/UserOrganizationMemberships.php
@@ -21,33 +21,12 @@ class UserOrganizationMemberships extends TerminusCollection {
   /**
    * Object constructor
    *
-   * @param array $options Options to set as $this->key
+   * @param array $options Options with which to configure this collection
    */
   public function __construct($options = []) {
     parent::__construct($options);
     $this->user = $options['user'];
     $this->url  = "users/{$this->user->id}/memberships/organizations";
-  }
-
-  /**
-   * Retrieves the matching organization from model members
-   *
-   * @param string $org ID or name of desired organization
-   * @return Organization $organization
-   * @throws TerminusException
-   */
-  public function getOrganization($org) {
-    $memberships = $this->all();
-    foreach ($memberships as $membership) {
-      $organization = $membership->organization;
-      if (in_array($org, [$organization->id, $organization->get('name'),])) {
-        return $organization;
-      }
-    }
-    throw new TerminusException(
-      'This user is not a member of an organizaiton identified by {org}.',
-      compact('org')
-    );
   }
 
 }

--- a/php/Terminus/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Collections/UserOrganizationMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
 

--- a/php/Terminus/Collections/UserOrganizationMemberships.php
+++ b/php/Terminus/Collections/UserOrganizationMemberships.php
@@ -10,6 +10,10 @@ class UserOrganizationMemberships extends TerminusCollection {
    */
   public $user;
   /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\UserOrganizationMembership';
+  /**
    * @var boolean
    */
   protected $paged = true;
@@ -23,22 +27,6 @@ class UserOrganizationMemberships extends TerminusCollection {
     parent::__construct($options);
     $this->user = $options['user'];
     $this->url  = "users/{$this->user->id}/memberships/organizations";
-  }
-
-  /**
-   * Adds a model to this collection
-   *
-   * @param object $model_data  Data to feed into attributes of new model
-   * @param array  $arg_options Data to make properties of the new model
-   * @return void
-   */
-  public function add($model_data = [], array $arg_options = []) {
-    $default_options = [
-      'id'         => $model_data->id,
-      'collection' => $this,
-    ];
-    $options         = array_merge($default_options, $arg_options);
-    parent::add($model_data, $options);
   }
 
   /**
@@ -60,16 +48,6 @@ class UserOrganizationMemberships extends TerminusCollection {
       'This user is not a member of an organizaiton identified by {org}.',
       compact('org')
     );
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'user';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/UserSiteMemberships.php
+++ b/php/Terminus/Collections/UserSiteMemberships.php
@@ -8,6 +8,10 @@ class UserSiteMemberships extends TerminusCollection {
    */
   public $user;
   /**
+   * @var string
+   */
+  protected $collected_class = 'Terminus\Models\UserSiteMembership';
+  /**
    * @var boolean
    */
   protected $paged = true;
@@ -21,32 +25,6 @@ class UserSiteMemberships extends TerminusCollection {
     parent::__construct($options);
     $this->user = $options['user'];
     $this->url  = "users/{$this->user->id}/memberships/sites";
-  }
-
-  /**
-   * Adds a model to this collection
-   *
-   * @param object $model_data  Data to feed into attributes of new model
-   * @param array  $arg_options Data to make properties of the new model
-   * @return void
-   */
-  public function add($model_data, array $arg_options = []) {
-    $default_options = [
-      'id'         => $model_data->id,
-      'collection' => $this,
-    ];
-    $options         = array_merge($default_options, $arg_options);
-    parent::add($model_data, $options);
-  }
-
-  /**
-   * Names the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = 'user';
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Collections/UserSiteMemberships.php
+++ b/php/Terminus/Collections/UserSiteMemberships.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 class UserSiteMemberships extends TerminusCollection {
   /**

--- a/php/Terminus/Collections/Workflows.php
+++ b/php/Terminus/Collections/Workflows.php
@@ -29,7 +29,7 @@ class Workflows extends TerminusCollection {
   /**
    * Instantiates the collection, sets param members as properties
    *
-   * @param array $options To be set to $this->key
+   * @param array $options Options with which to configure this collection
    */
   public function __construct(array $options = []) {
     parent::__construct($options);

--- a/php/Terminus/Collections/Workflows.php
+++ b/php/Terminus/Collections/Workflows.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Terminus\Models\Collections;
+namespace Terminus\Collections;
 
 use Terminus\Session;
 use Terminus\Models\Workflow;
@@ -241,7 +241,7 @@ class Workflows extends TerminusCollection {
     }
     $owner_name = strtolower(
       str_replace(
-        array('Terminus\\', 'Models\\', 'Collections\\'),
+        ['Terminus\\', 'Collections\\',],
         '',
         get_class($this->owner)
       )

--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -69,7 +69,7 @@ class AuthCommand extends TerminusCommand {
       );
       $auth->logInViaMachineToken(compact('email'));
       $this->log()->info('Logging in via machine token');
-    } elseif (!is_null($config['user'])
+    } elseif (!empty($config['user'])
       && !isset($assoc_args['password'])
       && $auth->tokenExistsForEmail($config['user'])
     ) {

--- a/php/Terminus/Commands/AuthCommand.php
+++ b/php/Terminus/Commands/AuthCommand.php
@@ -2,7 +2,7 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\TerminusCommand;
+use Terminus\Config;
 use Terminus\Models\Auth;
 use Terminus\Session;
 
@@ -46,6 +46,7 @@ class AuthCommand extends TerminusCommand {
    * : dump call information when logging in.
    */
   public function login($args, $assoc_args) {
+    $config = Config::getAll();
     $auth   = $this->auth;
     $tokens = $auth->getAllSavedTokenEmails();
     if (!empty($args)) {
@@ -68,16 +69,16 @@ class AuthCommand extends TerminusCommand {
       );
       $auth->logInViaMachineToken(compact('email'));
       $this->log()->info('Logging in via machine token');
-    } elseif (isset($_SERVER['TERMINUS_USER'])
+    } elseif (!is_null($config['user'])
       && !isset($assoc_args['password'])
-      && $auth->tokenExistsForEmail($_SERVER['TERMINUS_USER'])
+      && $auth->tokenExistsForEmail($config['user'])
     ) {
       // Try to log in using a machine token, if $_SERVER provides account email.
       $this->log()->info(
         'Found a machine token for "{email}".',
-        ['email' => $_SERVER['TERMINUS_USER'],]
+        ['email' => $config['user'],]
       );
-      $auth->logInViaMachineToken(['email' => $_SERVER['TERMINUS_USER']]);
+      $auth->logInViaMachineToken(['email' => $config['user']]);
       $this->log()->info('Logging in via machine token');
     } elseif (!isset($email) && (count($tokens) === 1)) {
       // Try to log in using a machine token, if there is only one saved token.

--- a/php/Terminus/Commands/CliCommand.php
+++ b/php/Terminus/Commands/CliCommand.php
@@ -3,10 +3,9 @@
 namespace Terminus\Commands;
 
 use Terminus\Completions;
+use Terminus\Config;
 use Terminus\Configurator;
-use Terminus\Commands\TerminusCommand;
-use Terminus\Models\Collections\Sites;
-use Terminus\Models\User;
+use Terminus\Collections\Sites;
 use Terminus\Session;
 
 /**
@@ -92,22 +91,23 @@ class CliCommand extends TerminusCommand {
    * : Accepted values: json
    */
   public function info($args, $assoc_args) {
-    $info   = array(
-      'php_binary_path'     => TERMINUS_PHP,
+    $config = Config::getAll();
+    $info   = [
+      'php_binary_path'     => $config['php'],
       'php_version'         => PHP_VERSION,
       'php_ini'             => get_cfg_var('cfg_file_path'),
       'project_config_path' => $this->runner->getUserConfigDir(),
-      'wp_cli_dir_path'     => TERMINUS_ROOT,
-      'wp_cli_version'      => TERMINUS_VERSION,
-    );
-    $labels = array(
+      'terminus_path'       => $config['root'],
+      'terminus_version'    => $config['version'],
+    ];
+    $labels = [
       'php_binary_path'     => 'PHP binary',
       'php_version'         => 'PHP version',
       'php_ini'             => 'php.ini used',
       'project_config_path' => 'Terminus project config',
-      'wp_cli_dir_path'     => 'Terminus root dir',
-      'wp_cli_version'      => 'Terminus version',
-    );
+      'terminus_dir_path'   => 'Terminus root dir',
+      'terminus_version'    => 'Terminus version',
+    ];
     $this->output()->outputRecord($info, $labels);
 
   }
@@ -145,12 +145,13 @@ class CliCommand extends TerminusCommand {
    * Print Terminus version.
    */
   public function version() {
-    $labels = array(
+    $labels = [
       'version' => 'Terminus version',
-      'script'  => 'Terminus script'
-    );
+      'script'  => 'Terminus script',
+    ];
+    $config = Config::getAll();
     $this->output()->outputRecord(
-      array('version' => TERMINUS_VERSION, 'script' => TERMINUS_SCRIPT),
+      ['version' => $config['version'], 'script' => $config['script'],],
       $labels
     );
   }

--- a/php/Terminus/Commands/CliCommand.php
+++ b/php/Terminus/Commands/CliCommand.php
@@ -96,7 +96,7 @@ class CliCommand extends TerminusCommand {
       'php_binary_path'     => $config['php'],
       'php_version'         => PHP_VERSION,
       'php_ini'             => get_cfg_var('cfg_file_path'),
-      'project_config_path' => $this->runner->getUserConfigDir(),
+      'project_config_path' => $config['config_dir'],
       'terminus_path'       => $config['root'],
       'terminus_version'    => $config['version'],
     ];

--- a/php/Terminus/Commands/CommandWithSSH.php
+++ b/php/Terminus/Commands/CommandWithSSH.php
@@ -2,8 +2,8 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\TerminusCommand;
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
+use Terminus\Config;
 
 /**
  * Base class for Terminus commands that deal with sending SSH commands
@@ -118,6 +118,7 @@ abstract class CommandWithSSH extends TerminusCommand {
    * @return array Connection info
    */
   protected function getAppserverInfo(array $site_info = []) {
+    $config = Config::getAll();
     $site_id = $site_info['site'];
     $env_id  = $site_info['environment'];
     $server  = [
@@ -125,12 +126,12 @@ abstract class CommandWithSSH extends TerminusCommand {
       'host' => "appserver.$env_id.$site_id.drush.in",
       'port' => '2222',
     ];
-    if ($ssh_host = TERMINUS_SSH_HOST) {
+    if (!is_null($ssh_host = $config['ssh_host'])) {
       $server['user'] = "appserver.$env_id.$site_id";
       $server['host'] = $ssh_host;
-    } else if (strpos(TERMINUS_HOST, 'onebox') !== false) {
+    } else if (strpos($config['host'], 'onebox') !== false) {
       $server['user'] = "appserver.$env_id.$site_id";
-      $server['host'] = TERMINUS_HOST;
+      $server['host'] = $config['host'];
     }
     return $server;
   }

--- a/php/Terminus/Commands/CommandWithSSH.php
+++ b/php/Terminus/Commands/CommandWithSSH.php
@@ -167,7 +167,7 @@ abstract class CommandWithSSH extends TerminusCommand {
       'env_id'  => $env_id,
       'command' => $args[0],
       'server'  => $this->getAppserverInfo(
-        ['site' => $site->get('id'), 'environment' => $env_id,]
+        ['site' => $site->id, 'environment' => $env_id,]
       ),
     ];
     return $elements;

--- a/php/Terminus/Commands/DrushCommand.php
+++ b/php/Terminus/Commands/DrushCommand.php
@@ -2,9 +2,6 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\CommandWithSSH;
-use Terminus\Models\Collections\Sites;
-
 /**
  * @command drush
  */

--- a/php/Terminus/Commands/InstrumentsCommand.php
+++ b/php/Terminus/Commands/InstrumentsCommand.php
@@ -36,7 +36,7 @@ class InstrumentsCommand extends TerminusCommand {
     foreach ($instruments as $id => $instrument) {
       $data[] = array(
         'label' => $instrument->get('label'),
-        'id'    => $instrument->get('id'),
+        'id'    => $instrument->id,
       );
     }
     if (empty($data)) {

--- a/php/Terminus/Commands/MachineTokensCommand.php
+++ b/php/Terminus/Commands/MachineTokensCommand.php
@@ -3,8 +3,6 @@
 namespace Terminus\Commands;
 
 use Terminus\Session;
-use Terminus\Commands\TerminusCommand;
-use Terminus\Models\User;
 
 /**
  * Show information for your Pantheon machine tokens

--- a/php/Terminus/Commands/MachineTokensCommand.php
+++ b/php/Terminus/Commands/MachineTokensCommand.php
@@ -35,7 +35,7 @@ class MachineTokensCommand extends TerminusCommand {
     $data        = array();
     foreach ($machine_tokens as $id => $machine_token) {
       $data[] = array(
-        'id'          => $machine_token->get('id'),
+        'id'          => $machine_token->id,
         'device_name' => $machine_token->get('device_name'),
       );
     }

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -2,13 +2,9 @@
 
 namespace Terminus\Commands;
 
+use Terminus\Collections\Sites;
+use Terminus\Config;
 use Terminus\Session;
-use Terminus\Commands\TerminusCommand;
-use Terminus\Models\User;
-use Terminus\Models\Organization;
-use Terminus\Models\OrganizationSiteMembership;
-use Terminus\Models\Collections\Sites;
-use Terminus\Models\Collections\UserOrganizationMemberships;
 
 /**
  * Show information for your Pantheon organizations
@@ -244,7 +240,10 @@ class OrganizationsCommand extends TerminusCommand {
           'id'            => $site->id,
           'service_level' => $site->get('service_level'),
           'framework'     => $site->get('framework'),
-          'created'       => date(TERMINUS_DATE_FORMAT, $site->get('created')),
+          'created'       => date(
+            Config::get('date_format'),
+            $site->get('created')
+          ),
           'tags'          => $membership->get('tags'),
         ];
         if ((boolean)$site->get('frozen')) {

--- a/php/Terminus/Commands/OrganizationsCommand.php
+++ b/php/Terminus/Commands/OrganizationsCommand.php
@@ -37,7 +37,7 @@ class OrganizationsCommand extends TerminusCommand {
     foreach ($organizations as $id => $org) {
       $data[] = [
         'name' => $org->get('profile')->name,
-        'id' => $org->get('id'),
+        'id' => $org->id,
       ];
     }
 
@@ -121,9 +121,10 @@ class OrganizationsCommand extends TerminusCommand {
   }
 
   private function addMemberToTeam($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
 
     $email = $this->input()->string(
       [
@@ -148,9 +149,10 @@ class OrganizationsCommand extends TerminusCommand {
   }
 
   private function removeMemberFromTeam($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
 
     $member = $this->input()->orgMember(
       [
@@ -173,19 +175,20 @@ class OrganizationsCommand extends TerminusCommand {
    * @return void
    */
   private function addSiteToOrganization($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
-    $site_memberships = $this->user->site_memberships->all();
+    $org = $this->user->getOrganizations()[$org_id];
+    $sites = $this->user->getSites();
     $choices = array_combine(
       array_map(
-        function ($membership) {
-          $site_name = $membership->site->get('name');
+        function ($site) {
+          $site_name = $site->get('name');
           return $site_name;
         },
-        $site_memberships
+        $sites
       ),
-      $site_memberships
+      $sites
     );
     $site = $this->sites->get(
       $this->input()->siteName(
@@ -214,9 +217,10 @@ class OrganizationsCommand extends TerminusCommand {
    * @return array $data Data to display about sites in the organization
    */
   private function listOrganizationalSites($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
 
     $tag = $this->input()->optional(
       ['key' => 'tag', 'choices' => $assoc_args,]
@@ -276,9 +280,10 @@ class OrganizationsCommand extends TerminusCommand {
    * @return void
    */
   private function removeSiteFromOrganization($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
     $site_memberships = $org->site_memberships->all();
     $choices = array_combine(
       array_map(
@@ -325,9 +330,10 @@ class OrganizationsCommand extends TerminusCommand {
    * @return array $data Data to display about sites in the organization
    */
   private function listOrganizationTeam($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
 
     $data = array_map(
       function ($membership) {
@@ -356,9 +362,10 @@ class OrganizationsCommand extends TerminusCommand {
    * @return void
    */
   private function setMemberRole($assoc_args) {
-    $org = $this->user->org_memberships->getOrganization(
-      $this->input()->orgId(['args' => $assoc_args, 'allow_none' => false,])
+    $org_id = $this->input()->orgId(
+      ['args' => $assoc_args, 'allow_none' => false,]
     );
+    $org = $this->user->getOrganizations()[$org_id];
     $role_choices = ['unprivileged', 'admin'];
 
     $member = $this->input()->orgMember(

--- a/php/Terminus/Commands/SiteCommand.php
+++ b/php/Terminus/Commands/SiteCommand.php
@@ -2,14 +2,12 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\TerminusCommand;
+use Terminus\Collections\Sites;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\User;
 use Terminus\Models\Workflow;
-use Terminus\Models\Collections\Sites;
 use Terminus\Request;
 use Terminus\Session;
-use Terminus\Utils;
 
 /**
  * Actions to be taken on an individual site
@@ -493,7 +491,7 @@ class SiteCommand extends TerminusCommand {
     }
     $url = sprintf(
       'https://%s/sites/%s%s',
-      TERMINUS_HOST,
+      Config::get('host'),
       $site->get('id'),
       $env
     );
@@ -818,7 +816,7 @@ class SiteCommand extends TerminusCommand {
       $data[] = array(
         'name'        => $env->get('id'),
         'created'     => date(
-          TERMINUS_DATE_FORMAT,
+          Config::get('date_format'),
           $env->get('environment_created')
         ),
         'domain'      => $env->domain(),

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -2,10 +2,9 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Configurator;
-use Terminus\Models\Collections\Sites;
+use Terminus\Config;
+use Terminus\Collections\Sites;
 use Terminus\Models\Site;
-use Terminus\Models\Upstreams;
 use Terminus\Session;
 
 /**
@@ -56,7 +55,7 @@ class SitesCommand extends TerminusCommand {
         'choices' => $assoc_args,
         'default' => sprintf(
           '%s/.drush/pantheon.aliases.drushrc.php',
-          Configurator::getHomeDir()
+          Config::getHomeDir()
         ),
       )
     );
@@ -206,7 +205,10 @@ class SitesCommand extends TerminusCommand {
         'service_level' => $site->get('service_level'),
         'framework'     => $site->get('framework'),
         'owner'         => $site->get('owner'),
-        'created'       => date(TERMINUS_DATE_FORMAT, $site->get('created')),
+        'created'       => date(
+          Config::get('date_format'),
+          $site->get('created')
+        ),
         'memberships'   => implode(', ', $memberships),
       ];
       if (!is_null($site->get('frozen'))) {
@@ -504,8 +506,8 @@ class SitesCommand extends TerminusCommand {
       $options['site_name'] = $assoc_args['name'];
     } elseif (array_key_exists('site', $assoc_args)) {
       $options['site_name'] = $assoc_args['site'];
-    } elseif (isset($_SERVER['TERMINUS_SITE'])) {
-      $options['site_name'] = $_SERVER['TERMINUS_SITE'];
+    } elseif (!is_null(Config::get('site'))) {
+      $options['site_name'] = Config::get('site');
     } else {
       $message  = 'Machine name of the site; used as part of the default URL';
       $message .= " (if left blank will be $suggested_name)";

--- a/php/Terminus/Commands/SitesCommand.php
+++ b/php/Terminus/Commands/SitesCommand.php
@@ -212,7 +212,7 @@ class SitesCommand extends TerminusCommand {
         'memberships'   => implode(', ', $memberships),
       ];
       if (!is_null($site->get('frozen'))) {
-        $rows[$site->get('id')]['frozen'] = true;
+        $rows[$site->id]['frozen'] = true;
       }
     }
 
@@ -367,7 +367,7 @@ class SitesCommand extends TerminusCommand {
             $this->log()->info('Backup of {site} created.', $context);
             $this->log()->info('Updating {site}.', $context);
             $response = $site->applyUpstreamUpdates(
-              $env->get('id'),
+              $env->id,
               $updatedb,
               $xoption
             );

--- a/php/Terminus/Commands/SshKeysCommand.php
+++ b/php/Terminus/Commands/SshKeysCommand.php
@@ -2,8 +2,7 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\TerminusCommand;
-use Terminus\Configurator;
+use Terminus\Config;
 use Terminus\Session;
 
 /**
@@ -64,7 +63,7 @@ class SshKeysCommand extends TerminusCommand {
     $file = $this->input()->fileName(
       [
         'args'    => $assoc_args,
-        'dir'     => Configurator::getHomeDir() . '/.ssh',
+        'dir'     => Config::getHomeDir() . '/.ssh',
         'message' => 'Please select your public SSH key file.',
         'regex'   => '~(.*.pub)~',
       ]

--- a/php/Terminus/Commands/SshKeysCommand.php
+++ b/php/Terminus/Commands/SshKeysCommand.php
@@ -39,7 +39,7 @@ class SshKeysCommand extends TerminusCommand {
     $data     = [];
     foreach ($ssh_keys as $id => $ssh_key) {
       $data[] = [
-        'fingerprint' => $ssh_key->get('id'),
+        'fingerprint' => $ssh_key->id,
         'comment'     => $ssh_key->getComment(),
       ];
     }
@@ -89,8 +89,8 @@ class SshKeysCommand extends TerminusCommand {
       $display_choices  = [];
       $choices          = [];
       foreach ($ssh_keys as $id => $ssh_key) {
-        $display_choices[] = $ssh_key->get('id') . ' - ' . $ssh_key->getComment();
-        $choices[]         = $ssh_key->get('id');
+        $display_choices[] = $ssh_key->id . ' - ' . $ssh_key->getComment();
+        $choices[]         = $ssh_key->id;
       }
       $fingerprint = $choices[$this->input()->menu(
         [

--- a/php/Terminus/Commands/TerminusCommand.php
+++ b/php/Terminus/Commands/TerminusCommand.php
@@ -3,6 +3,7 @@
 namespace Terminus\Commands;
 
 use Terminus\Caches\FileCache;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Loggers\Logger;
 use Terminus\Models\Auth;
@@ -111,8 +112,8 @@ abstract class TerminusCommand {
       if (count($tokens) === 1) {
         $email = array_shift($tokens);
         $auth->logInViaMachineToken(compact('email'));
-      } else if (isset($_SERVER['TERMINUS_USER'])
-       && $email = $_SERVER['TERMINUS_USER']
+      } else if (!is_null(Config::get('user'))
+       && $email = Config::get('user')
       ) {
         $auth->logInViaMachineToken(compact('email'));
       } else {

--- a/php/Terminus/Commands/UpstreamsCommand.php
+++ b/php/Terminus/Commands/UpstreamsCommand.php
@@ -2,8 +2,7 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\TerminusCommand;
-use Terminus\Models\Collections\Upstreams;
+use Terminus\Collections\Upstreams;
 
 /**
  * Show Pantheon upstream information

--- a/php/Terminus/Commands/WorkflowsCommand.php
+++ b/php/Terminus/Commands/WorkflowsCommand.php
@@ -2,11 +2,8 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Utils;
-use Terminus\Commands\TerminusCommand;
-use Terminus\Exceptions\TerminusException;
-use Terminus\Models\User;
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
+use Terminus\Config;
 
 define("WORKFLOWS_WATCH_INTERVAL", 5);
 
@@ -180,7 +177,7 @@ class WorkflowsCommand extends TerminusCommand {
             'description' => $workflow->get('description'),
             'env'         => $workflow->get('environment'),
             'time'        => date(
-              TERMINUS_DATE_FORMAT,
+              Config::get('date_format'),
               $workflow->get('started_at')
             ),
           ];
@@ -199,7 +196,7 @@ class WorkflowsCommand extends TerminusCommand {
             'description' => $workflow->get('description'),
             'env'         => $workflow->get('environment'),
             'time'        => date(
-              TERMINUS_DATE_FORMAT,
+              Config::get('date_format'),
               $workflow->get('finished_at')
             ),
           ];

--- a/php/Terminus/Commands/WorkflowsCommand.php
+++ b/php/Terminus/Commands/WorkflowsCommand.php
@@ -5,7 +5,7 @@ namespace Terminus\Commands;
 use Terminus\Collections\Sites;
 use Terminus\Config;
 
-define("WORKFLOWS_WATCH_INTERVAL", 5);
+define('WORKFLOWS_WATCH_INTERVAL', 5);
 
 /**
 * Actions to be taken on an individual site
@@ -167,13 +167,13 @@ class WorkflowsCommand extends TerminusCommand {
       $workflows = $site->workflows->all();
       foreach ($workflows as $workflow) {
         if (($workflow->get('created_at') > $last_created_at)
-          && !in_array($workflow->get('id'), $started)
+          && !in_array($workflow->id, $started)
         ) {
-          array_push($started, $workflow->get('id'));
+          array_push($started, $workflow->id);
 
           $started_message = 'Started {id} {description} ({env}) at {time}';
           $started_context = [
-            'id'          => $workflow->get('id'),
+            'id'          => $workflow->id,
             'description' => $workflow->get('description'),
             'env'         => $workflow->get('environment'),
             'time'        => date(
@@ -185,14 +185,14 @@ class WorkflowsCommand extends TerminusCommand {
         }
 
         if (($workflow->get('finished_at') > $last_finished_at)
-          && !in_array($workflow->get('id'), $finished)
+          && !in_array($workflow->id, $finished)
         ) {
-          array_push($finished, $workflow->get('id'));
+          array_push($finished, $workflow->id);
 
           $finished_message
             = 'Finished workflow {id} {description} ({env}) at {time}';
           $finished_context = [
-            'id'          => $workflow->get('id'),
+            'id'          => $workflow->id,
             'description' => $workflow->get('description'),
             'env'         => $workflow->get('environment'),
             'time'        => date(

--- a/php/Terminus/Commands/WpCommand.php
+++ b/php/Terminus/Commands/WpCommand.php
@@ -2,8 +2,6 @@
 
 namespace Terminus\Commands;
 
-use Terminus\Commands\CommandWithSSH;
-
 /**
  * @command wp
  */

--- a/php/Terminus/Config.php
+++ b/php/Terminus/Config.php
@@ -5,40 +5,19 @@ namespace Terminus;
 use Dotenv\Dotenv;
 use Symfony\Component\Yaml\Yaml;
 
-class Configurator {
+class Config {
   /**
    * @var string[]
    */
-  private $config = [];
+  private static $config = [];
   /**
    * @var string
    */
-  private $config_path = '/config/constants.yml';
+  private static $config_path = '/config/constants.yml';
   /**
    * @var string
    */
-  private $constant_prefix = 'TERMINUS_';
-
-  /**
-   * Constructs config, configures
-   */
-  public function construct() {
-    $this->configure();
-    $this->spec = include TERMINUS_ROOT . '/config/spec.php';
-
-    $defaults = [
-      'runtime'  => false,
-      'file'     => false,
-      'synopsis' => '',
-      'default'  => null,
-      'multiple' => false,
-    ];
-
-    foreach ($this->spec as $key => $details) {
-      $this->spec[$key]   = array_merge($defaults, $details);
-      $this->config[$key] = $details['default'];
-    }
-  }
+  private static $constant_prefix = 'TERMINUS_';
 
   /**
    * Returns the appropriate home directory.
@@ -66,20 +45,24 @@ class Configurator {
   /**
    * Returns a configuration setting
    *
-   * @param $key The key of the config setting to return
-   * @return string $this->config[$property]
+   * @param string $key The key of the config setting to return
+   * @return string self::$config[$property]
    */
   public static function get($key) {
-    return $this->config[$key];
+    $config = self::getAll();
+    return $config[$key];
   }
 
   /**
    * Returns all configuration settings
    *
-   * @return string[] $this->config
+   * @return string[] self::$config
    */
   public static function getAll() {
-    return $this->config;
+    if (empty(self::$config)) {
+      self::configure();
+    }
+    return self::$config;
   }
 
   /**
@@ -98,11 +81,64 @@ class Configurator {
   }
 
   /**
+   * Sets constants necessary for the proper functioning of Terminus
+   *
+   * @return void
+   */
+  private static function configure() {
+    self::importEnvironmentVariables();
+    self::$config['root'] = self::getTerminusRoot();
+    self::$config['php'] = self::getPhpBinary();
+    self::$config['script'] = self::getTerminusScript();
+
+    $file_config = Yaml::parse(
+      file_get_contents(self::$config['root'] . self::$config_path)
+    );
+    foreach ($file_config as $name => $setting) {
+      if (defined($name)) {
+        $setting = constant($name);
+      } else if (isset($_SERVER[$name]) && ($_SERVER[$name] != '')) {
+        $setting = $_SERVER[$name];
+      } else if (getenv($name)) {
+        $setting = getenv($name);
+      }
+      $value = self::replacePlaceholders($setting);
+      self::ensureDirExists($name, $value);
+      $key = self::getKeyFromConstant($name);
+      self::$config[$key] = $value;
+    }
+    date_default_timezone_set(self::get('time_zone'));
+  }
+
+  /**
+   * Ensures a directory exists
+   *
+   * @param string $name  The name of the config var
+   * @param string $value The value of the named config var
+   * @return bool
+   */
+  private static function ensureDirExists($name, $value) {
+    if ((strpos($name, 'TERMINUS_') !== false)
+      && (strpos($name, '_DIR') !== false)
+      && ($value != '~')
+    ) {
+      try {
+        $dir_exists = (is_dir($value)
+          || (!file_exists($value) && @mkdir($value, 0777, true)));
+      } catch (\Exception $e) {
+        return false;
+      }
+      return $dir_exists;
+    }
+    return null;
+  }
+
+  /**
    * Returns location of PHP with which to run Terminus
    *
    * @return string
    */
-  private function getPhpBinary() {
+  private static function getPhpBinary() {
     if (getenv('TERMINUS_PHP')) {
       $php_bin = getenv('TERMINUS_PHP');
     } elseif (defined('PHP_BINARY')) {
@@ -119,7 +155,7 @@ class Configurator {
    * @param string $current_dir Directory to start searching at
    * @return string
    */
-  private function getTerminusRoot($current_dir = null) {
+  private static function getTerminusRoot($current_dir = null) {
     if (defined('TERMINUS_ROOT')) {
       return TERMINUS_ROOT;
     }
@@ -133,10 +169,10 @@ class Configurator {
     $dir = explode('/', $current_dir);
     array_pop($dir);
     if (empty($dir)) {
-      throw new TerminusError("Could not locate root to set TERMINUS_ROOT.");
+      throw new TerminusError('Could not locate root to set TERMINUS_ROOT.');
     }
     $dir = implode('/', $dir);
-    $root_dir = $this->getTerminusRoot($dir);
+    $root_dir = self::getTerminusRoot($dir);
     return $root_dir;
   }
 
@@ -145,7 +181,7 @@ class Configurator {
    *
    * @return string
    */
-  private function getTerminusScript() {
+  private static function getTerminusScript() {
     if (defined('TERMINUS_SCRIPT')) {
       return TERMINUS_SCRIPT;
     }
@@ -153,7 +189,7 @@ class Configurator {
     $debug           = debug_backtrace();
     $script_location = array_pop($debug);
     $script_name     = str_replace(
-      $this->config['root'] . '/',
+      self::$config['root'] . '/',
       '',
       $script_location['file']
     );
@@ -161,41 +197,11 @@ class Configurator {
   }
 
   /**
-   * Sets constants necessary for the proper functioning of Terminus
-   *
-   * @return void
-   */
-  private function configure() {
-    $this->importEnvironmentVariables();
-    $config = [
-      'root'   => $this->getTerminusRoot(),
-      'php'    => $this->getPhpBinary(),
-      'script' => $this->getTerminusScript(),
-    ];
-    $this->config = $config;
-
-    $file_config = Yaml::parse(
-      file_get_contents($config['root'] . $this->config_path)
-    );
-    foreach ($file_config as $name => $setting) {
-      if (defined($name)) {
-        $setting = $constant['echo'];
-      } else if (isset($_SERVER[$name]) && ($_SERVER[$name] != '')) {
-        $setting = $_SERVER[$name];
-      } else if (getenv($name)) {
-        $setting = getenv($name);
-      }
-      $key = strtolower(str_replace($this->constant_prefix, '', $name));
-      $this->config[$key] = $this->replacePlaceholders($setting);
-    }
-  }
-
-  /**
    * Imports environment variables
    *
    * @return void
    */
-  private function importEnvironmentVariables() {
+  private static function importEnvironmentVariables() {
     //Load environment variables from __DIR__/.env
     if (file_exists(getcwd() . '/.env')) {
       $env = new Dotenv(getcwd());
@@ -209,14 +215,14 @@ class Configurator {
    * @param string $string The string to perform replacements on
    * @return string $string The modified string
    */
-  private function replacePlaceholders($string) {
+  private static function replacePlaceholders($string) {
     $regex = '~\[\[(.*?)\]\]~';
     preg_match_all($regex, $string, $matches);
     if (!empty($matches)) {
       foreach ($matches[1] as $id => $value) {
-        $replacement_key = trim($value);
-        if (isset($this->config[$replacement_key])) {
-          $replacement = $this->config[$replacement_key];
+        $replacement_key = self::getKeyFromConstant(trim($value));
+        if (isset(self::$config[$replacement_key])) {
+          $replacement = self::$config[$replacement_key];
           $string = str_replace($matches[0][$id], $replacement, $string);
         }
       }
@@ -225,6 +231,17 @@ class Configurator {
       str_replace('~', self::getHomeDir(), $string)
     );
     return $fixed_string;
+  }
+
+  /**
+   * Reflects a key name given a Terminus constant name
+   *
+   * @param string $constant_name The name of a constant to get a key for
+   * @return string
+   */
+  private static function getKeyFromConstant($constant_name) {
+    $key = strtolower(str_replace(self::$constant_prefix, '', $constant_name));
+    return $key;
   }
 
 }

--- a/php/Terminus/Config.php
+++ b/php/Terminus/Config.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Terminus;
+
+use Dotenv\Dotenv;
+use Symfony\Component\Yaml\Yaml;
+
+class Configurator {
+  /**
+   * @var string[]
+   */
+  private $config = [];
+  /**
+   * @var string
+   */
+  private $config_path = '/config/constants.yml';
+  /**
+   * @var string
+   */
+  private $constant_prefix = 'TERMINUS_';
+
+  /**
+   * Constructs config, configures
+   */
+  public function construct() {
+    $this->configure();
+    $this->spec = include TERMINUS_ROOT . '/config/spec.php';
+
+    $defaults = [
+      'runtime'  => false,
+      'file'     => false,
+      'synopsis' => '',
+      'default'  => null,
+      'multiple' => false,
+    ];
+
+    foreach ($this->spec as $key => $details) {
+      $this->spec[$key]   = array_merge($defaults, $details);
+      $this->config[$key] = $details['default'];
+    }
+  }
+
+  /**
+   * Returns the appropriate home directory.
+   *
+   * Adapted from Terminus Package Manager by Ed Reel
+   * @author Ed Reel <@uberhacker>
+   * @url    https://github.com/uberhacker/tpm
+   *
+   * @return string
+   */
+  public static function getHomeDir() {
+    $home = getenv('HOME');
+    if (!$home) {
+      $system = '';
+      if (getenv('MSYSTEM') !== null) {
+        $system = strtoupper(substr(getenv('MSYSTEM'), 0, 4));
+      }
+      if ($system != 'MING') {
+        $home = getenv('HOMEPATH');
+      }
+    }
+    return $home;
+  }
+
+  /**
+   * Returns a configuration setting
+   *
+   * @param $key The key of the config setting to return
+   * @return string $this->config[$property]
+   */
+  public static function get($key) {
+    return $this->config[$key];
+  }
+
+  /**
+   * Returns all configuration settings
+   *
+   * @return string[] $this->config
+   */
+  public static function getAll() {
+    return $this->config;
+  }
+
+  /**
+   * Ensures that directory paths work in any system
+   *
+   * @param string $path A path to set the directory separators for
+   * @return string
+   */
+  public static function fixDirectorySeparators($path) {
+    $fixed_path = str_replace(
+      ['/', '\\',],
+      DIRECTORY_SEPARATOR,
+      $path
+    );
+    return $fixed_path;
+  }
+
+  /**
+   * Returns location of PHP with which to run Terminus
+   *
+   * @return string
+   */
+  private function getPhpBinary() {
+    if (getenv('TERMINUS_PHP')) {
+      $php_bin = getenv('TERMINUS_PHP');
+    } elseif (defined('PHP_BINARY')) {
+      $php_bin = PHP_BINARY;
+    } else {
+      $php_bin = 'php';
+    }
+    return $php_bin;
+  }
+
+  /**
+   * Finds and returns the root directory of Terminus
+   *
+   * @param string $current_dir Directory to start searching at
+   * @return string
+   */
+  private function getTerminusRoot($current_dir = null) {
+    if (defined('TERMINUS_ROOT')) {
+      return TERMINUS_ROOT;
+    }
+
+    if (is_null($current_dir)) {
+      $current_dir = dirname(__DIR__);
+    }
+    if (file_exists("$current_dir/composer.json")) {
+      return $current_dir;
+    }
+    $dir = explode('/', $current_dir);
+    array_pop($dir);
+    if (empty($dir)) {
+      throw new TerminusError("Could not locate root to set TERMINUS_ROOT.");
+    }
+    $dir = implode('/', $dir);
+    $root_dir = $this->getTerminusRoot($dir);
+    return $root_dir;
+  }
+
+  /**
+   * Finds and returns the name of the script running Terminus functions
+   *
+   * @return string
+   */
+  private function getTerminusScript() {
+    if (defined('TERMINUS_SCRIPT')) {
+      return TERMINUS_SCRIPT;
+    }
+
+    $debug           = debug_backtrace();
+    $script_location = array_pop($debug);
+    $script_name     = str_replace(
+      $this->config['root'] . '/',
+      '',
+      $script_location['file']
+    );
+    return $script_name;
+  }
+
+  /**
+   * Sets constants necessary for the proper functioning of Terminus
+   *
+   * @return void
+   */
+  private function configure() {
+    $this->importEnvironmentVariables();
+    $config = [
+      'root'   => $this->getTerminusRoot(),
+      'php'    => $this->getPhpBinary(),
+      'script' => $this->getTerminusScript(),
+    ];
+    $this->config = $config;
+
+    $file_config = Yaml::parse(
+      file_get_contents($config['root'] . $this->config_path)
+    );
+    foreach ($file_config as $name => $setting) {
+      if (defined($name)) {
+        $setting = $constant['echo'];
+      } else if (isset($_SERVER[$name]) && ($_SERVER[$name] != '')) {
+        $setting = $_SERVER[$name];
+      } else if (getenv($name)) {
+        $setting = getenv($name);
+      }
+      $key = strtolower(str_replace($this->constant_prefix, '', $name));
+      $this->config[$key] = $this->replacePlaceholders($setting);
+    }
+  }
+
+  /**
+   * Imports environment variables
+   *
+   * @return void
+   */
+  private function importEnvironmentVariables() {
+    //Load environment variables from __DIR__/.env
+    if (file_exists(getcwd() . '/.env')) {
+      $env = new Dotenv(getcwd());
+      $env->load();
+    }
+  }
+
+  /**
+   * Exchanges values in [[ ]] in the given string with constants
+   *
+   * @param string $string The string to perform replacements on
+   * @return string $string The modified string
+   */
+  private function replacePlaceholders($string) {
+    $regex = '~\[\[(.*?)\]\]~';
+    preg_match_all($regex, $string, $matches);
+    if (!empty($matches)) {
+      foreach ($matches[1] as $id => $value) {
+        $replacement_key = trim($value);
+        if (isset($this->config[$replacement_key])) {
+          $replacement = $this->config[$replacement_key];
+          $string = str_replace($matches[0][$id], $replacement, $string);
+        }
+      }
+    }
+    $fixed_string = self::fixDirectorySeparators(
+      str_replace('~', self::getHomeDir(), $string)
+    );
+    return $fixed_string;
+  }
+
+}

--- a/php/Terminus/Helpers/FileHelper.php
+++ b/php/Terminus/Helpers/FileHelper.php
@@ -3,7 +3,6 @@
 namespace Terminus\Helpers;
 
 use Terminus\Exceptions\TerminusException;
-use Terminus\Helpers\TerminusHelper;
 
 class FileHelper extends TerminusHelper {
 
@@ -52,7 +51,7 @@ class FileHelper extends TerminusHelper {
    * @throws TerminusException
    */
   public function loadAsset($file) {
-    $asset_location = sprintf('%s/assets/%s', TERMINUS_ROOT, $file);
+    $asset_location = sprintf('%s/assets/%s', Config::get('root'), $file);
     /**
     * The warning reporting is disabled because missing files will both issue
     * warnings and return false, and we cannot just catch the warning such as

--- a/php/Terminus/Helpers/FileHelper.php
+++ b/php/Terminus/Helpers/FileHelper.php
@@ -2,6 +2,7 @@
 
 namespace Terminus\Helpers;
 
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
 
 class FileHelper extends TerminusHelper {

--- a/php/Terminus/Helpers/InputHelper.php
+++ b/php/Terminus/Helpers/InputHelper.php
@@ -2,14 +2,12 @@
 
 namespace Terminus\Helpers;
 
+use Terminus\Collections\Sites;
+use Terminus\Collections\Upstreams;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Helpers\TerminusHelper;
-use Terminus\Models\Collections\Sites;
-use Terminus\Models\Collections\Upstreams;
 use Terminus\Models\OrganizationUserMembership;
 use Terminus\Models\Site;
-use Terminus\Models\Upstream;
-use Terminus\Models\User;
 use Terminus\Models\Workflow;
 use Terminus\Session;
 use Terminus\Utils;
@@ -216,8 +214,8 @@ class InputHelper extends TerminusHelper {
       return $options['args'][$options['key']];
     }
     if (in_array($options['key'], ['env', 'from-env'])) {
-      if (isset($_SERVER['TERMINUS_ENV'])) {
-        return $_SERVER['TERMINUS_ENV'];
+      if (!is_null($env = Config::get('env'))) {
+        return $env;
       }
     }
     $choices = $options['choices'];
@@ -397,8 +395,8 @@ class InputHelper extends TerminusHelper {
         return $id;
       }
       return $arguments[$key];
-    } else if (isset($_SERVER['TERMINUS_ORG'])) {
-      return $_SERVER['TERMINUS_ORG'];
+    } else if (!is_null($org = Config::get('org'))) {
+      return $org;
     }
     if (count($org_list) == 0) {
       if ($options['allow_none']) {
@@ -787,8 +785,8 @@ class InputHelper extends TerminusHelper {
 
     if (isset($options['args'][$options['key']])) {
       return $options['args'][$options['key']];
-    } else if (isset($_SERVER['TERMINUS_SITE'])) {
-      return $_SERVER['TERMINUS_SITE'];
+    } else if (!is_null($site = Config::get('site'))) {
+      return $site;
     } else if (!empty($options['choices'])) {
       $choices = $options['choices'];
     } else {
@@ -924,7 +922,10 @@ class InputHelper extends TerminusHelper {
           $environment = 'None';
         }
 
-        $created_at = date(TERMINUS_DATE_FORMAT, $workflow->get('created_at'));
+        $created_at = date(
+          Config::get('date_format'),
+          $workflow->get('created_at')
+        );
 
         $workflow_description = sprintf(
           "%s - %s - %s - %s",

--- a/php/Terminus/Helpers/InputHelper.php
+++ b/php/Terminus/Helpers/InputHelper.php
@@ -467,7 +467,7 @@ class InputHelper extends TerminusHelper {
       foreach ($members as $member) {
         $user_data = $member->get('user');
 
-        if ($options['can_pick_self'] || $user_data->id != $self->get('id')) {
+        if ($options['can_pick_self'] || $user_data->id != $self->id) {
           $choices[$user_data->id] = sprintf(
             '%s <%s> [%s] (%s)',
             $user_data->profile->full_name,
@@ -892,7 +892,7 @@ class InputHelper extends TerminusHelper {
         )
       );
     }
-    $upstream_id = $upstream->get('id');
+    $upstream_id = $upstream->id;
     return $upstream_id;
   }
 
@@ -999,7 +999,7 @@ class InputHelper extends TerminusHelper {
     $user          = Session::getUser();
     $organizations = $user->getOrganizations();
     foreach ($organizations as $org) {
-      $org_list[$org->get('id')] = $org->get('profile')->name;
+      $org_list[$org->id] = $org->get('profile')->name;
     }
     return $org_list;
   }

--- a/php/Terminus/Helpers/LaunchHelper.php
+++ b/php/Terminus/Helpers/LaunchHelper.php
@@ -2,7 +2,7 @@
 
 namespace Terminus\Helpers;
 
-use Terminus\Helpers\TerminusHelper;
+use Terminus\Config;
 use Terminus\Utils;
 
 class LaunchHelper extends TerminusHelper {
@@ -83,7 +83,7 @@ class LaunchHelper extends TerminusHelper {
     $escaped_args = array_map('escapeshellarg', $options['args']);
     $full_command = sprintf(
       '"%s" "%s" %s %s %s',
-      TERMINUS_PHP,
+      Config::get('php'),
       $script_path,
       $options['command'],
       implode(' ', $escaped_args),

--- a/php/Terminus/Helpers/TemplateHelper.php
+++ b/php/Terminus/Helpers/TemplateHelper.php
@@ -2,6 +2,8 @@
 
 namespace Terminus\Helpers;
 
+use Terminus\Config;
+
 /**
  * Class TemplateHelper
  * Render PHP or other types of files using Twig templates
@@ -23,7 +25,7 @@ class TemplateHelper extends TerminusHelper {
    */
   public function __construct(array $options = []) {
     parent::__construct($options);
-    $this->template_root = TERMINUS_ROOT . '/templates';
+    $this->template_root = Config::get('templates_dir');
   }
 
   /**

--- a/php/Terminus/Helpers/UpdateHelper.php
+++ b/php/Terminus/Helpers/UpdateHelper.php
@@ -3,7 +3,7 @@
 namespace Terminus\Helpers;
 
 use Terminus\Caches\FileCache;
-use Terminus\Helpers\TerminusHelper;
+use Terminus\Config;
 use Terminus\Request;
 
 class UpdateHelper extends TerminusHelper {
@@ -43,7 +43,7 @@ class UpdateHelper extends TerminusHelper {
     ) {
       try {
         $current_version = $this->getCurrentVersion();
-        if (version_compare($current_version, TERMINUS_VERSION, '>')) {
+        if (version_compare($current_version, Config::get('version'), '>')) {
           $this->command->log()->info(
             'An update to Terminus is available. Please update to {version}.',
             ['version' => $current_version]

--- a/php/Terminus/Loggers/Logger.php
+++ b/php/Terminus/Loggers/Logger.php
@@ -28,9 +28,8 @@ class Logger extends KLogger {
     $logLevelThreshold = LogLevel::INFO
   ) {
     $config = $options['config'];
-    $app_config = Config::getAll();
     unset($options['config']);
-    $options['dateFormat'] = $app_config['date_format'];
+    $options['dateFormat'] = Config::get('date_format');
 
     if ($config['debug']) {
       $logLevelThreshold = LogLevel::DEBUG;
@@ -40,15 +39,8 @@ class Logger extends KLogger {
       $options['logFormat'] = $config['format'];
     }
 
-    if (!is_null($app_config['log_dir'])) {
-      $logDirectory = $app_config['log_dir'];
-    } elseif ($config['format'] == 'silent') {
-      $logDirectory = ini_get('error_log');
-      if ($logDirectory == '') {
-        $message  = 'You must either set error_log in your php.ini, or define ';
-        $message .= ' TERMINUS_LOG_DIR to use silent mode.' . PHP_EOL;
-        die($message);
-      }
+    if ($config['format'] == 'silent') {
+      $logDirectory = Config::get('log_dir');
     }
 
     parent::__construct($logDirectory, $logLevelThreshold, $options);

--- a/php/Terminus/Loggers/Logger.php
+++ b/php/Terminus/Loggers/Logger.php
@@ -4,6 +4,7 @@ namespace Terminus\Loggers;
 
 use Katzgrau\KLogger\Logger as KLogger;
 use Psr\Log\LogLevel;
+use Terminus\Config;
 
 class Logger extends KLogger {
 
@@ -27,8 +28,9 @@ class Logger extends KLogger {
     $logLevelThreshold = LogLevel::INFO
   ) {
     $config = $options['config'];
+    $app_config = Config::getAll();
     unset($options['config']);
-    $options['dateFormat'] = TERMINUS_DATE_FORMAT;
+    $options['dateFormat'] = $app_config['date_format'];
 
     if ($config['debug']) {
       $logLevelThreshold = LogLevel::DEBUG;
@@ -38,8 +40,8 @@ class Logger extends KLogger {
       $options['logFormat'] = $config['format'];
     }
 
-    if (isset($_SERVER['TERMINUS_LOG_DIR'])) {
-      $logDirectory = $_SERVER['TERMINUS_LOG_DIR'];
+    if (!is_null($app_config['log_dir'])) {
+      $logDirectory = $app_config['log_dir'];
     } elseif ($config['format'] == 'silent') {
       $logDirectory = ini_get('error_log');
       if ($logDirectory == '') {

--- a/php/Terminus/Models/Auth.php
+++ b/php/Terminus/Models/Auth.php
@@ -5,11 +5,15 @@ namespace Terminus\Models;
 use Terminus\Caches\TokensCache;
 use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
+use Terminus\Request;
 use Terminus\Session;
 use Terminus\Utils;
 
 class Auth extends TerminusModel {
-
+  /**
+   * @var Request
+   */
+  protected $request;
   /**
    * @var TokensCache
    */
@@ -22,9 +26,10 @@ class Auth extends TerminusModel {
    * @param array  $options    Options to set as $this->key
    * @return Auth
    */
-  public function __construct($attributes = null, array $options = array()) {
+  public function __construct($attributes = null, array $options = []) {
     $this->tokens_cache = new TokensCache();
-    parent::__construct($attributes, $options);
+    $this->attributes = $attributes;
+    $this->request = new Request();
   }
 
   /**

--- a/php/Terminus/Models/Auth.php
+++ b/php/Terminus/Models/Auth.php
@@ -3,9 +3,8 @@
 namespace Terminus\Models;
 
 use Terminus\Caches\TokensCache;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\TerminusModel;
-use Terminus\Request;
 use Terminus\Session;
 use Terminus\Utils;
 
@@ -44,13 +43,14 @@ class Auth extends TerminusModel {
    * @return string
    */
   public function getMachineTokenCreationUrl() {
+    $config = Config::getAll();
     $port = '';
-    if (TERMINUS_HOST == 'localhost') {
-      $port = ':' . TERMINUS_PORT;
+    if ($config['host'] == 'localhost') {
+      $port = ':' . $config['port'];
     }
     $url = vsprintf(
       '%s://%s%s/machine-token/create/%s',
-      [TERMINUS_PROTOCOL, TERMINUS_HOST, $port, gethostname(),]
+      [$config['protocol'], $config['host'], $port, gethostname(),]
     );
     return $url;
   }

--- a/php/Terminus/Models/Auth.php
+++ b/php/Terminus/Models/Auth.php
@@ -23,8 +23,7 @@ class Auth extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return Auth
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     $this->tokens_cache = new TokensCache();

--- a/php/Terminus/Models/Backup.php
+++ b/php/Terminus/Models/Backup.php
@@ -5,6 +5,21 @@ namespace Terminus\Models;
 use Terminus\Config;
 
 class Backup extends TerminusModel {
+  /**
+   * @var environment
+   */
+  public $environment;
+
+  /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   */
+  public function __construct($attributes, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->environment = $options['collection']->environment;
+  }
 
   /**
    * Determines whether the backup has been completed or not

--- a/php/Terminus/Models/Backup.php
+++ b/php/Terminus/Models/Backup.php
@@ -14,7 +14,7 @@ class Backup extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes, array $options = []) {
     parent::__construct($attributes, $options);
@@ -43,7 +43,7 @@ class Backup extends TerminusModel {
    * @return string
    */
   public function getBucket() {
-    $bucket = str_replace('_' . $this->getElement(), '', $this->get('id'));
+    $bucket = str_replace('_' . $this->getElement(), '', $this->id);
     return $bucket;
   }
 
@@ -126,8 +126,8 @@ class Backup extends TerminusModel {
   public function getUrl() {
     $path     = sprintf(
       'sites/%s/environments/%s/backups/catalog/%s/%s/s3token',
-      $this->environment->site->get('id'),
-      $this->environment->get('id'),
+      $this->environment->site->id,
+      $this->environment->id,
       $this->getBucket(),
       $this->getElement()
     );

--- a/php/Terminus/Models/Backup.php
+++ b/php/Terminus/Models/Backup.php
@@ -2,6 +2,8 @@
 
 namespace Terminus\Models;
 
+use Terminus\Config;
+
 class Backup extends TerminusModel {
 
   /**
@@ -43,7 +45,7 @@ class Backup extends TerminusModel {
     } else {
       return 'Pending';
     }
-    $date = date(TERMINUS_DATE_FORMAT, $datetime);
+    $date = date(Config::get('date_format'), $datetime);
     return $date;
   }
 

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -3,13 +3,11 @@
 namespace Terminus\Models;
 
 use GuzzleHttp\TransferStats as TransferStats;
-use Terminus\Request;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\TerminusModel;
-use Terminus\Models\Collections\Backups;
-use Terminus\Models\Collections\Bindings;
-use Terminus\Models\Collections\Commits;
-use Terminus\Models\Collections\Hostnames;
+use Terminus\Collections\Backups;
+use Terminus\Collections\Bindings;
+use Terminus\Collections\Commits;
+use Terminus\Collections\Hostnames;
 
 class Environment extends TerminusModel {
   /**

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -40,7 +40,7 @@ class Environment extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes, array $options = []) {
     parent::__construct($attributes, $options);
@@ -408,8 +408,7 @@ class Environment extends TerminusModel {
    * @return string
    */
   public function getName() {
-    $name = $this->id;
-    return $name;
+    return $this->id;
   }
 
   /**
@@ -418,17 +417,13 @@ class Environment extends TerminusModel {
    * @return Environment
    */
   public function getParentEnvironment() {
-    $env_id = $this->id;
-    if ($env_id == 'dev') {
-      return null;
-    }
     switch ($this->id) {
       case 'dev':
           return null;
-          break;
       case 'live':
         $parent_env_id = 'test';
           break;
+      case 'test':
       default:
         $parent_env_id = 'dev';
           break;
@@ -644,8 +639,8 @@ class Environment extends TerminusModel {
    * Merge code from a multidev environment into the dev environment
    *
    * @param array $options Parameters to override defaults
-   *        boolean updatedb True to update DB with merge
-   *        string  env      Name of the multidev environment to merge
+   *        string  from_environment Name of the multidev environment to merge
+   *        boolean updatedb         True to update DB with merge
    * @return Workflow
    * @throws TerminusException
    */
@@ -658,10 +653,7 @@ class Environment extends TerminusModel {
       );
     }
 
-    $default_params = [
-      'from_environment' => $options['env'],
-      'updatedb' => false,
-    ];
+    $default_params = ['updatedb' => false, 'from_environment' => null,];
     $params = array_merge($default_params, $options);
 
     $workflow = $this->workflows->create(

--- a/php/Terminus/Models/Hostname.php
+++ b/php/Terminus/Models/Hostname.php
@@ -12,7 +12,7 @@ class Hostname extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/Hostname.php
+++ b/php/Terminus/Models/Hostname.php
@@ -3,6 +3,21 @@
 namespace Terminus\Models;
 
 class Hostname extends TerminusModel {
+  /**
+   * @var Environment
+   */
+  public $environment;
+
+  /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   */
+  public function __construct($attributes, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->environment = $options['collection']->environment;
+  }
 
   /**
    * Delete a hostname from an environment
@@ -12,15 +27,29 @@ class Hostname extends TerminusModel {
   public function delete() {
     $url = sprintf(
       'sites/%s/environments/%s/hostnames/%s',
-      $this->environment->site->get('id'),
-      $this->environment->get('id'),
-      rawurlencode($this->get('id'))
+      $this->environment->site->id,
+      $this->environment->id,
+      rawurlencode($this->id)
     );
-    $response = $this->request->request(
-      $url,
-      ['method' => 'delete']
-    );
+    $response = $this->request->request($url, ['method' => 'delete']);
     return $response['data'];
+  }
+
+  /**
+   * Formats Hostname object into an associative array for output
+   *
+   * @return array $data associative array of data for output
+   */
+  public function serialize() {
+    $data = [
+      'domain' => $this->id,
+      'dns_zone_name' => $this->get('dns_zone_name'),
+      'environment' => $this->get('environment'),
+      'site_id' => $this->get('site_id'),
+      'key' => $this->get('key'),
+      'deletable' => $this->get('deletable'),
+    ];
+    return $data;
   }
 
 }

--- a/php/Terminus/Models/MachineToken.php
+++ b/php/Terminus/Models/MachineToken.php
@@ -8,16 +8,13 @@ class MachineToken extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes, array $options = []) {
     parent::__construct($attributes, $options);
     $this->user = $options['collection']->user;
   }
 
-  /**
-   * Changes connection mode
-   *
   /**
    * Deletes machine token
    *

--- a/php/Terminus/Models/MachineToken.php
+++ b/php/Terminus/Models/MachineToken.php
@@ -5,14 +5,28 @@ namespace Terminus\Models;
 class MachineToken extends TerminusModel {
 
   /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   */
+  public function __construct($attributes, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->user = $options['collection']->user;
+  }
+
+  /**
+   * Changes connection mode
+   *
+  /**
    * Deletes machine token
    *
    * @return array
    */
   public function delete() {
     $response = $this->request->request(
-      'users/' . $this->user->id . '/machine_tokens/' . $this->get('id'),
-      array('method' => 'delete')
+      "users/{$this->user->id}/machine_tokens/{$this->id}",
+      ['method' => 'delete',]
     );
     return $response;
   }

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -28,8 +28,7 @@ class Organization extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return Organization
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -2,9 +2,9 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\Collections\OrganizationSiteMemberships;
-use Terminus\Models\Collections\OrganizationUserMemberships;
-use Terminus\Models\Collections\Workflows;
+use Terminus\Collections\OrganizationSiteMemberships;
+use Terminus\Collections\OrganizationUserMemberships;
+use Terminus\Collections\Workflows;
 
 class Organization extends TerminusModel {
   /**

--- a/php/Terminus/Models/Organization.php
+++ b/php/Terminus/Models/Organization.php
@@ -36,7 +36,7 @@ class Organization extends TerminusModel {
     $params                 = ['organization' => $this,];
     $this->site_memberships = new OrganizationSiteMemberships($params);
     $this->user_memberships = new OrganizationUserMemberships($params);
-    $this->workflows        = new Workflows(['owner' => $this,]);
+    $this->workflows        = new Workflows($params);
   }
 
   /**

--- a/php/Terminus/Models/OrganizationSiteMembership.php
+++ b/php/Terminus/Models/OrganizationSiteMembership.php
@@ -16,8 +16,7 @@ class OrganizationSiteMembership extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return OrganizationSiteMembership
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/OrganizationSiteMembership.php
+++ b/php/Terminus/Models/OrganizationSiteMembership.php
@@ -22,7 +22,7 @@ class OrganizationSiteMembership extends TerminusModel {
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);
     $this->organization = $options['collection']->organization;
-    $this->site         = new Site(
+    $this->site = new Site(
       $attributes->site,
       ['id' => $attributes->site->id, 'memberships' => [$this,],]
     );

--- a/php/Terminus/Models/OrganizationUserMembership.php
+++ b/php/Terminus/Models/OrganizationUserMembership.php
@@ -16,8 +16,7 @@ class OrganizationUserMembership extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return OrganizationSiteMembership
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/Site.php
+++ b/php/Terminus/Models/Site.php
@@ -2,16 +2,14 @@
 
 namespace Terminus\Models;
 
-use Terminus\Caches\SitesCache;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\Organization;
-use Terminus\Models\TerminusModel;
-use Terminus\Models\Collections\Environments;
-use Terminus\Models\Collections\OrganizationSiteMemberships;
-use Terminus\Models\Collections\SiteAuthorizations;
-use Terminus\Models\Collections\SiteOrganizationMemberships;
-use Terminus\Models\Collections\SiteUserMemberships;
-use Terminus\Models\Collections\Workflows;
+use Terminus\Collections\Environments;
+use Terminus\Collections\OrganizationSiteMemberships;
+use Terminus\Collections\SiteAuthorizations;
+use Terminus\Collections\SiteOrganizationMemberships;
+use Terminus\Collections\SiteUserMemberships;
+use Terminus\Collections\Workflows;
 
 class Site extends TerminusModel {
   /**
@@ -497,7 +495,7 @@ class Site extends TerminusModel {
       }
     }
     if (!is_null($info['created']) && is_numeric($info['created'])) {
-      $info['created'] = date(TERMINUS_DATE_FORMAT, $info['created']);
+      $info['created'] = date(Config::get('date_format'), $info['created']);
     }
     if ((boolean)$this->get('frozen')) {
       $info['frozen'] = true;

--- a/php/Terminus/Models/SiteOrganizationMembership.php
+++ b/php/Terminus/Models/SiteOrganizationMembership.php
@@ -29,26 +29,14 @@ class SiteOrganizationMembership extends TerminusModel {
   }
 
   /**
-   * Returns organization object within SiteOrganizationMembership object
-   *
-   * @return Organization
-   */
-  public function getOrganization() {
-    if (!isset($this->organization)) {
-      $this->organization = new Organization($this->id);
-    }
-    return $this->organization;
-  }
-
-  /**
    * Remove membership of organization
    *
    * @return Workflow
    **/
-  public function removeMember() {
+  public function delete() {
     $workflow = $this->site->workflows->create(
       'remove_site_organization_membership',
-      array('params' => array('organization_id' => $this->id))
+      ['params' => ['organization_id' => $this->id,],]
     );
     return $workflow;
   }
@@ -62,7 +50,7 @@ class SiteOrganizationMembership extends TerminusModel {
   public function setRole($role) {
     $workflow = $this->site->workflows->create(
       'update_site_organization_membership',
-      array('params' => array('organization_id' => $this->id, 'role' => $role))
+      ['params' => ['organization_id' => $this->id, 'role' => $role,],]
     );
     return $workflow;
   }

--- a/php/Terminus/Models/SiteOrganizationMembership.php
+++ b/php/Terminus/Models/SiteOrganizationMembership.php
@@ -4,13 +4,29 @@ namespace Terminus\Models;
 
 class SiteOrganizationMembership extends TerminusModel {
   /**
-   * @var Site
-   */
-  protected $site;
-  /**
    * @var Organization
    */
-  protected $organization;
+  public $organization;
+  /**
+   * @var Site
+   */
+  public $site;
+
+  /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   * @return SiteUserMembership
+   */
+  public function __construct($attributes = null, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->site = $options['collection']->site;
+    $this->organization = new Organization(
+      $attributes->organization,
+      ['id' => $attributes->organization->id, 'memberships' => [$this,],]
+    );
+  }
 
   /**
    * Returns organization object within SiteOrganizationMembership object

--- a/php/Terminus/Models/SiteUserMembership.php
+++ b/php/Terminus/Models/SiteUserMembership.php
@@ -2,8 +2,6 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\TerminusModel;
-
 class SiteUserMembership extends TerminusModel {
   protected $site;
 

--- a/php/Terminus/Models/SiteUserMembership.php
+++ b/php/Terminus/Models/SiteUserMembership.php
@@ -16,7 +16,7 @@ class SiteUserMembership extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    * @return SiteUserMembership
    */
   public function __construct($attributes = null, array $options = []) {
@@ -33,10 +33,10 @@ class SiteUserMembership extends TerminusModel {
    *
    * @return Workflow
    **/
-  public function removeMember() {
+  public function delete() {
     $workflow = $this->site->workflows->create(
       'remove_site_user_membership',
-      array('params' => array('user_id' => $this->id))
+      ['params' => ['user_id' => $this->id,],]
     );
     return $workflow;
   }
@@ -50,7 +50,7 @@ class SiteUserMembership extends TerminusModel {
   public function setRole($role) {
     $workflow = $this->site->workflows->create(
       'update_site_user_membership',
-      array('params' => array('user_id' => $this->id, 'role' => $role))
+      ['params' => ['user_id' => $this->id, 'role' => $role,],]
     );
     return $workflow;
   }

--- a/php/Terminus/Models/SiteUserMembership.php
+++ b/php/Terminus/Models/SiteUserMembership.php
@@ -3,7 +3,30 @@
 namespace Terminus\Models;
 
 class SiteUserMembership extends TerminusModel {
-  protected $site;
+  /**
+   * @var Site
+   */
+  public $site;
+  /**
+   * @var User
+   */
+  public $user;
+
+  /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   * @return SiteUserMembership
+   */
+  public function __construct($attributes = null, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->site = $options['collection']->site;
+    $this->user = new User(
+      $attributes->user,
+      ['id' => $attributes->user->id, 'memberships' => [$this,],]
+    );
+  }
 
   /**
    * Remove membership, either org or user

--- a/php/Terminus/Models/SshKey.php
+++ b/php/Terminus/Models/SshKey.php
@@ -26,7 +26,7 @@ class SshKey extends TerminusModel {
    */
   public function delete() {
     $response = $this->request->request(
-      'users/' . $this->user->id . '/keys/' . $this->get('id'),
+      'users/' . $this->user->id . '/keys/' . $this->id,
       ['method' => 'delete',]
     );
     return (array)$response['data'];
@@ -49,7 +49,7 @@ class SshKey extends TerminusModel {
    * @return string
    */
   public function getHex() {
-    $hex = implode(':', str_split($this->get('id'), 2));
+    $hex = implode(':', str_split($this->id, 2));
     return $hex;
   }
 

--- a/php/Terminus/Models/SshKey.php
+++ b/php/Terminus/Models/SshKey.php
@@ -3,6 +3,21 @@
 namespace Terminus\Models;
 
 class SshKey extends TerminusModel {
+  /**
+   * @var User
+   */
+  public $user;
+
+  /**
+   * Object constructor
+   *
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to configure this model
+   */
+  public function __construct($attributes = null, array $options = []) {
+    parent::__construct($attributes, $options);
+    $this->user = $options['collection']->user;
+  }
 
   /**
    * Deletes a specific SSH key

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -30,7 +30,7 @@ abstract class TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     if (is_object($attributes)) {

--- a/php/Terminus/Models/TerminusModel.php
+++ b/php/Terminus/Models/TerminusModel.php
@@ -2,7 +2,6 @@
 
 namespace Terminus\Models;
 
-use Terminus\Configurator;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Request;
 
@@ -35,9 +34,6 @@ abstract class TerminusModel {
    * @param array  $options    Options to set as $this->key
    */
   public function __construct($attributes = null, array $options = array()) {
-    if (!defined('Terminus')) {
-      $configurator = new Configurator();
-    }
     if ($attributes == null) {
       $attributes = new \stdClass();
     }

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -2,12 +2,12 @@
 
 namespace Terminus\Models;
 
-use Terminus\Models\Collections\Instruments;
-use Terminus\Models\Collections\MachineTokens;
-use Terminus\Models\Collections\SshKeys;
-use Terminus\Models\Collections\UserOrganizationMemberships;
-use Terminus\Models\Collections\UserSiteMemberships;
-use Terminus\Models\Collections\Workflows;
+use Terminus\Collections\Instruments;
+use Terminus\Collections\MachineTokens;
+use Terminus\Collections\SshKeys;
+use Terminus\Collections\UserOrganizationMemberships;
+use Terminus\Collections\UserSiteMemberships;
+use Terminus\Collections\Workflows;
 
 class User extends TerminusModel {
   /**

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -44,7 +44,7 @@ class User extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);
@@ -146,7 +146,7 @@ class User extends TerminusModel {
    * @return void
    */
   private function setAliases() {
-    $path     = sprintf('users/%s/drush_aliases', $this->id);
+    $path     = "users/{$this->id}/drush_aliases";
     $options  = ['method' => 'get',];
     $response = $this->request->request($path, $options);
 

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -56,7 +56,7 @@ class User extends TerminusModel {
     $this->org_memberships  = new UserOrganizationMemberships($params);
     $this->site_memberships = new UserSiteMemberships($params);
     $this->ssh_keys         = new SshKeys($params);
-    $this->workflows        = new Workflows(['owner' => $this,]);
+    $this->workflows        = new Workflows($params);
   }
 
   /**

--- a/php/Terminus/Models/UserOrganizationMembership.php
+++ b/php/Terminus/Models/UserOrganizationMembership.php
@@ -16,8 +16,7 @@ class UserOrganizationMembership extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return UserSiteMembership
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/UserOrganizationMembership.php
+++ b/php/Terminus/Models/UserOrganizationMembership.php
@@ -21,7 +21,7 @@ class UserOrganizationMembership extends TerminusModel {
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);
-    $this->user         = $options['user'];
+    $this->user = $options['collection']->user;
     $this->organization = new Organization(
       $attributes->organization,
       ['id' => $attributes->organization->id, 'memberships' => [$this,],]

--- a/php/Terminus/Models/UserSiteMembership.php
+++ b/php/Terminus/Models/UserSiteMembership.php
@@ -16,8 +16,7 @@ class UserSiteMembership extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
-   * @return UserSiteMembership
+   * @param array  $options    Options with which to configure this model
    */
   public function __construct($attributes = null, array $options = []) {
     parent::__construct($attributes, $options);

--- a/php/Terminus/Models/Workflow.php
+++ b/php/Terminus/Models/Workflow.php
@@ -27,7 +27,7 @@ class Workflow extends TerminusModel {
    * Object constructor
    *
    * @param object $attributes Attributes of this model
-   * @param array  $options    Options to set as $this->key
+   * @param array  $options    Options with which to configure this model
    * @return Workflow
    */
   public function __construct($attributes = null, array $options = []) {

--- a/php/Terminus/Models/Workflow.php
+++ b/php/Terminus/Models/Workflow.php
@@ -3,8 +3,6 @@
 namespace Terminus\Models;
 
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\TerminusModel;
-use Terminus\Models\WorkflowOperation;
 
 class Workflow extends TerminusModel {
 

--- a/php/Terminus/Models/Workflow.php
+++ b/php/Terminus/Models/Workflow.php
@@ -3,41 +3,83 @@
 namespace Terminus\Models;
 
 use Terminus\Exceptions\TerminusException;
+use Terminus\Session;
 
 class Workflow extends TerminusModel {
+  /**
+   * @var Environment
+   */
+  private $environment;
+  /**
+   * @var Organization
+   */
+  private $organization;
+  /**
+   * @var Site
+   */
+  private $site;
+  /**
+   * @var User
+   */
+  private $user;
 
   /**
-   * Give the URL for collection data fetching
+   * Object constructor
    *
-   * @return string $url URL to use in fetch query
+   * @param object $attributes Attributes of this model
+   * @param array  $options    Options to set as $this->key
+   * @return Workflow
    */
-  public function getFetchUrl() {
-    $url = '';
-    switch ($this->getOwnerName()) {
-      case 'user':
-        $url = sprintf(
-          'users/%s/workflows/%s',
-          $this->owner->id,
-          $this->get('id')
-        );
-          break;
-      case 'site':
-        $url = sprintf(
+  public function __construct($attributes = null, array $options = []) {
+    parent::__construct($attributes, $options);
+    $owner = null;
+    if (isset($options['collection'])) {
+      $owner = $options['collection']->getOwnerObject();
+    } else if (isset($options['environment'])) {
+      $owner = $options['environment'];
+    } else if (isset($options['organization'])) {
+      $owner = $options['organization'];
+    } else if (isset($options['site'])) {
+      $owner = $options['site'];
+    } else if (isset($options['user'])) {
+      $owner = $options['user'];
+    }
+
+    switch (get_class($owner)) {
+      case 'Terminus\Models\Environment':
+        $this->environment = $owner;
+        $this->url = sprintf(
           'sites/%s/workflows/%s',
-          $this->owner->get('id'),
-          $this->get('id')
+          $this->environment->site->id,
+          $this->id
         );
           break;
-      case 'organization':
-        $url  = sprintf(
+      case 'Terminus\Models\Organization':
+        $this->organization = $owner;
+        $this->url  = sprintf(
           'users/%s/organizations/%s/workflows/%s',
-          $this->owner->user->id,
-          $this->owner->get('id'),
-          $this->get('id')
+          Session::getUser()->id,
+          $this->organization->id,
+          $this->id
+        );
+          break;
+      case 'Terminus\Models\Site':
+        $this->site = $owner;
+        $this->url = sprintf(
+          'sites/%s/workflows/%s',
+          $this->site->id,
+          $this->id
+        );
+          break;
+      case 'Terminus\Models\User':
+        $this->user = $owner;
+        $this->url = sprintf(
+          'users/%s/workflows/%s',
+          $this->user->id,
+          $this->id
         );
           break;
     }
-    return $url;
   }
 
   /**
@@ -46,13 +88,7 @@ class Workflow extends TerminusModel {
    * @return Workflow
    */
   public function fetchWithLogs() {
-    $options = array(
-      'fetch_args' => array(
-        'query' => array(
-          'hydrate' => 'operations_with_logs'
-        )
-      )
-    );
+    $options = ['query' => ['hydrate' => 'operations_with_logs',],];
     $this->fetch($options);
     return $this;
   }
@@ -102,10 +138,10 @@ class Workflow extends TerminusModel {
     if (is_array($this->get('operations'))) {
       $operations_data = $this->get('operations');
     } else {
-      $operations_data = array();
+      $operations_data = [];
     }
 
-    $operations = array();
+    $operations = [];
     foreach ($operations_data as $operation_data) {
       $operations[] = new WorkflowOperation($operation_data);
     }
@@ -129,20 +165,20 @@ class Workflow extends TerminusModel {
       $elapsed_time = time() - $this->get('created_at');
     }
 
-    $operations_data = array();
+    $operations_data = [];
     foreach ($this->operations() as $operation) {
       $operations_data[] = $operation->serialize();
     }
 
-    $data = array(
+    $data = [
       'id'             => $this->id,
       'env'            => $this->get('environment'),
       'workflow'       => $this->get('description'),
       'user'           => $user,
       'status'         => $this->getStatus(),
       'time'           => sprintf("%ds", $elapsed_time),
-      'operations'     => $operations_data
-    );
+      'operations'     => $operations_data,
+    ];
 
     return $data;
   }
@@ -178,22 +214,6 @@ class Workflow extends TerminusModel {
         }
       }
     }
-  }
-
-  /**
-   * Gets name of the model-owner of this collection
-   *
-   * @return string
-   */
-  protected function getOwnerName() {
-    $owner_name = strtolower(
-      str_replace(
-        array('Terminus\\', 'Models\\'),
-        '',
-        get_class($this->owner)
-      )
-    );
-    return $owner_name;
   }
 
 }

--- a/php/Terminus/Models/WorkflowOperation.php
+++ b/php/Terminus/Models/WorkflowOperation.php
@@ -32,7 +32,7 @@ class WorkflowOperation extends TerminusModel {
    */
   public function description() {
     $description = sprintf(
-      "Operation: %s finished in %s",
+      'Operation: %s finished in %s',
       $this->get('description'),
       $this->duration()
     );

--- a/php/Terminus/Models/WorkflowOperation.php
+++ b/php/Terminus/Models/WorkflowOperation.php
@@ -10,13 +10,13 @@ class WorkflowOperation extends TerminusModel {
    * @return array
    */
   public function serialize() {
-    $data = array(
+    $data = [
       'id'          => $this->id,
       'type'        => $this->get('type'),
       'description' => $this->get('description'),
       'result'      => $this->get('result'),
       'duration'    => $this->duration(),
-    );
+    ];
 
     if ($this->has('log_output')) {
       $data['log_output'] = $this->get('log_output');

--- a/php/Terminus/Models/WorkflowOperation.php
+++ b/php/Terminus/Models/WorkflowOperation.php
@@ -2,9 +2,6 @@
 
 namespace Terminus\Models;
 
-use Terminus\Exceptions\TerminusException;
-use Terminus\Models\TerminusModel;
-
 class WorkflowOperation extends TerminusModel {
 
   /**

--- a/php/Terminus/Request.php
+++ b/php/Terminus/Request.php
@@ -6,9 +6,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\RequestOptions;
 use GuzzleHttp\Psr7\Request as HttpRequest;
+use Terminus\Config;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Runner;
-use Terminus\Utils;
 
 /**
  * Handles requests made by terminus
@@ -109,6 +108,7 @@ class Request {
    * @throws TerminusException
    */
   public function request($path, $arg_options = []) {
+    $config = Config::getAll();
     $default_options = [
       'method'       => 'get',
       'absolute_url' => false,
@@ -119,9 +119,9 @@ class Request {
     if ((strpos($path, 'http') !== 0) && !$options['absolute_url']) {
       $url = sprintf(
         '%s://%s:%s/api/%s',
-        TERMINUS_PROTOCOL,
-        TERMINUS_HOST,
-        TERMINUS_PORT,
+        $config['protocol'],
+        $config['host'],
+        $config['port'],
         $path
       );
     }
@@ -145,12 +145,13 @@ class Request {
    * @return \Psr\Http\Message\ResponseInterface
    */
   private function send($uri, $method, array $arg_params = []) {
+    $host = Config::get('host');
     $extra_params = [
       'headers'         => [
         'User-Agent'    => $this->userAgent(),
         'Content-type'  => 'application/json',
       ],
-      RequestOptions::VERIFY => (strpos(TERMINUS_HOST, 'onebox') === false),
+      RequestOptions::VERIFY => (strpos($host, 'onebox') === false),
     ];
 
     if ((!isset($arg_params['absolute_url']) || !$arg_params['absolute_url'])
@@ -163,7 +164,7 @@ class Request {
       $params['json'] = $params['form_params'];
       unset($params['form_params']);
     }
-    $params[RequestOptions::VERIFY] = (strpos(TERMINUS_HOST, 'onebox') === false);
+    $params[RequestOptions::VERIFY] = (strpos($host, 'onebox') === false);
 
     $client = new Client(
       [
@@ -213,11 +214,12 @@ class Request {
    * @return string
    */
   private function getBaseUri() {
+    $config = Config::getAll();
     $base_uri = sprintf(
       '%s://%s:%s',
-      TERMINUS_PROTOCOL,
-      TERMINUS_HOST,
-      TERMINUS_PORT
+      $config['protocol'],
+      $config['host'],
+      $config['port']
     );
     return $base_uri;
   }
@@ -228,11 +230,12 @@ class Request {
    * @return string
    */
   private function userAgent() {
+    $config = Config::getAll();
     $agent = sprintf(
       'Terminus/%s (php_version=%s&script=%s)',
-      constant('TERMINUS_VERSION'),
+      $config['version'],
       phpversion(),
-      constant('TERMINUS_SCRIPT')
+      $config['script']
     );
     return $agent;
   }

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -2,6 +2,7 @@
 
 namespace Terminus;
 
+use Terminus\Config;
 use Terminus\Dispatcher;
 use Terminus\Dispatcher\CompositeCommand;
 use Terminus\Exceptions\TerminusException;
@@ -220,7 +221,7 @@ class Runner {
    * @return string
    */
   public function getUserConfigDir() {
-    return TERMINUS_CONFIG_DIR;
+    return Config::get('config_dir');
   }
 
   /**
@@ -247,7 +248,7 @@ class Runner {
    * @return string
    */
   private function getUserPluginsDir() {
-    return TERMINUS_PLUGINS_DIR;
+    return Config::get('plugins_dir');
   }
 
   /**
@@ -262,7 +263,7 @@ class Runner {
     $directories = [];
 
     // Add the directory of core commands first.
-    $directories[] = TERMINUS_ROOT . '/php/Terminus/Commands';
+    $directories[] = Config::get('root') . '/php/Terminus/Commands';
 
     // Find the command directories from the third party plugins directory.
     foreach ($this->getUserPlugins() as $dir) {

--- a/php/Terminus/Runner.php
+++ b/php/Terminus/Runner.php
@@ -216,22 +216,13 @@ class Runner {
   }
 
   /**
-   * Retrieves and returns the users local configuration directory (~/terminus)
-   *
-   * @return string
-   */
-  public function getUserConfigDir() {
-    return Config::get('config_dir');
-  }
-
-  /**
    * Retrieves and returns a list of plugin's base directories
    *
    * @return array
    */
   private function getUserPlugins() {
     $out = [];
-    if ($plugins_dir = $this->getUserPluginsDir()) {
+    if ($plugins_dir = Config::get('plugins_dir')) {
       $plugin_iterator = new \DirectoryIterator($plugins_dir);
       foreach ($plugin_iterator as $dir) {
         if (!$dir->isDot()) {
@@ -240,15 +231,6 @@ class Runner {
       }
     }
     return $out;
-  }
-
-  /**
-   * Retrieves and returns the local config directory
-   *
-   * @return string
-   */
-  private function getUserPluginsDir() {
-    return Config::get('plugins_dir');
   }
 
   /**

--- a/php/utils.php
+++ b/php/utils.php
@@ -10,11 +10,7 @@ use Terminus\Config;
  * @return bool
  */
 function isTest() {
-
-  $is_test = (
-    (boolean)Config::get('test_mode')
-    || (boolean)TERMINUS_VCR_CASSETTE
-  );
+  $is_test = (boolean)Config::get('test_mode');
   return $is_test;
 }
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -2,13 +2,19 @@
 
 namespace Terminus\Utils;
 
+use Terminus\Config;
+
 /**
  * Terminus is in test mode
  *
  * @return bool
  */
 function isTest() {
-  $is_test = ((boolean)TERMINUS_TEST_MODE || (boolean)TERMINUS_VCR_CASSETTE);
+
+  $is_test = (
+    (boolean)Config::get('test_mode')
+    || (boolean)TERMINUS_VCR_CASSETTE
+  );
   return $is_test;
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,7 +4,7 @@ vendor/bin/phpcpd php
 set -e
 phpcs="vendor/bin/phpcs --standard=tests/config/standards.xml --extensions=php --warning-severity=6 --error-severity=1"
 #Run PHP Code Sniffer on files with internal documentation
-cmd=$phpcs+" --ignore=php/Terminus/Commands/*,vendor/*,tests/unit_tests/*,tests/features/* *"
+cmd=$phpcs+" --ignore=php/Terminus/Commands/* php/*"
 eval $cmd
 cmd=$phpcs+" php/Terminus/Commands/TerminusCommand.php"
 eval $cmd

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -1,0 +1,58 @@
+<?php
+// src/Terminus.php
+
+use Symfony\Component\Console\Application;
+use Terminus\Config;
+
+class Terminus extends Application {
+
+  /**
+   * @inheritdoc
+   */
+  public function __construct() {
+    $this->setAutoloader();
+    parent::__construct('Terminus', Config::get('version'));
+    date_default_timezone_set(Config::get('time_zone'));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getDefaultHelperSet() {
+    $helper_set = parent::getDefaultHelperSet();
+    //$helper_set->set(new Terminus\Helpers\FileHelper());
+    return $helper_set;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getDefaultInputDefinition() {
+    $definition = parent::getDefaultInputDefinition();
+    $definition->addOptions(
+      [
+        new InputOption(
+          '--yes',
+          '-y',
+          InputOption::VALUE_NONE,
+          'Answer yes to all prompts'
+        ),
+      ]
+    );
+    return $definition;
+  }
+
+  /**
+   * Sets the autoloader up to retrieve files as necessary
+   *
+   * @return void
+   */
+  private function setAutoloader() {
+    $loader = new Psr4ClassLoader();
+    $loader->addPrefix('Terminus\\', __DIR__);
+    $loader->addPrefix('Terminus\\Models', __DIR__ . '../php/Terminus/Models');
+    $loader->addPrefix('Terminus\\Collections', __DIR__ . '../php/Terminus/Collections');
+    $loader->register();
+  }
+
+}

--- a/src/run.php
+++ b/src/run.php
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+// src/run.php
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/Terminus.php';
+
+$terminus = new Terminus();

--- a/tests/unit_tests/caches/test-tokens-cache.php
+++ b/tests/unit_tests/caches/test-tokens-cache.php
@@ -1,24 +1,29 @@
 <?php
 
 use Terminus\Caches\TokensCache;
+use Terminus\Config;
 
 /**
  * Testing class for Terminus\Caches\TokensCache
  */
 class TokensCacheTest extends PHPUnit_Framework_TestCase {
-
   /**
    * @var TokensCache
    */
   private $tokens_cache;
+  /**
+   * @var string
+   */
+  private $tokens_path;
 
   public function __construct() {
     $this->tokens_cache = new TokensCache();
+    $this->tokens_path = Config::get('tokens_dir');
   }
 
   public function testAdd() {
     $email     = 'fake@email.address';
-    $file_name = TERMINUS_TOKENS_DIR . "/$email";
+    $file_name = $this->tokens_path . "/$email";
     exec("rm $file_name");
     $this->tokens_cache->add(compact('email'));
     $contents = retrieveOutput($file_name);
@@ -32,7 +37,7 @@ class TokensCacheTest extends PHPUnit_Framework_TestCase {
     $contents = $this->tokens_cache->findByEmail($email);
     $this->assertEquals($contents['email'], $email);
 
-    $file_name = TERMINUS_TOKENS_DIR . "/$email";
+    $file_name = $this->tokens_path . "/$email";
     exec("rm $file_name");
     try {
       $contents = $this->tokens_cache->findByEmail($email);
@@ -44,7 +49,7 @@ class TokensCacheTest extends PHPUnit_Framework_TestCase {
 
   public function testGetAllSavedTokenEmails() {
     $email     = 'fake@email.address';
-    $file_name = TERMINUS_TOKENS_DIR . "/$email";
+    $file_name = $this->tokens_path . "/$email";
     exec("rm $file_name");
     $emails = $this->tokens_cache->getAllSavedTokenEmails();
     $this->assertFalse(in_array($email, $emails));
@@ -56,7 +61,7 @@ class TokensCacheTest extends PHPUnit_Framework_TestCase {
 
   public function testTokenExistsForEmail() {
     $email     = 'fake@email.address';
-    $file_name = TERMINUS_TOKENS_DIR . "/$email";
+    $file_name = $this->tokens_path . "/$email";
     exec("rm $file_name");
     $this->assertFalse($this->tokens_cache->tokenExistsForEmail($email));
 

--- a/tests/unit_tests/helpers/test-input-helper.php
+++ b/tests/unit_tests/helpers/test-input-helper.php
@@ -2,7 +2,6 @@
 
 use Terminus\Commands\ArtCommand;
 use Terminus\Helpers\InputHelper;
-use Terminus\Loggers\Logger;
 use Terminus\Runner;
 
 /**
@@ -34,15 +33,9 @@ class InputHelperTest extends PHPUnit_Framework_TestCase {
 
   public function testEnv() {
     //From args
-    $env_id = $this->inputter->env(array('args' => array('env' => 'test')));
+    $env_id = $this->inputter->env(['args' => ['env' => 'test',],]);
     $this->assertInternalType('string', $env_id);
     $this->assertEquals('test', $env_id);
-
-    //From environment variable
-    $_SERVER['TERMINUS_ENV'] = 'live';
-    $env_id = $this->inputter->env();
-    $this->assertInternalType('string', $env_id);
-    $this->assertEquals('live', $env_id);
   }
 
   public function testGetNullInputs() {

--- a/tests/unit_tests/models/test-environment.php
+++ b/tests/unit_tests/models/test-environment.php
@@ -1,6 +1,6 @@
 <?php
 
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
 use Terminus\Runner;
 
 /**


### PR DESCRIPTION
The old method of setting configurabls constnats necessitated the creation of a Configurator object, properly belonging to WP-CLI's dispatcher, to make use of Terminus' configuration. I've separated the Terminus Config from the Configurator and ended the widespread use of constants in favor of static methods from the Config class.

Also:
- Removed a whole lot of duplicative code
- Standardized the format of models and collections
