### PR TITLE
Extract progress bar, tighten up output of clone content command

### DIFF
--- a/src/Commands/TerminusCommand.php
+++ b/src/Commands/TerminusCommand.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\Commands;
 
 use Pantheon\Terminus\Session\SessionAwareInterface;
 use Pantheon\Terminus\Session\SessionAwareTrait;
+use Pantheon\Terminus\Style\TerminusStyle;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -20,7 +21,9 @@ abstract class TerminusCommand implements
 {
     use LoggerAwareTrait;
     use ConfigAwareTrait;
-    use IO;
+    use IO {
+        io as roboIo;
+    }
     use SessionAwareTrait;
 
     /**
@@ -38,5 +41,16 @@ abstract class TerminusCommand implements
     protected function log()
     {
         return $this->logger;
+    }
+
+    /**
+     * Override Robo's IO function with our custom style.
+     */
+    protected function io()
+    {
+        if (!$this->io) {
+            $this->io = new TerminusStyle($this->input(), $this->output());
+        }
+        return $this->io;
     }
 }

--- a/src/Style/TerminusStyle.php
+++ b/src/Style/TerminusStyle.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pantheon\Terminus\Style;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Terminus\Models\Workflow;
+
+class TerminusStyle extends SymfonyStyle
+{
+    const NORMAL_PROGRESS_FORMAT = " <bg=blue;fg=black> %message% </>\n <info>Progress: %bar% <info>%percent:3s%%</info> \n <info>Elapsed: %elapsed:6s% \n Estimated Time Remaining: %estimated:-6s%</info>";
+
+    /**
+     * TerminusStyle constructor.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        ProgressBar::setFormatDefinition('normal', self::NORMAL_PROGRESS_FORMAT);
+        parent::__construct($input, $output);
+    }
+}

--- a/tests/active_features/bootstrap/FeatureContext.php
+++ b/tests/active_features/bootstrap/FeatureContext.php
@@ -1074,4 +1074,25 @@ class FeatureContext implements Context, SnippetAcceptingContext
         }
         return $this->cassette_name;
     }
+
+    /**
+     * @Then I should see a progress bar with the message: :message
+     */
+    public function iShouldSeeAProgressBarWithTheMessage($message)
+    {
+        mb_substr_count(
+            $this->output,
+            $message
+        ) == 1
+        &&
+        mb_substr_count(
+            $this->output,
+            'Progress: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0%'
+        ) == 1
+        &&
+        mb_substr_count(
+            $this->output,
+            'Progress: ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ 100%'
+        ) == 1;
+    }
 }

--- a/tests/active_features/env-clone.feature
+++ b/tests/active_features/env-clone.feature
@@ -9,28 +9,18 @@ Feature: Cloning site content
 
   @vcr site_clone-content
   Scenario: Site Clone Environment
-    When I run "terminus env:clone [[test_site_name]].test dev --yes"
-    Then I should get:
-    """
-    Running cloneDatabase...
-    """
-    Then I should get:
-    """
-    Running cloneFiles...
-    """
+    When I run "terminus --no-ansi env:clone [[test_site_name]].test dev --yes"
+    Then I should see a progress bar with the message: 'setting up...'
+    Then I should see a progress bar with the message: 'Cloned files from "live" to "dev", cloned database from "live" to "dev"'
 
   @vcr site_clone-content
   Scenario: Site Clone Files Only
-    When I run "terminus env:clone [[test_site_name]].test dev --files-only --yes"
-    Then I should get:
-    """
-    Running cloneFiles...
-    """
+    When I run "terminus --no-ansi env:clone [[test_site_name]].test dev --files-only --yes"
+    Then I should see a progress bar with the message: 'setting up...'
+    Then I should see a progress bar with the message: 'Cloned files from "live" to "dev"'
 
   @vcr site_clone-content
   Scenario: Site Clone Files Only
-    When I run "terminus env:clone [[test_site_name]].test dev --db-only --yes"
-    Then I should get:
-    """
-    Running cloneDatabase...
-    """
+    When I run "terminus --no-ansi env:clone [[test_site_name]].test dev --db-only --yes"
+    Then I should see a progress bar with the message: 'setting up...'
+    Then I should see a progress bar with the message: 'Cloned database from "live" to "dev"'


### PR DESCRIPTION
@TeslaDethray this still needs a bit of work to make my Behat tests pass, I'll probably update the tests and possible add a step definition for progress bars. Also we will probably want to switch the behat tests to run terminus with `--no-ansi` to make the test output more reliable
