### PR TITLE
Add Authorizer::ensureLogin()

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "1.3.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/annotated-command.git",
-                "reference": "dc78a7303453a67598aa7cdbf22c1fbf2714c684"
+                "url": "https://github.com/consolidation/annotated-command.git",
+                "reference": "c2dc2464e1edf0498bf97a99f34cac5805d00946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/annotated-command/zipball/dc78a7303453a67598aa7cdbf22c1fbf2714c684",
-                "reference": "dc78a7303453a67598aa7cdbf22c1fbf2714c684",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/c2dc2464e1edf0498bf97a99f34cac5805d00946",
+                "reference": "c2dc2464e1edf0498bf97a99f34cac5805d00946",
                 "shasum": ""
             },
             "require": {
@@ -57,19 +57,19 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-09-09 04:45:40"
+            "time": "2016-09-13 21:37:50"
         },
         {
             "name": "consolidation/log",
             "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/log.git",
+                "url": "https://github.com/consolidation/log.git",
                 "reference": "74ba81b4edc585616747cc5c5309ce56fec41254"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/log/zipball/74ba81b4edc585616747cc5c5309ce56fec41254",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/74ba81b4edc585616747cc5c5309ce56fec41254",
                 "reference": "74ba81b4edc585616747cc5c5309ce56fec41254",
                 "shasum": ""
             },
@@ -111,12 +111,12 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/output-formatters.git",
+                "url": "https://github.com/consolidation/output-formatters.git",
                 "reference": "6428d8fb30c9ed3b96314580808b3e4415b46dd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/output-formatters/zipball/6428d8fb30c9ed3b96314580808b3e4415b46dd9",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/6428d8fb30c9ed3b96314580808b3e4415b46dd9",
                 "reference": "6428d8fb30c9ed3b96314580808b3e4415b46dd9",
                 "shasum": ""
             },
@@ -158,13 +158,13 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/Robo.git",
-                "reference": "a2fdb08d6a1cb0e07c066f7fc736f780f1dbc20d"
+                "url": "https://github.com/consolidation/Robo.git",
+                "reference": "00d80a0bea8f862af520aa6bdc89482c7e396c06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/Robo/zipball/a2fdb08d6a1cb0e07c066f7fc736f780f1dbc20d",
-                "reference": "a2fdb08d6a1cb0e07c066f7fc736f780f1dbc20d",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/00d80a0bea8f862af520aa6bdc89482c7e396c06",
+                "reference": "00d80a0bea8f862af520aa6bdc89482c7e396c06",
                 "shasum": ""
             },
             "require": {
@@ -225,7 +225,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2016-09-12 20:29:51"
+            "time": "2016-09-14 04:21:43"
         },
         {
             "name": "container-interop/container-interop",

--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pantheon\Terminus;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Consolidation\AnnotatedCommand\CommandError;
+use Robo\Contract\ConfigAwareInterface;
+use Robo\Common\ConfigAwareTrait;
+use Terminus\Models\Auth;
+
+class Authorizer implements LoggerAwareInterface, ConfigAwareInterface
+{
+    use LoggerAwareTrait;
+    use ConfigAwareTrait;
+
+    /**
+     * Authorize the current user prior to running a command.  The
+     * Annotated Commands hook manager will call this function during
+     * the pre-validate phase of any command that has an 'authorize'
+     * annotation.
+     *
+     * @hook pre-validate @authorize
+     */
+    public function ensureLogin()
+    {
+        throw new \Exception('Bam!');
+        return new CommandError("Sorry about that.");
+        $auth   = new Auth();
+        $tokens = $auth->getAllSavedTokenEmails();
+        if (!$auth->loggedIn()) {
+            if (count($tokens) === 1) {
+                $email = array_shift($tokens);
+                $auth->logInViaMachineToken(compact('email'));
+            } elseif (!is_null($this->config->get('user')) && $email = $this->config->get('user')) {
+                $auth->logInViaMachineToken(compact('email'));
+            } else {
+                $this->logger->error(
+                    'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
+                );
+                // This should print an error message, but presently it does not.
+                throw new \RuntimeException(
+                    'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
+                );
+            }
+        }
+    }
+}

--- a/src/Commands/ArtCommand.php
+++ b/src/Commands/ArtCommand.php
@@ -11,6 +11,7 @@ class ArtCommand extends TerminusCommand
      * Displays Pantheon ASCII artwork
      *
      * @name art
+     * @authorize
      *
      * @param string $name Name of the artwork to select
      * @usage terminus art rocket

--- a/src/Commands/TerminusCommand.php
+++ b/src/Commands/TerminusCommand.php
@@ -19,19 +19,10 @@ abstract class TerminusCommand implements IOAwareInterface, LoggerAwareInterface
     use IO;
 
     /**
-     * @var boolean True if the command requires the user to be logged in
-     */
-    protected $authorized = false;
-
-    /**
      * TerminusCommand constructor
      */
     public function __construct()
     {
-        // TODO: Cannot log in until our dependencies are inflected
-        //if ($this->authorized) {
-        //    $this->ensureLogin();
-        //}
     }
 
     /**
@@ -42,28 +33,5 @@ abstract class TerminusCommand implements IOAwareInterface, LoggerAwareInterface
     protected function log()
     {
         return $this->logger;
-    }
-
-    /**
-     * Logs the user in or errs
-     *
-     * @return void
-     */
-    private function ensureLogin() {
-        $auth   = new Auth();
-        $tokens = $auth->getAllSavedTokenEmails();
-        if (!$auth->loggedIn()) {
-            if (count($tokens) === 1) {
-                $email = array_shift($tokens);
-                $auth->logInViaMachineToken(compact('email'));
-            } else if (!is_null($this->config->get('user')) && $email = $this->config->get('user')) {
-                $auth->logInViaMachineToken(compact('email'));
-            } else {
-                $this->log()->error(
-                  'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
-                );
-            }
-        }
-        return true;
     }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -30,6 +30,7 @@ class Runner
         $commands_directory = __DIR__ . '/Commands';
         $top_namespace = 'Pantheon\Terminus\Commands';
         $this->commands = $this->getCommands(['path' => $commands_directory, 'namespace' => $top_namespace,]);
+        $this->commands[] = 'Pantheon\\Terminus\\Authorizer';
         $this->runner = new RoboRunner();
         $this->runner->setContainer($container);
     }


### PR DESCRIPTION
Annotate it with a @hook to cause it to be called for any command annotated with @authorize.

This mostly works; however, if you exit from the validate hook with an exit code (e.g. '1') it does not exit (as it should), and if you throw an exception, the message is not printed (as it should be).  I'll work on fixing both these problems, and you can pick which way you prefer to fail when not logged in. Note also that I made no attempt to test the Auth() stuff; it may or may not be working (status should be the same as current state of master branch).

Note that there are a few different ways this could work.  The Authorizer could just be implemented as a TerminusCommand, although it isn't really a command -- it is a hook that is called when other appropriately-annotated commands are called.

Also, instead of registering the authorizer with the command factory and annotating it with '@hook pre-validate @authorize', it would also be possible to just make a class that implemented ValidationInterface, and register the object directly with the hook manager (which may be obtained from the container).

I can refactor this if you prefer any of the other options.
