### PR TITLE
Improve 'help' output, provide 'format' and 'fields' options by default.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.0.0-beta2",
+            "version": "2.0.0-beta4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "4a529d09f13c886a09cce06b6d4b2a42a010cba4"
+                "reference": "47d5e634385f379c17ccf547e4a20f48c11b9183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/4a529d09f13c886a09cce06b6d4b2a42a010cba4",
-                "reference": "4a529d09f13c886a09cce06b6d4b2a42a010cba4",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/47d5e634385f379c17ccf547e4a20f48c11b9183",
+                "reference": "47d5e634385f379c17ccf547e4a20f48c11b9183",
                 "shasum": ""
             },
             "require": {
@@ -30,10 +30,13 @@
                 "symfony/finder": "~2.5|~3.0"
             },
             "require-dev": {
-                "consolidation/output-formatters": "^2.0.0-beta2",
+                "consolidation/output-formatters": "^2.0.0-beta3",
                 "phpunit/phpunit": "4.*",
                 "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "consolidation/output-formatters": "Format text by applying transformations provided by plug-in formatters."
             },
             "type": "library",
             "extra": {
@@ -57,7 +60,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-09-15 22:36:27"
+            "time": "2016-09-19 19:00:17"
         },
         {
             "name": "consolidation/log",
@@ -108,21 +111,22 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "2.0.0-beta2",
+            "version": "2.0.0-beta5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "8473a4c0f337914078a036cbf360ecd9532e9f46"
+                "reference": "9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/8473a4c0f337914078a036cbf360ecd9532e9f46",
-                "reference": "8473a4c0f337914078a036cbf360ecd9532e9f46",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a",
+                "reference": "9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "symfony/console": "~2.5|~3.0"
+                "symfony/console": "~2.5|~3.0",
+                "symfony/finder": "~2.5|~3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
@@ -151,7 +155,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-09-15 22:28:19"
+            "time": "2016-09-19 19:44:19"
         },
         {
             "name": "consolidation/robo",
@@ -159,18 +163,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "67f5bdfbdd9d3a55640c430b74b324ce9c567315"
+                "reference": "9af2f87c9da1579526ac7ebacaa03613bcc6bad1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/67f5bdfbdd9d3a55640c430b74b324ce9c567315",
-                "reference": "67f5bdfbdd9d3a55640c430b74b324ce9c567315",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/9af2f87c9da1579526ac7ebacaa03613bcc6bad1",
+                "reference": "9af2f87c9da1579526ac7ebacaa03613bcc6bad1",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "^2.0.0-beta1",
+                "consolidation/annotated-command": "^2.0.0-beta3",
                 "consolidation/log": "~1",
-                "consolidation/output-formatters": "^2.0.0-beta1",
+                "consolidation/output-formatters": "^2.0.0-beta3",
                 "league/container": "^2.2",
                 "php": ">=5.5.0",
                 "symfony/console": "~2.5|~3.0",
@@ -225,7 +229,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2016-09-15 20:16:13"
+            "time": "2016-09-19 19:22:04"
         },
         {
             "name": "container-interop/container-interop",
@@ -661,16 +665,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3"
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
-                "reference": "47b254ea51f1d6d5dc04b9b299e88346bf2369e3",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0",
                 "shasum": ""
             },
             "require": {
@@ -708,7 +712,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-04-19 13:41:41"
+            "time": "2016-09-16 12:04:44"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1903,16 +1907,16 @@
         },
         {
             "name": "behat/gherkin",
-            "version": "v4.4.2",
+            "version": "v4.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "d26757dc970e67b50ed0ee47b95273daeb84fea6"
+                "reference": "cf8cc94647101e02a33d690245896d83d880aea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/d26757dc970e67b50ed0ee47b95273daeb84fea6",
-                "reference": "d26757dc970e67b50ed0ee47b95273daeb84fea6",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/cf8cc94647101e02a33d690245896d83d880aea1",
+                "reference": "cf8cc94647101e02a33d690245896d83d880aea1",
                 "shasum": ""
             },
             "require": {
@@ -1958,7 +1962,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-09-03 07:28:57"
+            "time": "2016-09-18 12:16:14"
         },
         {
             "name": "behat/transliterator",

--- a/src/Commands/Auth/WhoamiCommand.php
+++ b/src/Commands/Auth/WhoamiCommand.php
@@ -24,9 +24,9 @@ class WhoamiCommand extends TerminusCommand
      *   Responds with the email of the logged-in user
      * @usage terminus auth:whoami --format=table
      *   Responds with the current session and user's data
-     * @return \Consolidation\OutputFormatters\StructuredData\AssociativeList
+     * @return AssociativeList
      */
-    public function whoAmI($options = ['format' => 'string', 'fields' => ''])
+    public function whoAmI()
     {
         $auth = new Auth();
         if ($auth->loggedIn()) {

--- a/src/Commands/MachineToken/ListCommand.php
+++ b/src/Commands/MachineToken/ListCommand.php
@@ -25,7 +25,7 @@ class ListCommand extends TerminusCommand
      * @usage terminus machine-token:list
      *   Lists your user's machine tokens
      */
-    public function listTokens($options = ['format' => 'table', 'fields' => '']) {
+    public function listTokens() {
         $user = $this->session()->getUser();
 
         $machine_tokens = $user->machine_tokens->all();

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus;
 
-use Robo\Application;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 
 class Terminus extends Application


### PR DESCRIPTION
Update to latest available dependencies; extend the Symfony Console application, not the Robo application.

With this PR:

```
$ php ./bin/terminus.php help whoami 
Usage:
  auth:whoami [options]
  whoami
  auth:whoami terminus auth:whoami
  auth:whoami terminus auth:whoami --format=table

Options:
      --format[=FORMAT]  Format the result data. Available formats: csv,json,list,php,print-r,string,table,tsv,var_export,xml,yaml [default: "string"]
      --fields[=FIELDS]  Available fields: First Name (firstname), Last Name (lastname), eMail (email), ID (id) [default: ""]
  -h, --help             Display this help message
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi             Force ANSI output
      --no-ansi          Disable ANSI output
  -n, --no-interaction   Do not ask any interactive question
  -y, --yes              Answer yes to all prompts
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Displays information about the user currently logged in
```

Prior to this PR:

```
$ php ./bin/terminus.php help whoami
Usage:
  auth:whoami [options]
  whoami
  auth:whoami terminus auth:whoami
  auth:whoami terminus auth:whoami --format=table

Options:
      --format[=FORMAT]                 [default: "string"]
      --fields[=FIELDS]                 [default: ""]
  -h, --help                           Display this help message
  -q, --quiet                          Do not output any message
  -V, --version                        Display this application version
      --ansi                           Force ANSI output
      --no-ansi                        Disable ANSI output
  -n, --no-interaction                 Do not ask any interactive question
      --simulate                       Run in simulated mode (show what would have happened).
      --progress-delay=PROGRESS-DELAY  Number of seconds before progress bar is displayed in long-running task collections. Default: 2s. [default: 2]
      --supress-messages               Supress all Robo TaskIO messages.
  -y, --yes                            Answer yes to all prompts
  -v|vv|vvv, --verbose                 Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Displays information about the user currently logged in
```

n.b. It is no longer necessary to explicitly add `format` or `fields` options to commands. The annotated commands library will now add these automatically if the @return type of the command indicates a formattable data type. Nifty!

n.n.b. The options `--simulate`, `--progress-delay` and `--supress-messages` were being added by Robo, but these are not needed by Terminus.  The `--yes` option, on the other hand, is added by Terminus. Perhaps this was not intentional, but I did not remove it. This could be done here or in a follow-on PR if desired.

n.n.n.b. I did not update the `connection:info` command, because it requires more changes (it should use AssociativeList instead of RowsOfFields). I'll do this in a follow-on PR.
