### PR TITLE
Inject dependencies at runtime.

### DIFF
--- a/bin/terminus.php
+++ b/bin/terminus.php
@@ -4,6 +4,10 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Pantheon\Terminus\Runner;
+use Pantheon\Terminus\Terminus;
+use Pantheon\Terminus\Config;
 
-$runner = new Runner();
+$config = new Config();
+$application = new Terminus($config);
+$runner = new Runner([], $application);
 $runner->run();

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -24,11 +24,12 @@ class Runner
      * Runner constructor
      *
      * @param array $options Options to configure the runner
+     * @param \Pantheon\Terminus\Terminus $application
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options = [], Terminus $application = null)
     {
         $this->commands_directory = __DIR__ . '/Commands';
-        $this->application = new Terminus();
+        $this->application = $application;
         $this->configureApplication(new Config($options));
     }
 

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -11,10 +11,10 @@ class Terminus extends Application
     /**
      * @inheritdoc
      */
-    public function __construct()
+    public function __construct(Config $config)
     {
-        $config = new Config();
-        parent::__construct('Terminus', $config->get('version'));
+        $this->config = $config;
+        parent::__construct('Terminus', $this->config->get('version'));
     }
 
     /**


### PR DESCRIPTION
For easier testing and refactoring, we should inject object dependencies rather than instantiating them in the constructor of objects whenever possible.
