### PR TITLE
Adds ACs around using remote commands on unsupported frameworks

### DIFF
--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -651,7 +651,7 @@ class Environment extends TerminusModel
                 'output'    => "Terminus is in test mode. "
                     . "Environment::sendCommandViaSsh commands will not be sent over the wire. "
                     . "SSH Command: ${ssh_command}",
-                'exit_code' => 255
+                'exit_code' => 0
             ];
         }
 

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -106,7 +106,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         // print_r([$framework,$this->valid_frameworks]);
         if (!in_array($framework, $this->valid_frameworks)) {
             throw new TerminusException(
-                "The {command} command is only available on a sites running {frameworks}. "
+                "The {command} command is only available on sites running {frameworks}. "
                 ."The framework for this site is {framework}.",
                 [
                     'command'    => $this->command,

--- a/src/Commands/Remote/WpCommand.php
+++ b/src/Commands/Remote/WpCommand.php
@@ -17,7 +17,10 @@ class WpCommand extends SSHBaseCommand
     /**
      * @inheritdoc
      */
-    protected $valid_frameworks = ['wordpress'];
+    protected $valid_frameworks = [
+        'wordpress',
+        'wordpress_network',
+    ];
 
     /**
      * @inheritdoc

--- a/tests/active_features/bootstrap/FeatureContext.php
+++ b/tests/active_features/bootstrap/FeatureContext.php
@@ -741,14 +741,16 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function shouldSeeATypeOfMessage($type, $message = null)
     {
-        $type_marker = "[$type]";
-        if (strpos($this->output, $type_marker) === false) {
-            throw new \Exception("Expected $type_marker in message: $this->output");
+        $expected_message = "[$type]";
+        if (!empty($message)) {
+            $expected_message .= " {$message}";
         }
 
-        if (!empty($message) and strpos($this->output, $message) === false) {
-            throw new \Exception("Expected '$message' in message: $this->output");
+        $compressed_output = preg_replace('/\s+/', ' ', $this->output);
+        if (strpos($compressed_output, $expected_message) === false) {
+            throw new \Exception("Expected $expected_message in message: $this->output");
         }
+
         return true;
     }
 

--- a/tests/active_features/drush.feature
+++ b/tests/active_features/drush.feature
@@ -16,5 +16,10 @@ Feature: Running Drush Commands on a Drupal Site
   @vcr remote-drush.yml
   Scenario: Running a drush command that is not permitted
     When I run: terminus drush [[test_site_name]].dev -- sql-connect
-    Then I should get: "That command is not available via Terminus. Please use the native drush command."
+    Then I should see an error message: That command is not available via Terminus. Please use the native drush command.
     Then I should get: "Hint: You may want to try `terminus connection:info --field=mysql_command`."
+
+  @vcr remote-wp.yml
+  Scenario: Running a drush command on a Wordpress site is not possible
+    When I run: terminus drush [[test_site_name]].dev -- status
+    Then I should see an error message: The drush command is only available on sites running drupal, drupal8. The framework for this site is wordpress.

--- a/tests/active_features/wp-cli.feature
+++ b/tests/active_features/wp-cli.feature
@@ -16,7 +16,9 @@ Feature: Running WP-CLI Commands on a Drupal Site
   @vcr remote-wp.yml
   Scenario: Running a WP-CLI command that is not permitted
     When I run: terminus wp [[test_site_name]].dev -- db query 'CHECK TABLE $(wp db tables | paste -s -d',');'
-    Then I should get:
-    """
-    That command is not available via Terminus. Please use the native wp command.
-    """
+    Then I should see an error message: That command is not available via Terminus. Please use the native wp command.
+
+  @vcr remote-drush.yml
+  Scenario: Running a WP-CLI command on a Drupal site is not possible
+    When I run: terminus wp [[test_site_name]].dev -- cli version
+    Then I should see an error message: The wp command is only available on sites running wordpress, wordpress_network. The framework for this site is drupal8.

--- a/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -103,7 +103,7 @@ class SSHBaseCommandTest extends CommandTestCase
 
     /**
      * @expectedException \Terminus\Exceptions\TerminusException
-     * @expectedExceptionMessage The dummy command is only available on a sites running framework-a, framework-b.
+     * @expectedExceptionMessage The dummy command is only available on sites running framework-a, framework-b.
      */
     public function testValidateFrameworkInvalid()
     {


### PR DESCRIPTION
- Updates ACs to use `Then I should see a <type> message:` step matcher
- Enhances `shouldSeeATypeOfMessage` matcher to be more strict: `<type>` and `<message>` must be a pair ... was matching randomly in output
- Fixes Environment::sendCommandViaSsh not to be an error in `test_mode`
### Examples

```
❯ terminus wp drupal-vcr.dev -- cli version
 [error]  The wp command is only available on sites running WordPress. The framework for this site is Drupal. 
❯ terminus drush wordpress-vcr.dev -- version
 [error]  The drush command is only available on sites running Drupal. The framework for this site is WordPress. 
```
