### PR TITLE
Tidy up connection:info command

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.0.0-beta5",
+            "version": "2.0.0-beta7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "daebf45082ac93719ee0ccee53971a2db1c2d115"
+                "reference": "76a15b061124f8a57742854662a58a501133a84a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/daebf45082ac93719ee0ccee53971a2db1c2d115",
-                "reference": "daebf45082ac93719ee0ccee53971a2db1c2d115",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/76a15b061124f8a57742854662a58a501133a84a",
+                "reference": "76a15b061124f8a57742854662a58a501133a84a",
                 "shasum": ""
             },
             "require": {
@@ -30,7 +30,7 @@
                 "symfony/finder": "~2.5|~3.0"
             },
             "require-dev": {
-                "consolidation/output-formatters": "^2.0.0-beta3",
+                "consolidation/output-formatters": "^2.0.0-beta6",
                 "phpunit/phpunit": "4.*",
                 "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "2.*"
@@ -60,7 +60,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-09-19 23:01:07"
+            "time": "2016-09-23 20:31:13"
         },
         {
             "name": "consolidation/log",
@@ -111,16 +111,16 @@
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "2.0.0-beta5",
+            "version": "2.0.0-beta7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a"
+                "reference": "e38a631b56e31b996e621bf87a3e06c59bc29b8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a",
-                "reference": "9f40486dfccd510bb1620a7c0b4ee5dfd6ccd66a",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/e38a631b56e31b996e621bf87a3e06c59bc29b8f",
+                "reference": "e38a631b56e31b996e621bf87a3e06c59bc29b8f",
                 "shasum": ""
             },
             "require": {
@@ -155,7 +155,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-09-19 19:44:19"
+            "time": "2016-09-23 21:25:10"
         },
         {
             "name": "consolidation/robo",

--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus\Commands\Connection;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\AssociativeList;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Terminus\Collections\Sites;
@@ -21,67 +21,48 @@ class InfoCommand extends TerminusCommand
      *
      * @command connection:info
      *
-     * @param string $environment Name of the environment to retrieve
-     * @param string $filter Parameter filter (optional)
-     * @param array $options [fields=<env,param,value>] [format=<table|csv|yaml|json>]
-     *
-     * @return RowsOfFields
-     *
      * @field-labels
-     *   env: Environment
-     *   param: Parameter
-     *   value: Connection Info
+     *   sftp_username: SFTP Username
+     *   sftp_host: SFTP Host
+     *   sftp_password: SFTP Password
+     *   sftp_url: SFTP URL
+     *   sftp_command: SFTP Command
+     *   git_username: Git Username
+     *   git_host: Git Host
+     *   git_port: Git Port
+     *   git_url: Git URL
+     *   git_command: Git Command
+     *   mysql_host: Mysql Host
+     *   mysql_username: Mysql Username
+     *   mysql_password: Mysql Password
+     *   mysql_port: Mysql Port
+     *   mysql_database: Mysql Database
+     *   mysql_url: Mysql URL
+     *   mysql_command: Mysql Command
      *
-     * @example connection:info awesome-site.dev git_command --format=json
+     * @param string $environment Name of the environment to retrieve
+     *
+     * @return AssociativeList
+     *
+     * @usage connection:info awesome-site.dev --format=json
+     *   Display connection information in json format
+     * @usage connection:info awesome-site.dev --fields=mysql_command --format=string
      *   Display connection information only for the given parameter
+     * @usage connection:info awesome-site.dev --fields=git_*
+     *   Display all of the connection information fields related to git.
      *
      */
-    public function connectionInfo(
-        $environment,
-        $filter = null,
-        $options = ['format' => 'table', 'fields' => 'param,value']
-    ) {
-        $connection_info = [[]];
-
+    public function connectionInfo($environment)
+    {
         $site_env = explode('.', $environment);
         if (count($site_env) != 2) {
-            $this->log()
-                ->error('The environment argument must be given as <site_name>.<environment>');
-
-            return new RowsOfFields($connection_info);
+            throw new \Exception('The environment argument must be given as <site_name>.<environment>');
         }
 
         $sites = new Sites();
         $site  = $sites->get($site_env[0]);
         $env   = $site->environments->get($site_env[1]);
 
-        $connection_info = $this->environmentParams($env, $filter);
-        return new RowsOfFields($connection_info);
-    }
-
-
-    /**
-     * Retrieve Environment#connectionInfo() in a structure suitable for formatting
-     *   Ex: ['env' => 'live', 'param' => 'mysql_host', 'value' => 'onebox']
-     *
-     * @param Environment $environment A Terminus\Models\Environment to interrogate
-     * @param string $filter An optional parameter name to filter results
-     *
-     * @return array of connection info parameters
-     */
-    protected function environmentParams($environment, $filter = null)
-    {
-        $params = [];
-        foreach ($environment->connectionInfo() as $param => $value) {
-            if (is_null($filter) or $param == $filter) {
-                $params[] = array(
-                    'env'   => "{$environment->site->get('name')}.{$environment->id}",
-                    'param' => $param,
-                    'value' => $value,
-                );
-            }
-        }
-
-        return $params;
+        return new AssociativeList($env->connectionInfo());
     }
 }

--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -32,13 +32,17 @@ class InfoCommand extends TerminusCommand
      *   git_port: Git Port
      *   git_url: Git URL
      *   git_command: Git Command
-     *   mysql_host: Mysql Host
-     *   mysql_username: Mysql Username
-     *   mysql_password: Mysql Password
-     *   mysql_port: Mysql Port
-     *   mysql_database: Mysql Database
-     *   mysql_url: Mysql URL
-     *   mysql_command: Mysql Command
+     *   mysql_host: MySQL Host
+     *   mysql_username: MySQL Username
+     *   mysql_password: MySQL Password
+     *   mysql_port: MySQL Port
+     *   mysql_database: MySQL Database
+     *   mysql_url: MySQL URL
+     *   mysql_command: MySQL Command
+     *   redis_command: Redis Command
+     *   redis_password: Redis Password
+     *   redis_port: Redis Port
+     *   redis_url: Redis URL
      *
      * @param string $environment Name of the environment to retrieve
      *

--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -22,27 +22,28 @@ class InfoCommand extends TerminusCommand
      * @command connection:info
      *
      * @field-labels
+     *   sftp_command: SFTP Command
      *   sftp_username: SFTP Username
      *   sftp_host: SFTP Host
      *   sftp_password: SFTP Password
      *   sftp_url: SFTP URL
-     *   sftp_command: SFTP Command
+     *   git_command: Git Command
      *   git_username: Git Username
      *   git_host: Git Host
      *   git_port: Git Port
      *   git_url: Git URL
-     *   git_command: Git Command
-     *   mysql_host: MySQL Host
+     *   mysql_command: MySQL Command
      *   mysql_username: MySQL Username
+     *   mysql_host: MySQL Host
      *   mysql_password: MySQL Password
+     *   mysql_url: MySQL URL
      *   mysql_port: MySQL Port
      *   mysql_database: MySQL Database
-     *   mysql_url: MySQL URL
-     *   mysql_command: MySQL Command
      *   redis_command: Redis Command
-     *   redis_password: Redis Password
      *   redis_port: Redis Port
      *   redis_url: Redis URL
+     *   redis_password: Redis Password
+     * @default-fields *_command
      *
      * @param string $environment Name of the environment to retrieve
      *

--- a/tests/active_features/connection-info.feature
+++ b/tests/active_features/connection-info.feature
@@ -17,10 +17,64 @@ Feature: Environment Connection Info Command
       Git Command
       MySQL Command
     """
+    And I should not get:
+    """
+      Git URL
+    """
+
+  @vcr site_connection-info
+  Scenario: Show all connection info for a site's environment
+    When I run "terminus connection:info [[test_site_name]].dev --fields='*_url'"
+    Then I should see a table with rows like:
+    """
+      SFTP URL
+      Git URL
+      MySQL URL
+    """
+    And I should not get:
+    """
+      Git Command
+    """
+
+  @vcr site_connection-info
+  Scenario: Show all connection info for a site's environment
+    When I run "terminus connection:info [[test_site_name]].dev --fields='*'"
+    Then I should see a table with rows like:
+    """
+      SFTP Command
+      SFTP Username
+      SFTP Host
+      SFTP Password
+      SFTP URL
+      Git Command
+      Git Username
+      Git Host
+      Git Port
+      Git URL
+      MySQL Command
+      MySQL Username
+      MySQL Host
+      MySQL Password
+      MySQL URL
+      MySQL Port
+      MySQL Database
+    """
 
   @vcr site_connection-info
   Scenario: Show only a specific connection info parameter for a site's environment
     When I run "terminus connection:info [[test_site_name]].dev --fields=git_command"
+    Then I should see a table with rows like:
+    """
+      Git Command
+    """
+    And I should not get:
+    """
+      SFTP Command
+    """
+
+  @vcr site_connection-info
+  Scenario: Show only a specific connection info parameter for a site's environment
+    When I run "terminus connection:info [[test_site_name]].dev --fields='Git Command'"
     Then I should see a table with rows like:
     """
       Git Command

--- a/tests/active_features/connection-info.feature
+++ b/tests/active_features/connection-info.feature
@@ -11,46 +11,36 @@ Feature: Environment Connection Info Command
   @vcr site_connection-info
   Scenario: Show all connection info for a site's environment
     When I run "terminus connection:info [[test_site_name]].dev"
-    Then I should see a table with the headers: Parameter, Connection Info
-    And I should see a table with rows like:
+    Then I should see a table with rows like:
     """
-      sftp_command
-      sftp_host
-      sftp_password
-      sftp_url
-      sftp_username
-      git_username
-      git_host
-      git_port
-      git_url
-      git_command
-      mysql_host
-      mysql_username
-      mysql_password
-      mysql_port
-      mysql_database
-      mysql_url
-      mysql_command
-      redis_password
-      redis_host
-      redis_port
-      redis_url
-      redis_command
+      SFTP Command
+      Git Command
+      MySQL Command
     """
 
   @vcr site_connection-info
   Scenario: Show only a specific connection info parameter for a site's environment
-    When I run "terminus connection:info [[test_site_name]].dev git_command"
-    Then I should see a table with the headers: Parameter, Connection Info
-    And I should see a table with rows like:
+    When I run "terminus connection:info [[test_site_name]].dev --fields=git_command"
+    Then I should see a table with rows like:
     """
-      git_command
+      Git Command
+    """
+    And I should not get:
+    """
+      SFTP Command
     """
 
   @vcr site_connection-info
-  Scenario: Specify connection info table headers
-    When I run "terminus connection:info [[test_site_name]].dev --fields=env,param,value"
-    Then I should see a table with the headers: Environment, Parameter, Connection Info
+  Scenario: Show only a specific connection info parameter for a site's environment
+    When I run "terminus connection:info [[test_site_name]].dev --field=git_command"
+    Then I should see a table with rows like:
+    """
+      git clone ssh://codeserver
+    """
+    And I should not get:
+    """
+      Git Command
+    """
 
   @vcr site_connection-info
   Scenario: Show only a specific connection info parameter for a site's environment

--- a/tests/new_unit_tests/Commands/Connection/InfoCommandTest.php
+++ b/tests/new_unit_tests/Commands/Connection/InfoCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Connection;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\AssociativeList;
 use Pantheon\Terminus\Commands\Connection\InfoCommand;
 use Pantheon\Terminus\Config;
 
@@ -53,117 +53,30 @@ class InfoCommandTest extends ConnectionCommandTest
         $out = $this->command->connectionInfo('behat-tests.dev');
 
         // should return a RowOfFields object
-        $this->assertInstanceOf(RowsOfFields::class, $out);
+        $this->assertInstanceOf(AssociativeList::class, $out);
 
         // should have a field structure
         $connection_info = $out->getArrayCopy();
-        $this->assertEquals(['env', 'param', 'value'], array_keys($connection_info[0]));
 
         // should contain connection parameters
-        $parameters = array_column($connection_info, 'param');
-        $this->assertContains('sftp_command', $parameters);
-        $this->assertContains('git_command', $parameters);
-        $this->assertContains('mysql_command', $parameters);
-        $this->assertContains('redis_command', $parameters);
-    }
-
-    /**
-     * Exercises connection:info command with a valid environment and filter
-     *
-     * @return void
-     *
-     * @vcr site_connection-info
-     */
-    public function testConnectionInfoFilter()
-    {
-        // command output using a filter argument
-        $out        = $this->command->connectionInfo('behat-tests.dev', 'git_command');
-        $parameters = array_column($out->getArrayCopy(), 'param');
-
-        // assert parameter count
-        $this->assertCount(1, $parameters);
-
-        // assert filtered field
-        $this->assertContains('git_command', $parameters);
+        $connection_keys = array_keys($connection_info);
+        $this->assertContains('sftp_command', $connection_keys);
+        $this->assertContains('git_command', $connection_keys);
+        $this->assertContains('mysql_command', $connection_keys);
+        $this->assertContains('redis_command', $connection_keys);
     }
 
     /**
      * Exercises connection:info command without a valid environment argument
      *
      * @return void
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage The environment argument must be given as <site_name>.<environment>
      */
     public function testConnectionInfoInvalid()
     {
-        // should display an error message
-        $this->logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->equalTo('error'),
-                $this->equalTo('The environment argument must be given as <site_name>.<environment>')
-            );
-
         // should return the correct type and structure
         $out = $this->command->connectionInfo('invalid-env');
-        $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([[]], $out->getArrayCopy());
-    }
-
-    /**
-     * Exercises the environmentParams protected method
-     *
-     * @return void
-     */
-    public function testEnvironmentParams()
-    {
-        $site_prophet = $this->prophet->prophesize(Site::class);
-        $site_prophet->get('name')->willReturn('my_site');
-        $site = $site_prophet->reveal();
-
-        $env_prophet = $this->prophet->prophesize(Environment::class);
-        $env_prophet->connectionInfo()->willReturn([
-            'param_a' => 'value_a',
-            'param_b' => 'value_b',
-        ]);
-        $environment       = $env_prophet->reveal();
-        $environment->id   = 'my_env';
-        $environment->site = $site;
-
-        // should return all parameters
-        $this->assertEquals(
-            [
-                ['env' => 'my_site.my_env', 'param' => 'param_a', 'value' => 'value_a'],
-                ['env' => 'my_site.my_env', 'param' => 'param_b', 'value' => 'value_b'],
-            ],
-            $this->protectedMethodCall($this->command, 'environmentParams', [$environment])
-        );
-    }
-
-    /**
-     * Exercises the environmentParams protected method with a filter argument
-     *
-     * @return void
-     */
-    public function testEnvironmentParamsFilter()
-    {
-        $site_prophet = $this->prophet->prophesize(Site::class);
-        $site_prophet->get('name')->willReturn('my_site');
-        $site = $site_prophet->reveal();
-
-        $env_prophet = $this->prophet->prophesize(Environment::class);
-        $env_prophet->connectionInfo()->willReturn([
-            'param_a' => 'value_a',
-            'param_b' => 'value_b',
-        ]);
-        $environment       = $env_prophet->reveal();
-        $environment->id   = 'my_env';
-        $environment->site = $site;
-
-        // should return only filtered parameter
-        $this->assertEquals(
-            [
-                ['env' => 'my_site.my_env', 'param' => 'param_b', 'value' => 'value_b'],
-            ],
-            $this->protectedMethodCall($this->command, 'environmentParams', [$environment, 'param_b'])
-        );
     }
 }


### PR DESCRIPTION
The connection:info command was building its own RowOfFields object, whereas an AssociativeList is a much more natural datatype to use in this instance.  Also, failed commands are better off throwing an exception rather than logging an error and returning empty placeholder data.
