### PR TITLE
Suppress exception message when running unit test that expects exception

### DIFF
--- a/tests/new_unit_tests/RunnerTest.php
+++ b/tests/new_unit_tests/RunnerTest.php
@@ -8,7 +8,7 @@ use Pantheon\Terminus\Runner;
 use Pantheon\Terminus\Terminus;
 use Robo\Robo;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -50,7 +50,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         // Configuring the dependency-injection container
         $this->container = new Container();
         $input = new ArgvInput($_SERVER['argv']);
-        $this->output = new ConsoleOutput();
+        $this->output = new NullOutput();
         $roboConfig = new \Robo\Config(); // TODO: make Terminus Config extend \Robo\Config and use $config here
         Robo::configureContainer($this->container, $roboConfig, $input, $this->output, $this->application);
 


### PR DESCRIPTION
When running this test, an exception prints to stdout even though this exception is expected, the change here simply prevents it from showing up. So this:

```
$ TERMINUS_TEST_MODE=1 vendor/bin/phpunit -c tests/config/phpunit-10.xml.dist
PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

......................

  [Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "DNE" is not defined.


......

Time: 1.12 seconds, Memory: 20.50MB

OK (28 tests, 69 assertions)
```

becomes:

```
$ TERMINUS_TEST_MODE=1 vendor/bin/phpunit -c tests/config/phpunit-10.xml.dist
PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

............................

Time: 1.12 seconds, Memory: 20.75MB

OK (28 tests, 69 assertions)
```
