### PR TITLE
Cache the deps to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ before_script:
 
 script:
   - TERMINUS_TEST_MODE=1 vendor/bin/phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml
+  # XDebug is needed for code coverage, but makes things slow. It's enabled
+  # by default in Travis, we disable it here post-coverage run for speedy builds.
+  - phpenv config-rm xdebug.ini
   - TERMINUS_TEST_MODE=1 ./scripts/test.sh
 
 after_success:
@@ -56,3 +59,8 @@ after_success:
 notifications:
   email:
     on_success: never
+
+cache:
+  directories:
+    - $HOME/.cache/composer
+    - $HOME/.composer/cache

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -4,4 +4,4 @@
 
 set -ex
 
-composer install --no-interaction --prefer-source
+composer install --no-interaction --prefer-dist


### PR DESCRIPTION
This makes quite a large difference, I'm seeing build times almost chopped in half for PHP 7!
### Before:

<img width="1011" alt="screen shot 2016-09-29 at 15 22 22" src="https://cloud.githubusercontent.com/assets/453297/18955649/8b702c7a-8658-11e6-84e7-fbf6b9eb206c.png">

The pieces that are significantly speeded up are the prepare.sh script and the test.sh script:

```
$ ./scripts/prepare.sh 67.56s
$ TERMINUS_TEST_MODE=1 ./scripts/test.sh 277.19s
```
### After:

<img width="1017" alt="screen shot 2016-09-29 at 15 22 51" src="https://cloud.githubusercontent.com/assets/453297/18955665/9be524f2-8658-11e6-85fd-1fe3d8a45a9a.png">

```
$ ./scripts/prepare.sh 9.35s
$ TERMINUS_TEST_MODE=1 ./scripts/test.sh 135.08s

```
