### PR TITLE
Prevent tests from overwriting working cache

### DIFF
--- a/tests/active_features/bootstrap/FeatureContext.php
+++ b/tests/active_features/bootstrap/FeatureContext.php
@@ -32,9 +32,10 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $this->cliroot          = dirname(dirname(__DIR__)) . '/..';
         $this->parameters      = $parameters;
         $this->start_time      = time();
-        $this->cache_file_name = $_SERVER['HOME'] . '/.terminus/cache/session';
-        $this->cache_token_dir = $_SERVER['HOME'] . '/.terminus/cache/tokens';
         $this->connection_info = ['host' => $parameters['host'], 'machine_token' => $parameters['machine_token'],];
+
+        $this->cache_dir = $parameters['cache_dir'];
+        $this->cache_token_dir = $this->cache_dir . "/tokens";
     }
 
     /**
@@ -651,6 +652,10 @@ class FeatureContext implements Context, SnippetAcceptingContext
         if (!empty($mode = $this->parameters['vcr_mode'])) {
             $command = "TERMINUS_VCR_MODE=$mode $command";
         }
+
+        // Pass the cache directory to the command so that tests don't poison the user's cache.
+        $command = "TERMINUS_CACHE_DIR=$this->cache_dir $command";
+
         $command = preg_replace($regex, $terminus_cmd, $command);
 
         ob_start();

--- a/tests/config/behat_10.yml
+++ b/tests/config/behat_10.yml
@@ -19,6 +19,7 @@ default:
               machine_token:           '111111111111111111111111111111111111111111111'
               machine_token_device:    'Behat Testing Token'
               machine_token_id:        'dcr_q4tFMiYiK9DfJO15'
+              cache_dir:                '~/.terminus/behatcache'
     qa:
       paths: [ %paths.base%/../qa_features ]
       contexts:

--- a/tests/fixtures/cli_session-clear
+++ b/tests/fixtures/cli_session-clear
@@ -1,0 +1,74 @@
+
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.4 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            headers: application/json
+            verify: '1'
+            method: post
+            absolute_url: ''
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"111111111111111111111111111111111111111111111","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 16 Aug 2016 22:55:28 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 85856ee0-6404-11e6-9844-1524ed28772c
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"session":"11111111-1111-1111-1111-111111111111:869b935e-6404-11e6-8a36-bc764e1141f9:ze8jBeq7jdfDFQH3KSMTp","expires_at":1473807328,"user_id":"11111111-1111-1111-1111-111111111111"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/users/11111111-1111-1111-1111-111111111111'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.4 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:869b935e-6404-11e6-8a36-bc764e1141f9:ze8jBeq7jdfDFQH3KSMTp'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:869b935e-6404-11e6-8a36-bc764e1141f9:ze8jBeq7jdfDFQH3KSMTp'
+            verify: '1'
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 16 Aug 2016 22:55:28 GMT'
+            Content-Type: application/json
+            Content-Length: '3327'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 86d08c80-6404-11e6-9844-1524ed28772c
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"profile": {"utm_term": "", "invites_to_nonuser": 4, "seen_first_time_user_popover": true, "utm_content": "/", "experiments": {"welcome_video": "shown"}, "full_name": "Dev User", "pullFromLive": false, "utm_device": "", "initial_identity_strategy": null, "utm_campaign": "pantheon.io (organic)", "tracking_first_site_create": 1428723370, "verify": "037eadb020d51ccddba9e06a64908c98", "tracking_first_code_push": 1428811227, "google_adwords_account_registered_sent": 1428707350, "invites_to_user": 8, "utm_medium": "", "job_function": "developer", "tracking_first_workflow_in_live": 1428811293, "tracking_first_team_invite": 1436464837, "firstname": "Dev", "invites_to_site": 12, "lastname": "User", "pda_campaign": null, "utm_source": "https://www.bing.com/search?setmkt=en-US&q=pantheon+san+francisco", "google_adwords_pushed_code_sent": 1428811242, "last-org-spinup": "none", "web_services_business": null, "initial_identity_name": null, "guilty_of_abuse": null, "invites_sent": 12, "tracking_first_site_upgrade": 1437784612, "google_adwords_paid_for_site_sent": 1438018300, "modified": 1458174494, "maxdevsites": 2, "lead_type": "", "organization": " Pantheon Systems, Inc"}, "feature_flags": [{"name": "Experimental Products", "default": false, "enabled": false, "visible": false, "optional": false, "id": "experimental-products"}, {"name": "annotate git tags", "default": false, "enabled": false, "visible": false, "optional": false, "id": "annotate_git_tags"}, {"name": "Cacheserver Add-on", "default": false, "enabled": false, "visible": false, "optional": false, "id": "cacheserver-addon"}, {"name": "Apollo Spinup", "default": true, "enabled": true, "visible": false, "optional": false, "id": "apollo-spinup"}, {"name": "Pantheon One", "default": false, "enabled": false, "visible": false, "optional": false, "id": "one"}, {"name": "Unified User Account Screen ", "default": false, "enabled": false, "visible": true, "optional": false, "id": "apollo-user"}, {"name": "Indexserver Add-on", "default": false, "enabled": false, "visible": true, "optional": false, "id": "indexserver-addon"}, {"name": "Wordpress", "default": false, "enabled": false, "visible": false, "optional": false, "id": "wordpress"}, {"name": "Apollo Self-Service Toggle", "default": true, "enabled": true, "visible": false, "optional": false, "id": "apollo-toggle"}, {"name": "Site Audit Checks", "default": false, "enabled": false, "visible": false, "optional": false, "id": "site_audit_checks"}, {"description": "Enables the new Desk API 2.0 Interface", "default": false, "enabled": true, "visible": true, "percentage": 100, "optional": false, "id": "desk", "name": "desk"}, {"name": "org tags", "default": false, "enabled": false, "visible": true, "optional": false, "id": "org-tags"}, {"name": "Apollo Dashboard", "default": true, "enabled": true, "visible": false, "optional": false, "id": "apollo"}, {"name": "Org Upstream Updates", "default": false, "enabled": false, "visible": false, "optional": false, "id": "org-has-code"}], "user_id": "11111111-1111-1111-1111-111111111111", "created_at": 1428707345, "dev_sites_count": 2, "id": "11111111-1111-1111-1111-111111111111", "destination_organization_id": null, "is_registered": true, "created_organization_id": null, "password": "SCRUBBED", "email": "devuser@pantheon.io"}'

--- a/tests/new_unit_tests/bootstrap.php
+++ b/tests/new_unit_tests/bootstrap.php
@@ -6,3 +6,10 @@
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 \VCR\VCR::configure()->enableRequestMatchers(['method', 'url', 'body',]);
+
+
+// Override the default cache directory by setting an environment variable. This prevents our tests from overwriting
+// the user's real cache and session.
+// @TODO: Unit tests should not rely on side effects like these. When the Config object is properly injectable this
+// will not be necessary.
+putenv("TERMINUS_CACHE_DIR=~/.terminus/testcache");


### PR DESCRIPTION
When you run the beahat/phpunit tests your local cache gets overwritten with test data including your current session. That makes it kind of a pain to work run the tests and is poor testing practice.

This PR kind of fixes it by setting a new cache directory to be used during tests. It interferes with VCR somehow causing the unit tests to fail. 

@TeslaDethray Is it worth trying to figure out the VCR issue and get this working? I'm not sure how much more time it will take but I don't want to put any more time into it unless other's think it's worth it.
