### PR TITLE
[AL-569] drush command

### DIFF
--- a/src/Commands/Remote/DrushCommand.php
+++ b/src/Commands/Remote/DrushCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Remote;
+
+/**
+ * Command to proxy drush commands on an Environment using SSH
+ *
+ * @package Pantheon\Terminus\Commands\Remote
+ */
+class DrushCommand extends SSHBaseCommand
+{
+    /**
+     * @inheritdoc
+     */
+    protected $command = 'drush';
+
+    /**
+     * @inheritdoc
+     */
+    protected $unavailable_commands = [
+        'sql-connect' => 'connection:info --field=mysql_command',
+        'sql-sync'    => '',
+    ];
+
+    /**
+     * Run arbitrary drush commands on a site environment
+     *
+     * @command remote:drush
+     * @aliases   drush
+     *
+     * @authenticated
+     *
+     * @param string $site_env_id Name of the environment to run the drush command on.
+     * @param array $drush_command Drush command to invoke on the environment
+     *
+     * @return string Output of the given drush command executed on the site environment
+     */
+    public function drushCommand($site_env_id, array $drush_command)
+    {
+        $this->prepareEnvironment($site_env_id);
+
+        return $this->executeCommand($drush_command);
+    }
+}

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -31,7 +31,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
     protected function prepareEnvironment($site_env_id)
     {
         list($this->site, $this->environment) = $this->getSiteEnv($site_env_id);
-        $this->validateEnvironment();
+        $this->validateConnectionMode($this->environment->get('connection_mode'));
     }
 
     protected function executeCommand(array $command_args)
@@ -79,28 +79,16 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         return $is_valid;
     }
 
-    protected function validateEnvironment()
+    protected function validateConnectionMode($mode)
     {
-        $this->validateConnectionMode();
-        $this->validateApplication();
-    }
-
-    protected function validateConnectionMode()
-    {
-        if ($this->environment->info('connection_mode') == 'git') {
-            $this->log()->warning(
-                "Note: This environment is in read-only Git mode. "
+        if ($mode == 'git') {
+            $this->log()->notice(
+                "This environment is in read-only Git mode. "
                 . "If you want to make changes to the codebase of this site "
                 . "(e.g. updating modules or plugins), "
                 . "you will need to toggle into read/write SFTP mode first."
             );
         }
-    }
-
-    protected function validateApplication()
-    {
-        // TODO: validate application type [drupal, wordpress]
-        // print_r($this->environment->info);
     }
 
     private function getCommandLine($command_args)

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Remote;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Terminus\Exceptions\TerminusException;
+
+/**
+ * Base class for Terminus commands that deal with sending SSH commands
+ */
+abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+
+    /**
+     * @var string Name of the command to be run as it will be used on server
+     */
+    protected $command = '';
+
+    /**
+     * @var string[] A hash of commands which do not work using Terminus.
+     *               The key is the native command, and the value is the Terminus equivalent which is optional.
+     */
+    protected $unavailable_commands = [];
+
+    private $site;
+    private $environment;
+
+    protected function prepareEnvironment($site_env_id)
+    {
+        list($this->site, $this->environment) = $this->getSiteEnv($site_env_id);
+        $this->validateEnvironment();
+    }
+
+    protected function executeCommand(array $command_args)
+    {
+        $output = '';
+        if ($this->validateCommand($command_args)) {
+            $command_line = $this->getCommandLine($command_args);
+
+            $result = $this->environment->sendCommandViaSsh($command_line);
+            $output = $result['output'];
+            $exit   = $result['exit_code'];
+
+            $this->log()->info('Command: {site}.{env} -- {command} [Exit: {exit}]', [
+                'site'    => $this->site->get('name'),
+                'env'     => $this->environment->id,
+                'command' => escapeshellarg($command_line),
+                'exit'    => $exit,
+            ]);
+
+            if ($exit != 0) {
+                throw new TerminusException($output);
+            }
+        }
+
+        return rtrim($output);
+    }
+
+    protected function validateCommand(array $command)
+    {
+        $is_valid = true;
+        foreach ($command as $element) {
+            if (isset($this->unavailable_commands[$element])) {
+                $is_valid       = false;
+                $message        = "That command is not available via Terminus. ";
+                $message        .= "Please use the native {command} command.";
+                $interpolations = ['command' => $this->command];
+                if (!empty($alternative = $this->unavailable_commands[$element])) {
+                    $message .= " Hint: You may want to try `{suggestion}`.";
+                    $interpolations['suggestion'] = "terminus $alternative";
+                }
+                $this->log()->error($message, $interpolations);
+            }
+        }
+
+        return $is_valid;
+    }
+
+    protected function validateEnvironment()
+    {
+        $this->validateConnectionMode();
+        $this->validateApplication();
+    }
+
+    protected function validateConnectionMode()
+    {
+        if ($this->environment->info('connection_mode') == 'git') {
+            $this->log()->warning(
+                "Note: This environment is in read-only Git mode. "
+                . "If you want to make changes to the codebase of this site "
+                . "(e.g. updating modules or plugins), "
+                . "you will need to toggle into read/write SFTP mode first."
+            );
+        }
+    }
+
+    protected function validateApplication()
+    {
+        // TODO: validate application type [drupal, wordpress]
+        // print_r($this->environment->info);
+    }
+
+    private function getCommandLine($command_args)
+    {
+        array_unshift($command_args, $this->command);
+
+        return implode(" ", $command_args);
+    }
+}

--- a/tests/new_unit_tests/Commands/Remote/DrushCommandTest.php
+++ b/tests/new_unit_tests/Commands/Remote/DrushCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Commands;
+
+use Pantheon\Terminus\Commands\Remote\DrushCommand;
+
+/**
+ * Class DrushCommandTest
+ *
+ * @package Pantheon\Terminus\UnitTests\Commands\Remote
+ */
+class DrushCommandTest extends CommandTestCase
+{
+    protected $command;
+
+    public function testDrushCommand()
+    {
+        $command = $this->getMockBuilder(DrushCommand::class)
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'prepareEnvironment',
+                'executeCommand',
+            ])
+            ->getMock();
+
+        $command->expects($this->once())
+            ->method('prepareEnvironment')
+            ->with($this->equalTo('dummy-site.dummy-env'));
+
+        $command->expects($this->once())
+            ->method('executeCommand')
+            ->willReturn('command output');
+
+        $output = $command->drushCommand('dummy-site.dummy-env', ['drushable', 'command', 'arguments']);
+        $this->assertEquals('command output', $output);
+    }
+}

--- a/tests/new_unit_tests/Commands/Remote/DummyCommand.php
+++ b/tests/new_unit_tests/Commands/Remote/DummyCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Commands\Remote;
+
+use Pantheon\Terminus\Commands\Remote\SSHBaseCommand;
+
+/**
+ * DummyCommand to exercise with SSHBaseCommand
+ */
+class DummyCommand extends SSHBaseCommand
+{
+    protected $command = 'dummy';
+
+    protected $unavailable_commands = [
+        'avoided'        => 'alternative',
+        'no-alternative' => '',
+    ];
+
+    public function dummyCommand($site_env_id, array $dummy_args)
+    {
+        $this->prepareEnvironment($site_env_id);
+
+        return $this->executeCommand($dummy_args);
+    }
+}

--- a/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Commands\Remote;
+
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+
+/**
+ * SSHBaseCommand Test Suite
+ *
+ * @package Pantheon\Terminus\UnitTests\Commands\Remote
+ */
+class SSHBaseCommandTest extends CommandTestCase
+{
+    protected $command;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->command = new DummyCommand($this->getConfig());
+        $this->command->setSites($this->sites);
+        $this->command->setLogger($this->logger);
+    }
+
+    public function testExecuteCommand()
+    {
+        // fake out ssh command
+        $this->environment->expects($this->once())
+            ->method('sendCommandViaSsh')
+            ->with($this->equalTo('dummy arg1 arg2'))
+            ->willReturn(['output' => 'dummy output', 'exit_code' => 0]);
+
+        $output = $this->command->dummyCommand('dummy-site.dummy-env', ['arg1', 'arg2']);
+
+        $this->assertEquals('dummy output', $output);
+    }
+
+    public function testValidateConnectionModeGitWarning()
+    {
+        // fake out ssh command
+        $this->environment->expects($this->once())
+            ->method('sendCommandViaSsh')
+            ->with($this->equalTo('dummy arg1 arg2'))
+            ->willReturn(['output' => 'dummy output', 'exit_code' => 0]);
+
+        // trigger git connection mode warning
+        $this->environment->expects($this->once())
+            ->method('info')
+            ->with($this->equalTo('connection_mode'))
+            ->willReturn('git');
+
+        //expected info and error messages
+        $this->logger->expects($this->exactly(2))
+            ->method('log')->withConsecutive(
+                [
+                    $this->equalTo('warning'),
+                    $this->stringContains('Note: This environment is in read-only Git mode.')
+                ],
+                [$this->equalTo('info'), $this->stringContains('Command:')]
+            );
+
+        $this->command->dummyCommand('dummy-site.dummy-env', ['arg1', 'arg2']);
+    }
+
+    public function testUnavailableWithSuggestion()
+    {
+        //expected info and error messages
+        $this->logger->expects($this->once())
+            ->method('log')->with(
+                $this->equalTo('error'),
+                $this->equalTo(
+                    'That command is not available via Terminus. '
+                    . 'Please use the native {command} command. '
+                    . 'Hint: You may want to try `{suggestion}`.'
+                ),
+                $this->equalTo([
+                    'command'    => 'dummy',
+                    'suggestion' => "terminus alternative"
+                ])
+            );
+
+        $output = $this->command->dummyCommand('dummy-site.dummy-env', ['avoided']);
+
+        $this->assertEquals('', $output);
+    }
+
+    public function testUnavailableWithoutSuggestion()
+    {
+        //expected info and error messages
+        $this->logger->expects($this->once())
+            ->method('log')->with(
+                $this->equalTo('error'),
+                $this->equalTo(
+                    'That command is not available via Terminus. '
+                    . 'Please use the native {command} command.'
+                ),
+                $this->equalTo([
+                    'command' => 'dummy',
+                ])
+            );
+
+        $output = $this->command->dummyCommand('dummy-site.dummy-env', ['no-alternative']);
+
+        $this->assertEquals('', $output);
+    }
+}

--- a/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -35,33 +35,6 @@ class SSHBaseCommandTest extends CommandTestCase
         $this->assertEquals('dummy output', $output);
     }
 
-    public function testValidateConnectionModeGitWarning()
-    {
-        // fake out ssh command
-        $this->environment->expects($this->once())
-            ->method('sendCommandViaSsh')
-            ->with($this->equalTo('dummy arg1 arg2'))
-            ->willReturn(['output' => 'dummy output', 'exit_code' => 0]);
-
-        // trigger git connection mode warning
-        $this->environment->expects($this->once())
-            ->method('info')
-            ->with($this->equalTo('connection_mode'))
-            ->willReturn('git');
-
-        //expected info and error messages
-        $this->logger->expects($this->exactly(2))
-            ->method('log')->withConsecutive(
-                [
-                    $this->equalTo('warning'),
-                    $this->stringContains('Note: This environment is in read-only Git mode.')
-                ],
-                [$this->equalTo('info'), $this->stringContains('Command:')]
-            );
-
-        $this->command->dummyCommand('dummy-site.dummy-env', ['arg1', 'arg2']);
-    }
-
     public function testUnavailableWithSuggestion()
     {
         //expected info and error messages
@@ -102,5 +75,17 @@ class SSHBaseCommandTest extends CommandTestCase
         $output = $this->command->dummyCommand('dummy-site.dummy-env', ['no-alternative']);
 
         $this->assertEquals('', $output);
+    }
+
+    public function testValidateConnectionModeGit()
+    {
+        // should warn about git mode
+        $this->logger->expects($this->once())
+            ->method('log')->with(
+                $this->equalTo('notice'),
+                $this->stringContains('This environment is in read-only Git mode.')
+            );
+
+        $this->protectedMethodCall($this->command, 'validateConnectionMode', ['git']);
     }
 }

--- a/tests/newfeatures/drush.feature
+++ b/tests/newfeatures/drush.feature
@@ -1,0 +1,31 @@
+Feature: Running Drush Commands on a Drupal Site
+  In order to interact with Drupal without configuring Pantheon site aliases
+  As a Terminus user
+  I want the ability to run arbitrary drush commands in terminus
+
+  Background: I am authenticated and have a site named [[test_site_name]]
+    Given I am authenticated
+    And a site named: [[test_site_name]]
+
+  Scenario: Running a simple drush command
+    When I run "terminus drush [[test_site_name]].dev -- version"
+    Then I should get:
+    """
+    Drush Version   :  8.1.3
+    """
+
+  Scenario: Running a drush command that is permitted by PantheonSSH
+    When This step is implemented I will test: a permitted drush command
+    When I run "terminus drush [[test_site_name]].dev -- php-eval 'print \"oh happy days\"'"
+    Then I should get:
+    """
+    oh happy days
+    """
+
+  Scenario: Running a drush command that is not permitted by PantheonSSH
+    When This step is implemented I will test: a protected drush command
+    When I run "terminus drush [[test_site_name]].dev -- php-eval 'print \"oh happy days\";'"
+    Then I should get:
+    """
+    Command not supported as typed
+    """


### PR DESCRIPTION
### Help

```
❯ terminus drush --help            
Usage:
  remote:drush <site_env_id> [<drush_command>]...
  drush

Arguments:
  site_env_id           Name of the environment to run the drush command on.
  drush_command         

Help:
  Run arbitrary drush commands on a site environment
```
### Example

```
❯ terminus drush -v evil-bunny.dev status
 [info] Command: evil-bunny.dev -- 'drush status' [Exit: 0]
 Drupal version         :  7.50                                                 
 Site URI               :  http://dev-evil-bunny.pantheonsite.io                
 Database driver        :  mysql                                                
 Database hostname      :  10.223.225.14                                        
 Database port          :  10845                                                
 Database username      :  pantheon                                             
 Database name          :  pantheon                                             
 Drupal bootstrap       :  Successful                                           
 Drupal user            :                                                       
 Default theme          :  seven                                                
 Administration theme   :  seven                                                
 PHP executable         :  /srv/bindings/bdddea92171a4097878e031b9c8475f9/php/p 
                           hp                                                   
 PHP configuration      :  /srv/bindings/bdddea92171a4097878e031b9c8475f9/php.i 
                           ni                                                   
 PHP OS                 :  Linux                                                
 Drush script           :  /opt/pantheon/drush-8/drush.php                      
 Drush version          :  8.1.3                                                
 Drush temp directory   :  /tmp                                                 
 Drush configuration    :  /srv/bindings/bdddea92171a4097878e031b9c8475f9/.drus 
                           h/drushrc.php /etc/drush/drush8rc.php                
 Drush alias files      :                                                       
 Install profile        :  pantheon                                             
 Drupal root            :  /srv/bindings/bdddea92171a4097878e031b9c8475f9/code  
 Drupal Settings File   :  sites/default/settings.php                           
 Site path              :  sites/default                                        
 File directory path    :  sites/default/files                                  
 Private file           :  sites/default/files/private                          
 directory path                                                                 
 Temporary file         :  /srv/bindings/bdddea92171a4097878e031b9c8475f9/tmp   
 directory path
```
