### PR TITLE
Changed how Robo Runner recieves its container to conform to changes on master

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus;
 
 use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use League\Container\Container;
+use Robo\Robo;
 use Robo\Runner as RoboRunner;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,7 +30,8 @@ class Runner
         $commands_directory = __DIR__ . '/Commands';
         $top_namespace = 'Pantheon\Terminus\Commands';
         $this->commands = $this->getCommands(['path' => $commands_directory, 'namespace' => $top_namespace,]);
-        $this->runner = new RoboRunner(null, null, $container);
+        $this->runner = new RoboRunner();
+        $this->runner->setContainer($container);
     }
 
     /**


### PR DESCRIPTION
The old-style construction doesn't seem to get in the way of the rest of the functioning of Terminus 1.0, less the presence of `--yes` and the program name/version being incorrect (i.e. it's using a default application that works for our purposes at the moment).
