### PR TITLE
Update backup:list feature

### DIFF
--- a/tests/newfeatures/backup-list.feature
+++ b/tests/newfeatures/backup-list.feature
@@ -9,13 +9,13 @@ Feature: List Backups for a Site
 
   @vcr site_backups_list
   Scenario: Show all backups for an environment
-    When I run "terminus backup:list --site=[[test_site_name]] --env=dev --format=json"
+    When I run "terminus backup:list [[test_site_name]].[[test_env_name]] --format=json"
     Then I should have "7" records
     And I should get: "code.tar.gz"
 
   @vcr site_backups_list
   Scenario: Filter backups by element
-    When I run "terminus backup:list --site=[[test_site_name]] --env=dev --element=db --format=json"
+    When I run "terminus backup:list [[test_site_name]].[[test_env_name]] db --format=json"
     Then I should have "2" records
     And I should get: "database.sql.gz"
     And I should not get: "code.tar.gz"


### PR DESCRIPTION
Based on conversation with @ari-gold to match proposed interface for `backup:create`: `terminus backup:create site.env <element>`
