### PR TITLE
Great big dependency inversion refactor

### DIFF
--- a/bin/terminus.php
+++ b/bin/terminus.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Terminus\Collections\Sites;
 
-
-
 // Initializing the Terminus application
 $config = new Config();
 $application = new Terminus('Terminus', $config->get('version'), $config);

--- a/bin/terminus.php
+++ b/bin/terminus.php
@@ -14,6 +14,7 @@ if ($phar_path) {
 
 use League\Container\Container;
 use Pantheon\Terminus\Config;
+use Pantheon\Terminus\DataStore\FileStore;
 use Pantheon\Terminus\Runner;
 use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\Session\SessionAwareInterface;
@@ -22,8 +23,9 @@ use Pantheon\Terminus\Terminus;
 use Robo\Robo;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Terminus\Caches\FileCache;
 use Terminus\Collections\Sites;
+
+
 
 // Initializing the Terminus application
 $config = new Config();
@@ -34,14 +36,14 @@ $input = new ArgvInput($_SERVER['argv']);
 $output = new ConsoleOutput();
 $container = Robo::createDefaultContainer($input, $output, $application, $config);
 
-$container->share('fileCache', FileCache::class);
+
+$container->share('dataStore', FileStore::class)
+    ->withArgument(new League\Container\Argument\RawArgument($config->get('cache_dir')));
 $container->share('session', Session::class)
-    ->withArgument('fileCache');
+    ->withArgument('dataStore');
 $container->inflector(SessionAwareInterface::class)
     ->invokeMethod('setSession', ['session']);
-$container->share('sites', Sites::class);
-$container->inflector(SiteAwareInterface::class)
-    ->invokeMethod('setSites', ['sites']);
+
 
 $factory = $container->get('commandFactory');
 $factory->setIncludeAllPublicMethods(false);

--- a/php/Terminus/Collections/Sites.php
+++ b/php/Terminus/Collections/Sites.php
@@ -28,8 +28,7 @@ class Sites extends TerminusCollection
         // @TODO: HACK ALERT: Jury rigging DI into this model without breaking the old code. This should be replaced.
         if (isset($options['user'])) {
             $this->user = $options['user'];
-        }
-        else {
+        } else {
             $this->user = Session::getUser();
         }
         parent::__construct($options);

--- a/php/Terminus/Collections/Sites.php
+++ b/php/Terminus/Collections/Sites.php
@@ -3,6 +3,7 @@
 namespace Terminus\Collections;
 
 use Terminus\Exceptions\TerminusException;
+use Terminus\Models\User;
 use Terminus\Session;
 
 class Sites extends TerminusCollection
@@ -24,7 +25,13 @@ class Sites extends TerminusCollection
    */
     public function __construct(array $options = [])
     {
-        $this->user = Session::getUser();
+        // @TODO: HACK ALERT: Jury rigging DI into this model without breaking the old code. This should be replaced.
+        if (isset($options['user'])) {
+            $this->user = $options['user'];
+        }
+        else {
+            $this->user = Session::getUser();
+        }
         parent::__construct($options);
     }
 

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -130,7 +130,8 @@ class User extends TerminusModel
      *
      * @return \Terminus\Collections\Sites
      */
-    public function sitesCollection() {
+    public function sitesCollection()
+    {
         return new Sites(['user' => $this]);
     }
 

--- a/php/Terminus/Models/User.php
+++ b/php/Terminus/Models/User.php
@@ -4,6 +4,7 @@ namespace Terminus\Models;
 
 use Terminus\Collections\Instruments;
 use Terminus\Collections\MachineTokens;
+use Terminus\Collections\Sites;
 use Terminus\Collections\SshKeys;
 use Terminus\Collections\UserOrganizationMemberships;
 use Terminus\Collections\UserSiteMemberships;
@@ -120,6 +121,17 @@ class User extends TerminusModel
             )
         );
         return $sites;
+    }
+
+    /**
+     * Get a site's collection owned by the user.
+     *
+     * This creates a weird circular dependency which should be eliminated once the old code no longer exists.
+     *
+     * @return \Terminus\Collections\Sites
+     */
+    public function sitesCollection() {
+        return new Sites(['user' => $this]);
     }
 
   /**

--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -2,6 +2,8 @@
 
 namespace Pantheon\Terminus;
 
+use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Session\SessionAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Consolidation\AnnotatedCommand\CommandError;
@@ -9,10 +11,11 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Common\ConfigAwareTrait;
 use Terminus\Models\Auth;
 
-class Authorizer implements LoggerAwareInterface, ConfigAwareInterface
+class Authorizer implements LoggerAwareInterface, ConfigAwareInterface, SessionAwareInterface
 {
     use LoggerAwareTrait;
     use ConfigAwareTrait;
+    use SessionAwareTrait;
 
     /**
      * Authorize the current user prior to running a command.  The
@@ -24,19 +27,6 @@ class Authorizer implements LoggerAwareInterface, ConfigAwareInterface
      */
     public function ensureLogin()
     {
-        $auth   = new Auth();
-        $tokens = $auth->getAllSavedTokenEmails();
-        if (!$auth->loggedIn()) {
-            if (count($tokens) === 1) {
-                $email = array_shift($tokens);
-                $auth->logInViaMachineToken(compact('email'));
-            } elseif (!is_null($this->config->get('user')) && $email = $this->config->get('user')) {
-                $auth->logInViaMachineToken(compact('email'));
-            } else {
-                throw new \Exception(
-                    'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
-                );
-            }
-        }
+        $this->session()->ensureLogin();
     }
 }

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -37,8 +37,7 @@ class LoginCommand extends TerminusCommand
         $emails = $session->getAllSavedTokenEmails();
         if (isset($options['email']) && !is_null($options['email'])) {
             $email = $options['email'];
-        }
-        else if (count($emails) == 1) {
+        } else if (count($emails) == 1) {
             $email = reset($emails);
         }
 

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -3,6 +3,7 @@
 namespace Pantheon\Terminus\Commands\Auth;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
+use Terminus\Exceptions\TerminusException;
 use Terminus\Models\Auth;
 
 class LoginCommand extends TerminusCommand
@@ -24,35 +25,37 @@ class LoginCommand extends TerminusCommand
      */
     public function logIn(array $options = ['machine-token' => null, 'email' => null,])
     {
-        $auth = new Auth();
-        $tokens = $auth->getAllSavedTokenEmails();
-        if (!is_null($token = $options['machine-token'])) {
-            $auth->logInViaMachineToken(compact('token'));
+        $session = $this->session();
+
+        if (isset($options['machine-token']) && !is_null($token = $options['machine-token'])) {
+            $session->logInViaMachineToken($token);
             $this->log()->notice('Logging in via machine token.');
-        } elseif (!is_null($email = $options['email']) && !$auth->tokenExistsForEmail($email)) {
-            $message = 'There are no saved tokens for %s.';
-            throw new \Exception(vsprintf($message, compact('email')), 1);
-        } elseif ((
-          (!is_null($email = $options['email']) || !empty($email = $this->config->get('user')))
-          && $auth->tokenExistsForEmail($email)
-        )
-        ) {
-            $auth->logInViaMachineToken(compact('email'));
-            $this->log()->notice('Logging in via machine token.');
-        } elseif (is_null($options['email']) && (count($tokens) == 1)) {
-            $email = array_shift($tokens);
-            $this->log()->notice('Found a machine token for {email}.', compact('email'));
-            $auth->logInViaMachineToken(compact('email'));
-            $this->log()->notice('Logging in via machine token.');
-        } else {
-            if (count($tokens) > 1) {
-                $message = "Tokens were saved for the following email addresses:\n"
-                  . implode("\n", $tokens) . "\n You may log in via `terminus auth:login <email>` , or you may ";
-            } else {
-                $message = "Please ";
-            }
-            $message .= "visit the dashboard to generate a machine token:\n {$auth->getMachineTokenCreationUrl()}";
-            throw new \Exception($message, 1);
+            return;
         }
+
+        $email = '';
+        $emails = $session->getAllSavedTokenEmails();
+        if (isset($options['email']) && !is_null($options['email'])) {
+            $email = $options['email'];
+        }
+        else if (count($emails) == 1) {
+            $email = reset($emails);
+        }
+
+        if ($email) {
+            $session->logInViaSavedEmailMachineToken($email);
+            $this->log()->notice('Found a machine token for {email}.', compact('email'));
+            $this->log()->notice('Logging in via machine token.');
+            return;
+        }
+
+        if (count($emails) > 1) {
+            $message = "Tokens were saved for the following email addresses:\n"
+              . implode("\n", $emails) . "\n You may log in via `terminus auth:login <email>` , or you may ";
+        } else {
+            $message = "Please ";
+        }
+        $message .= "visit the dashboard to generate a machine token:\n {url}";
+        throw new TerminusException($message, ['url' => $session->getMachineTokenCreationUrl()]);
     }
 }

--- a/src/Commands/Auth/LogoutCommand.php
+++ b/src/Commands/Auth/LogoutCommand.php
@@ -19,8 +19,7 @@ class LogoutCommand extends TerminusCommand
      */
     public function logOut()
     {
-        $auth = new Auth();
-        $auth->logOut();
+        $this->session()->logOut();
         $this->log()->notice('You have been logged out of Pantheon.');
     }
 }

--- a/src/Commands/Auth/WhoamiCommand.php
+++ b/src/Commands/Auth/WhoamiCommand.php
@@ -28,9 +28,8 @@ class WhoamiCommand extends TerminusCommand
      */
     public function whoAmI()
     {
-        $auth = new Auth();
-        if ($auth->loggedIn()) {
-            $user = $this->session()->getUser();
+        $user = $this->session()->getUser();
+        if ($user) {
             return new AssociativeList($user->fetch()->serialize());
         } else {
             $this->log()->notice('You are not logged in.');

--- a/src/Commands/Multidev/ListCommand.php
+++ b/src/Commands/Multidev/ListCommand.php
@@ -40,7 +40,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
             function ($environment) {
                 return $environment->serialize();
             },
-            $this->sites->get($site_name)->environments->multidev()
+            $this->getSite($site_name)->environments->multidev()
         );
 
         if (empty($envs)) {

--- a/src/Commands/Site/InfoCommand.php
+++ b/src/Commands/Site/InfoCommand.php
@@ -44,6 +44,6 @@ class InfoCommand extends SiteCommand
      */
     public function info($site)
     {
-        return new AssociativeList($this->sites->get($site)->serialize());
+        return new AssociativeList($this->sites()->get($site)->serialize());
     }
 }

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -49,7 +49,8 @@ class ListCommand extends SiteCommand
      */
     public function index($options = ['team' => false, 'owner' => null, 'org' => null, 'name' => null,])
     {
-        $this->sites->fetch(
+        $sites = $this->sites();
+        $sites->fetch(
             [
                 'org_id' => $options['org'],
                 'team_only' => $options['team'],
@@ -57,13 +58,13 @@ class ListCommand extends SiteCommand
         );
 
         if (!is_null($name = $options['name'])) {
-            $this->sites->filterByName($name);
+            $sites->filterByName($name);
         }
         if (!is_null($owner = $options['owner'])) {
             if ($owner == 'me') {
                 $owner = $this->session()->getUser()->id;
             }
-            $this->sites->filterByOwner($owner);
+            $sites->filterByOwner($owner);
         }
 
         $all_sites = array_map(
@@ -79,7 +80,7 @@ class ListCommand extends SiteCommand
                     'memberships'   => implode(',', $site->memberships),
                 ];
             },
-            $this->sites->all()
+            $sites->all()
         );
 
         if (empty($all_sites)) {

--- a/src/DataStore/DataStoreInterface.php
+++ b/src/DataStore/DataStoreInterface.php
@@ -51,5 +51,4 @@ interface DataStoreInterface
      * @return array A list of keys
      */
     public function keys($group = null);
-
 }

--- a/src/DataStore/DataStoreInterface.php
+++ b/src/DataStore/DataStoreInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+/**
+ * Interface DataStoreInterface
+ */
+interface DataStoreInterface
+{
+    /**
+     * Reads retrieves data from the store
+     *
+     * @param string $key A key
+     * @param string|null $group Retrieve the data from this named group if specified.
+     * @return mixed The value fpr the given key or null.
+     */
+    public function get($key, $group = null);
+
+    /**
+     * Saves a value with the given key
+     *
+     * @param string $key A key
+     * @param mixed $data Data to save to the store
+     * @param string|null $group Put the data into this named group.
+     * @return
+     */
+    public function set($key, $data, $group = null);
+
+    /**
+     * Checks if a key is in the store
+     *
+     * @param string $key A key
+     * @param string|null $group Check in this named group if specified.
+     * @return bool Whether a value exists with the given key
+     */
+    public function has($key, $group = null);
+
+    /**
+     * Remove value from the store
+     *
+     * @param string $key A key
+     * @param null $group Remove from this named group.
+     * @return
+     */
+    public function remove($key, $group = null);
+
+    /**
+     * Return a list of all keys in the store.
+     *
+     * @param string|null $group Limit the list to this group if specified.
+     * @return array A list of keys
+     */
+    public function keys($group = null);
+
+}

--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+class FileStore implements DataStoreInterface
+{
+    /**
+     * @var string The directory to store the data files in.
+     */
+    protected $directory;
+
+    public function __construct($directory)
+    {
+        $this->directory = $directory;
+    }
+
+    /**
+     * Reads retrieves data from the store
+     *
+     * @param string $key A key
+     * @param null $group
+     * @return mixed The value fpr the given key or null.
+     */
+    public function get($key, $group = null)
+    {
+        $out = null;
+        // Read the json encoded value from disk if it exists.
+        $path = $this->getFileName($key, $group);
+        if (file_exists($path)) {
+            $out = file_get_contents($path);
+            $out = json_decode($out);
+        }
+        return $out;
+    }
+
+    /**
+     * Saves a value with the given key
+     *
+     * @param string $key A key
+     * @param mixed $data Data to save to the store
+     * @param null $group
+     */
+    public function set($key, $data, $group = null)
+    {
+        $path = $this->getFileName($key, $group);
+        file_put_contents($path, json_encode($data));
+    }
+
+    /**
+     * Checks if a key is in the store
+     *
+     * @param string $key A key
+     * @param null $group
+     * @return bool Whether a value exists with the given key
+     */
+    public function has($key, $group = null)
+    {
+        $path = $this->getFileName($key, $group);
+        return file_exists($path);
+    }
+
+    /**
+     * Remove value from the store
+     *
+     * @param string $key A key
+     * @param null $group
+     */
+    public function remove($key, $group = null)
+    {
+        $path = $this->getFileName($key, $group);
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    /**
+     * Return a list of all keys in the store.
+     *
+     * @param string|null $group Limit the list to this group if specified.
+     * @return array A list of keys
+     */
+    public function keys($group = null)
+    {
+        $root = $this->directory;
+        if ($group) {
+            $root = $root . '/' . $this->cleanKey($group);
+        }
+        return array_diff(scandir($root), array('..', '.'));
+    }
+
+    /**
+     * Get a valid file name for the given key.
+     * @param string $key The data key to be written or read
+     * @return string A file path
+     */
+    protected function getFileName($key, $group = null) {
+        $key = $this->cleanKey($key);
+        // If there is a group put the file in a directory with that name.
+        if ($group) {
+            $key = $this->cleanKey($group) . '/' . $key;
+        }
+        return $this->directory . '/' . $key;
+    }
+
+    /**
+     * Make the file path safe by whitelisting characters.
+     * This is a very naive approach to hashing but in practice this doesn't matter since this is only used for a
+     * few already safe keys.
+     *
+     * @param $key
+     * @return mixed
+     */
+    protected function cleanKey($key) {
+        return preg_replace('/[^a-zA-Z0-9\-\_\@\.]/', '-', $key);
+    }
+
+}

--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -93,7 +93,8 @@ class FileStore implements DataStoreInterface
      * @param string $key The data key to be written or read
      * @return string A file path
      */
-    protected function getFileName($key, $group = null) {
+    protected function getFileName($key, $group = null)
+    {
         $key = $this->cleanKey($key);
         // If there is a group put the file in a directory with that name.
         if ($group) {
@@ -110,8 +111,8 @@ class FileStore implements DataStoreInterface
      * @param $key
      * @return mixed
      */
-    protected function cleanKey($key) {
+    protected function cleanKey($key)
+    {
         return preg_replace('/[^a-zA-Z0-9\-\_\@\.]/', '-', $key);
     }
-
 }

--- a/src/DataStore/MemoryStore.php
+++ b/src/DataStore/MemoryStore.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+class MemoryStore implements DataStoreInterface
+{
+    /**
+     * @var array The in-memory data.
+     */
+    protected $data;
+
+    /**
+     * Reads retrieves data from the store
+     *
+     * @param string $key A key
+     * @return mixed The value fpr the given key or null.
+     */
+    public function get($key)
+    {
+        return $this->has($key) ? $this->data[$key] : null;
+    }
+
+    /**
+     * Saves a value with the given key
+     *
+     * @param string $key A key
+     * @param mixed $data Data to save to the store
+     */
+    public function set($key, $data)
+    {
+        $this->data[$key] = $data;
+    }
+
+    /**
+     * Checks if a key is in the store
+     *
+     * @param string $key A key
+     * @return bool Whether a value exists with the given key
+     */
+    public function has($key)
+    {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * Remove value from the store
+     *
+     * @param string $key A key
+     */
+    public function remove($key)
+    {
+        unset($this->data[$key]);
+    }
+}

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -183,8 +183,7 @@ class Session implements ConfigAwareInterface
         $saved_token = (array)$this->cache->get($email, 'tokens');
         if ($saved_token && $saved_token['token']) {
             $token = $saved_token['token'];
-        }
-        else {
+        } else {
             throw new TerminusException(
                 'There are no saved tokens for {email}.',
                 compact('email'),
@@ -271,5 +270,4 @@ class Session implements ConfigAwareInterface
         );
         return $url;
     }
-
 }

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -2,32 +2,48 @@
 
 namespace Pantheon\Terminus\Session;
 
+use Pantheon\Terminus\Config;
+use Pantheon\Terminus\DataStore\DataStoreInterface;
+use Robo\Common\ConfigAwareTrait;
+use Robo\Contract\ConfigAwareInterface;
 use Terminus\Caches\FileCache;
+use Terminus\Exceptions\TerminusException;
 use Terminus\Models\User;
+use Terminus\Request;
 
-class Session
+class Session implements ConfigAwareInterface
 {
+    use ConfigAwareTrait;
+
     /**
      * @var FileCache
      */
     protected $cache;
 
     /**
-     * @var object
+     * @var array
      */
     protected $data;
 
     /**
-     * Instantiates object, sets session data
+     * @var Request
      */
-    public function __construct($fileCache)
+    protected $request;
+
+    /**
+     * Instantiates object, sets session data
+     * @param DataStoreInterface $store The data store to save the session to
+     */
+    public function __construct(DataStoreInterface $store)
     {
-        $this->cache = $fileCache;
-        $session = $this->cache->getData('session');
-        $this->data = $session;
+        $this->cache = $store;
+        $session = $this->cache->get('session');
+        $this->data = (array)$session;
         if (empty($session)) {
-            $this->data = new \stdClass();
+            $this->data = [];
         }
+
+        $this->request = new Request();
     }
 
     /**
@@ -49,8 +65,8 @@ class Session
      */
     public function get($key, $default = false)
     {
-        if (isset($this->data) && isset($this->data->$key)) {
-            return $this->data->$key;
+        if (isset($this->data) && isset($this->data[$key])) {
+            return $this->data[$key];
         }
         return $default;
     }
@@ -58,26 +74,30 @@ class Session
     /**
      * Sets a keyed value to be part of the data property object
      *
-     * TODO: This is never used and arguably shouldn't be (since it doesn't save
-     *       data to the persistent session store)
-     *       This should be removed in favor of setData which is designed to
-     *       instantiate the entire session or changed to add persistent data.
-     *
      * @param string $key Name of data property
      * @param mixed $value Value of property to set
      * @return Session
      */
     public function set($key, $value = null)
     {
-        $this->data->$key = $value;
+        $this->data[$key] = $value;
         return $this;
     }
 
     /**
-     * Saves session data to cache
+     * Sets a keyed value to be part of the data property object
      *
-     * TODO: The difference between set and setData is confusing. This should be
-     *       refactored when Auth() is.
+     * @param string $key Name of data property
+     * @param mixed $value Value of property to set
+     * @return Session
+     */
+    public function write()
+    {
+        $this->cache->set('session', $this->data);
+    }
+
+    /**
+     * Saves session data to cache
      *
      * @param array $data Session data to save
      * @return bool
@@ -87,11 +107,12 @@ class Session
         if (empty($data)) {
             return false;
         }
-        $this->cache->putData('session', $data);
 
         foreach ($data as $k => $v) {
             $this->set($k, $v);
         }
+
+        $this->write();
         return true;
     }
 
@@ -101,9 +122,154 @@ class Session
      */
     public function getUser()
     {
-        $user_uuid = $this->get('user_uuid');
-        // TODO: Remove this direct instantiation to make this more testable
-        $user = new User((object)array('id' => $user_uuid));
-        return $user;
+        if ($this->loggedIn()) {
+            $user_id = $this->get('user_id');
+            // TODO: Remove this direct instantiation to make this more testable
+            $user = new User((object)array('id' => $user_id));
+            return $user;
+        }
     }
+
+    /**
+     * Authorize the current user prior to running a command.  The
+     * Annotated Commands hook manager will call this function during
+     * the pre-validate phase of any command that has an 'authorize'
+     * annotation.
+     *
+     */
+    public function ensureLogin()
+    {
+        if (!$this->loggedIn()) {
+            $tokens = $this->getAllSavedTokenEmails();
+            if (count($tokens) === 1) {
+                $email = array_shift($tokens);
+                $this->logInViaSavedEmailMachineToken($email);
+            } elseif (!is_null($this->getConfigValue('user')) && $email = $this->getConfigValue('user')) {
+                $this->logInViaSavedEmailMachineToken($email);
+            } else {
+                throw new TerminusException(
+                    'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'
+                );
+            }
+        }
+    }
+
+    /**
+     * Checks to see if the current user is logged in
+     *
+     * @return bool True if the user is logged in
+     */
+    public function loggedIn()
+    {
+        $is_logged_in = (
+            $this->get('user_id')
+            && (
+                $this->getConfig()->get('test_mode')
+                || ($this->get('session_expire_time') >= time())
+            )
+        );
+        return $is_logged_in;
+    }
+
+    /**
+     * Execute the login based on a machine token
+     *
+     * @param string $email The email address to look up the token by
+     * @return bool True if login succeeded
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function logInViaSavedEmailMachineToken($email)
+    {
+        $saved_token = (array)$this->cache->get($email, 'tokens');
+        if ($saved_token && $saved_token['token']) {
+            $token = $saved_token['token'];
+        }
+        else {
+            throw new TerminusException(
+                'There are no saved tokens for {email}.',
+                compact('email'),
+                1
+            );
+        }
+
+        return $this->logInViaMachineToken($token);
+    }
+
+    /**
+     * Execute the login based on a machine token
+     *
+     * @param string $token The machine token to log in with.
+     * @return bool True if login succeeded
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function logInViaMachineToken($token)
+    {
+        $options = [
+            'form_params' => [
+                'machine_token' => $token,
+                'client'        => 'terminus',
+            ],
+            'method' => 'post',
+        ];
+
+        try {
+            $response = $this->request->request(
+                'authorize/machine-token',
+                $options
+            );
+        } catch (\Exception $e) {
+            throw new TerminusException(
+                'The provided machine token is not valid.',
+                [],
+                1
+            );
+        }
+
+        $this->setData((array)$response['data']);
+        $user = $this->getUser();
+        $user->fetch();
+        $user_data = $user->serialize();
+        $this->cache->set(
+            $user_data['email'],
+            ['email' => $user_data['email'], 'token' => $token,],
+            'tokens'
+        );
+        return true;
+    }
+    
+    /**
+     * Logs the current user out.
+     *
+     * @return void
+     */
+    public function logOut()
+    {
+        $this->destroy();
+    }
+
+    /**
+     * Gets all email addresses for which there are saved machine tokens
+     *
+     * @return string[]
+     */
+    public function getAllSavedTokenEmails()
+    {
+        $emails = $this->cache->keys('tokens');
+        return $emails;
+    }
+
+    /**
+     * Generates the URL string for where to create a machine token
+     *
+     * @return string
+     */
+    public function getMachineTokenCreationUrl()
+    {
+        $url = vsprintf(
+            '%s://%s/machine-token/create/%s',
+            [$this->getConfig()->get('dashboard_protocol'), $this->getConfig()->get('dashboard_host'), gethostname(),]
+        );
+        return $url;
+    }
+
 }

--- a/src/Site/SiteAwareTrait.php
+++ b/src/Site/SiteAwareTrait.php
@@ -32,7 +32,7 @@ trait SiteAwareTrait
      */
     public function sites()
     {
-        return $this->sites;
+        return $this->session()->getUser()->sitesCollection();
     }
 
     /**

--- a/tests/new_unit_tests/Commands/ArtCommandTest.php
+++ b/tests/new_unit_tests/Commands/ArtCommandTest.php
@@ -2,17 +2,24 @@
 namespace Pantheon\Terminus\UnitTests\Commands;
 
 use Pantheon\Terminus\Commands\ArtCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class ArtCommandTest extends CommandTestCase
 {
     protected $command;
 
+    protected $output;
+
     protected function setUp()
     {
         parent::setUp();
+
+        // This is hard to mock due to the way it interacts with SymfonyStyle and IO
+        $this->output = new BufferedOutput();
+
         $this->command = new ArtCommand();
         $this->command->setConfig($this->config);
-        $this->setInput(['command' => 'art', 'name' => 'hello']);
+        $this->command->setOutput($this->output);
     }
 
     /**
@@ -20,7 +27,9 @@ class ArtCommandTest extends CommandTestCase
      */
     public function artCommandPrintsContentsOfFilesInAssetsDirectory()
     {
-        $this->assertEquals('Hello World!', $this->runCommand()->fetchTrimmedOutput());
+        $this->command->art('hello');
+
+        $this->assertEquals("Hello World!", trim($this->output->fetch()));
     }
 
     /**
@@ -28,11 +37,12 @@ class ArtCommandTest extends CommandTestCase
      */
     public function artCommandRejectsFilesNotInAssetsDirectory()
     {
-        $this->setInput(['command' => 'art', 'name' => 'foo']);
-        $this->assertEquals(
-            '[error]  There is no source for the requested foo artwork.',
-            $this->runCommand()->fetchTrimmedOutput()
+        $this->setExpectedException(
+            \Exception::class,
+            "There is no source for the requested foo artwork."
         );
+
+        $this->command->art('foo');
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Auth/LogoutCommandTest.php
+++ b/tests/new_unit_tests/Commands/Auth/LogoutCommandTest.php
@@ -3,7 +3,6 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Auth;
 
-
 use Pantheon\Terminus\Commands\Auth\LogoutCommand;
 use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;

--- a/tests/new_unit_tests/Commands/Auth/LogoutCommandTest.php
+++ b/tests/new_unit_tests/Commands/Auth/LogoutCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Commands\Auth;
+
+
+use Pantheon\Terminus\Commands\Auth\LogoutCommand;
+use Pantheon\Terminus\Session\Session;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+
+class LogoutCommandTest extends CommandTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->command = new LogoutCommand($this->getConfig());
+        $this->command->setSession($this->session);
+        $this->command->setLogger($this->logger);
+    }
+
+    /**
+     */
+    public function testLogout()
+    {
+        $this->session->expects($this->once())
+            ->method('logOut');
+
+        $this->logger->expects($this->at(0))
+            ->method('log')
+            ->with(
+                $this->equalTo('notice'),
+                $this->equalTo('You have been logged out of Pantheon.')
+            );
+
+        $this->command->logOut();
+    }
+}

--- a/tests/new_unit_tests/Commands/Auth/WhoamiCommandTest.php
+++ b/tests/new_unit_tests/Commands/Auth/WhoamiCommandTest.php
@@ -3,7 +3,6 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Auth;
 
-
 use Pantheon\Terminus\Commands\Auth\WhoamiCommand;
 use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;

--- a/tests/new_unit_tests/Commands/Auth/WhoamiCommandTest.php
+++ b/tests/new_unit_tests/Commands/Auth/WhoamiCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Commands\Auth;
+
+
+use Pantheon\Terminus\Commands\Auth\WhoamiCommand;
+use Pantheon\Terminus\Session\Session;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+use Terminus\Models\User;
+
+class WhoamiCommandTest extends CommandTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->command = new WhoamiCommand($this->getConfig());
+        $this->command->setSession($this->session);
+        $this->command->setLogger($this->logger);
+    }
+
+    public function testWhoamiLoggedIn()
+    {
+        $info = [
+            'firstname' => 'Test',
+            'lastname' => 'User',
+            'email' => 'test@example.com',
+            'id' => '111111111111111111111111111111111111111111111',
+        ];
+
+        $this->user->expects($this->once())
+            ->method('fetch')
+            ->willReturn($this->user);
+
+        $this->user->expects($this->once())
+            ->method('serialize')
+            ->willReturn($info);
+
+        $out = $this->command->whoAmI();
+        $this->assertInstanceOf('Consolidation\OutputFormatters\StructuredData\AssociativeList', $out);
+        $this->assertEquals($info, $out->getArrayCopy());
+    }
+
+    public function testWhoamiLoggedOut()
+    {
+        $this->session = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->session->expects($this->once())
+            ->method('getUser')
+            ->willReturn(null);
+
+        $this->logger->expects($this->at(0))
+            ->method('log')
+            ->with(
+                $this->equalTo('notice'),
+                $this->equalTo('You are not logged in.')
+            );
+
+        $this->command->setSession($this->session);
+        $out = $this->command->whoAmI();
+        $this->assertNull($out);
+    }
+}

--- a/tests/new_unit_tests/Commands/Backup/GetCommandTest.php
+++ b/tests/new_unit_tests/Commands/Backup/GetCommandTest.php
@@ -20,7 +20,7 @@ class GetCommandTest extends BackupCommandTest
         parent::setUp();
         $this->command = new GetCommand($this->sites);
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Backup/ListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Backup/ListCommandTest.php
@@ -20,7 +20,7 @@ class ListCommandTest extends BackupCommandTest
         parent::setUp();
         $this->command = new ListCommand($this->sites);
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/CommandTestCase.php
+++ b/tests/new_unit_tests/Commands/CommandTestCase.php
@@ -121,8 +121,6 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
         $this->logger = $this->getMockBuilder(NullLogger::class)
             ->setMethods(array('log'))
             ->getMock();
-
-
     }
 
     /**

--- a/tests/new_unit_tests/Commands/CommandTestCase.php
+++ b/tests/new_unit_tests/Commands/CommandTestCase.php
@@ -5,7 +5,9 @@ namespace Pantheon\Terminus\UnitTests\Commands;
 use League\Container\Container;
 use Pantheon\Terminus\Config;
 use Pantheon\Terminus\Runner;
+use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\Terminus;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use ReflectionMethod;
 use Robo\Robo;
@@ -16,38 +18,16 @@ use Terminus\Collections\Environments;
 use Terminus\Collections\Sites;
 use Terminus\Models\Environment;
 use Terminus\Models\Site;
+use Terminus\Models\User;
 use VCR\VCR;
 
 abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var Terminus
-     */
-    protected $app;
-    /**
-     * @var string
-     */
-    protected $status_code;
-    /**
      * @var Config
      */
     protected $config;
-    /**
-     * @var Container
-     */
-    protected $container;
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
-    /**
-     * @var Runner
-     */
-    protected $runner;
-    /**
-     * @var ArrayInput
-     */
-    protected $input;
+
 
     /**
      * @var Sites
@@ -59,24 +39,16 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
      */
     protected $site;
 
+    /**
+     * @var Session
+     */
+    protected $session;
 
     /**
-     * @return Terminus
+     * @var LoggerInterface
      */
-    public function getApp()
-    {
-        return $this->app;
-    }
+    protected $logger;
 
-    /**
-     * @param Terminus $app
-     * @return $this
-     */
-    public function setApp($app)
-    {
-        $this->app = $app;
-        return $this;
-    }
 
     /**
      * @return Config
@@ -96,118 +68,6 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
         return $this;
     }
 
-    /**
-     * @return Runner
-     */
-    public function getRunner()
-    {
-        return $this->runner;
-    }
-
-    /**
-     * @param Runner $runner
-     * @return CommandTestCase
-     */
-    public function setRunner($runner)
-    {
-        $this->runner = $runner;
-        return $this;
-    }
-
-    /**
-     * @return OutputInterface
-     */
-    public function getOutput()
-    {
-        return $this->output;
-    }
-
-    /**
-     * Convert the output of a command to an easily digested string.
-     * @return string|OutputInterface
-     */
-    public function fetchTrimmedOutput()
-    {
-        if (get_class($this->output) == BufferedOutput::class) {
-            return trim($this->getOutput()->fetch());
-        }
-        return $this->getOutput();
-    }
-
-    /**
-     * @param OutputInterface $output
-     * @return CommandTestCase
-     */
-    public function setOutput(OutputInterface $output)
-    {
-        $this->output = $output;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getContainer()
-    {
-        return $this->container;
-    }
-
-    /**
-     * @param mixed $container
-     * @return CommandTestCase
-     */
-    public function setContainer($container)
-    {
-        $this->container = $container;
-        return $this;
-    }
-
-    /**
-     * @return int
-     */
-    public function getStatusCode()
-    {
-        return $this->status_code;
-    }
-
-    /**
-     * @param mixed $status_code
-     * @return CommandTestCase
-     */
-    public function setStatusCode($status_code)
-    {
-        $this->status_code = $status_code;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getInput()
-    {
-        return $this->input;
-    }
-
-    /**
-     * @param mixed $input
-     * @return CommandTestCase
-     */
-    public function setInput($input)
-    {
-        $this->input = new ArrayInput($input);
-        return $this;
-    }
-
-    /**
-     * Run the command and capture the exit code.
-     *
-     * @return $this
-     */
-    public function runCommand()
-    {
-        $this->status_code = $this->runner->run($this->input, $this->output);
-        return $this;
-    }
 
     /**
      * @inheritdoc
@@ -216,41 +76,6 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     {
         if (!$this->config) {
             $this->config = new Config();
-        }
-
-        if (!$this->app) {
-            $this->app = new Terminus('Terminus', $this->config->get('version'), $this->config);
-        }
-
-        if (!$this->container) {
-            $this->container = new Container();
-        }
-
-        if (!$this->output) {
-            $this->output = new BufferedOutput();
-        }
-
-        if (!$this->input) {
-            $this->input = new ArrayInput([]);
-        }
-        // Configuring the dependency-injection container
-        Robo::configureContainer(
-            $this->container,
-            $this->app,
-            $this->config,
-            $this->input,
-            $this->output
-        );
-
-        // Set the application dispatcher (required when using Robo::configureContainer)
-        $this->app->setDispatcher($this->container->get('eventDispatcher'));
-
-        if (!$this->runner) {
-            $this->runner = new Runner($this->container);
-        }
-
-        if (!empty($mode = $this->config->get('vcr_mode'))) {
-            VCR::configure()->setMode($mode);
         }
 
         // These are not used by every test but are useful for SiteAwareInterface commands. Which is a lot of them.
@@ -277,11 +102,27 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
         $this->sites->method('get')
             ->willReturn($this->site);
 
+        $this->user= $this->getMockBuilder(User::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->user->method('sitesCollection')
+            ->willReturn($this->sites);
+
+        $this->session = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->session->method('getUser')
+            ->willReturn($this->user);
+
         // A lot of commands output to a logger.
         // To use this call `$command->setLogger($this->logger);` after you create your command to test.
         $this->logger = $this->getMockBuilder(NullLogger::class)
             ->setMethods(array('log'))
             ->getMock();
+
+
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Connection/InfoCommandTest.php
+++ b/tests/new_unit_tests/Commands/Connection/InfoCommandTest.php
@@ -25,7 +25,7 @@ class InfoCommandTest extends ConnectionCommandTest
         $this->command = new InfoCommand($this->getConfig());
 
         // use the basic mocked sites from CommandTestCase
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Connection/SetCommandTest.php
+++ b/tests/new_unit_tests/Commands/Connection/SetCommandTest.php
@@ -23,7 +23,7 @@ class SetCommandTest extends ConnectionCommandTest
         $this->command = new SetCommand($this->getConfig());
 
         // use the basic mocks from CommandTestCase
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
 

--- a/tests/new_unit_tests/Commands/Env/CodeLogCommandTest.php
+++ b/tests/new_unit_tests/Commands/Env/CodeLogCommandTest.php
@@ -18,13 +18,13 @@ class CodeLogCommandTest extends EnvCommandTest
         parent::setUp();
         $this->command = new CodeLogCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
 
         $this->commits = $this->getMockBuilder(Commits::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->env->commits = $this->commits;
+        $this->environment->commits = $this->commits;
 
         $this->commit_1_attribs = [
             'datetime' => '2016-09-21T12:21:18',
@@ -51,7 +51,7 @@ class CodeLogCommandTest extends EnvCommandTest
      */
     public function testLog()
     {
-        $this->env->id = 'dev';
+        $this->environment->id = 'dev';
         $this->commits->method('all')
             ->willReturn([
                 $this->commit_1,
@@ -77,7 +77,7 @@ class CodeLogCommandTest extends EnvCommandTest
      */
     public function testDeployNoCode()
     {
-        $this->env->id = 'dev';
+        $this->environment->id = 'dev';
         $this->commits->method('all')
             ->willReturn([]);
 

--- a/tests/new_unit_tests/Commands/Env/CommitCommandTest.php
+++ b/tests/new_unit_tests/Commands/Env/CommitCommandTest.php
@@ -16,8 +16,8 @@ class CommitCommandTest extends EnvCommandTest
         parent::setUp();
         $this->command = new CommitCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
-        $this->env->id = 'dev';
+        $this->command->setSession($this->session);
+        $this->environment->id = 'dev';
     }
 
     /**
@@ -27,11 +27,11 @@ class CommitCommandTest extends EnvCommandTest
      */
     public function testCommit()
     {
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('diffstat')
             ->willReturn(['a', 'b']);
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('commitChanges')
             ->willReturn($this->workflow)
             ->with('Custom message.');

--- a/tests/new_unit_tests/Commands/Env/DeployCommandTest.php
+++ b/tests/new_unit_tests/Commands/Env/DeployCommandTest.php
@@ -16,7 +16,7 @@ class DeployCommandTest extends EnvCommandTest
         parent::setUp();
         $this->command = new DeployCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**
@@ -26,13 +26,13 @@ class DeployCommandTest extends EnvCommandTest
      */
     public function testDeploy()
     {
-        $this->env->id = 'test';
+        $this->environment->id = 'test';
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('hasDeployableCode')
             ->willReturn(true);
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('deploy')
             ->willReturn($this->workflow)
             ->with([
@@ -66,13 +66,13 @@ class DeployCommandTest extends EnvCommandTest
      */
     public function testDeployNoCode()
     {
-        $this->env->id = 'test';
+        $this->environment->id = 'test';
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('hasDeployableCode')
             ->willReturn(false);
 
-        $this->env->expects($this->never())
+        $this->environment->expects($this->never())
             ->method('deploy');
 
         $this->logger->expects($this->once())
@@ -89,13 +89,13 @@ class DeployCommandTest extends EnvCommandTest
      */
     public function testDeployLive()
     {
-        $this->env->id = 'live';
+        $this->environment->id = 'live';
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('hasDeployableCode')
             ->willReturn(true);
 
-        $this->env->expects($this->once())
+        $this->environment->expects($this->once())
             ->method('deploy')
             ->willReturn($this->workflow)
             ->with([

--- a/tests/new_unit_tests/Commands/Env/EnvCommandTest.php
+++ b/tests/new_unit_tests/Commands/Env/EnvCommandTest.php
@@ -16,10 +16,6 @@ use Terminus\Models\Workflow;
  */
 abstract class EnvCommandTest extends CommandTestCase
 {
-    protected $session;
-    protected $sites;
-    protected $user;
-    protected $logger;
     protected $command;
 
     /**
@@ -27,31 +23,7 @@ abstract class EnvCommandTest extends CommandTestCase
      */
     protected function setUp()
     {
-        $this->sites = $this->getMockBuilder(Sites::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->site = $this->getMockBuilder(Site::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->sites->method('get')
-            ->willReturn($this->site);
-
-        $this->site->environments = $this->getMockBuilder(Environments::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->env = $this->getMockBuilder(Environment::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $this->site->environments->method('get')
-            ->willReturn($this->env);
-
-        $this->logger = $this->getMockBuilder(NullLogger::class)
-            ->setMethods(array('log'))
-            ->getMock();
+        parent::setUp();
 
         $this->workflow = $this->getMockBuilder(Workflow::class)
             ->disableOriginalConstructor()

--- a/tests/new_unit_tests/Commands/Multidev/CreateCommandTest.php
+++ b/tests/new_unit_tests/Commands/Multidev/CreateCommandTest.php
@@ -18,7 +18,7 @@ class CreateCommandTest extends MultidevCommandTest
 
         $this->command = new CreateCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->site->environments->method('create')->willReturn($this->workflow);
     }
 

--- a/tests/new_unit_tests/Commands/Multidev/DeleteCommandTest.php
+++ b/tests/new_unit_tests/Commands/Multidev/DeleteCommandTest.php
@@ -18,7 +18,7 @@ class DeleteCommandTest extends MultidevCommandTest
 
         $this->command = new DeleteCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->environment->method('delete')->willReturn($this->workflow);
     }
 

--- a/tests/new_unit_tests/Commands/Multidev/ListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Multidev/ListCommandTest.php
@@ -19,7 +19,7 @@ class ListCommandTest extends MultidevCommandTest
 
         $this->command = new ListCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Multidev/MergeFromDevCommandTest.php
+++ b/tests/new_unit_tests/Commands/Multidev/MergeFromDevCommandTest.php
@@ -18,7 +18,7 @@ class MergeFromDevCommandTest extends MultidevCommandTest
 
         $this->command = new MergeFromDevCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->environment->method('mergeFromDev')->willReturn($this->workflow);
     }
 

--- a/tests/new_unit_tests/Commands/Multidev/MergeToDevCommandTest.php
+++ b/tests/new_unit_tests/Commands/Multidev/MergeToDevCommandTest.php
@@ -18,7 +18,7 @@ class MergeToDevCommandTest extends MultidevCommandTest
 
         $this->command = new MergeToDevCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->environment->method('mergeToDev')->willReturn($this->workflow);
     }
 

--- a/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/new_unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -18,7 +18,7 @@ class SSHBaseCommandTest extends CommandTestCase
         parent::setUp();
 
         $this->command = new DummyCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
 
         $this->site->expects($this->any())->method('get')

--- a/tests/new_unit_tests/Commands/Site/ImportCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/ImportCommandTest.php
@@ -22,7 +22,7 @@ class ImportCommandTest extends CommandTestCase
     {
         parent::setUp();
         $this->command = new ImportCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
     

--- a/tests/new_unit_tests/Commands/Site/InfoCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/InfoCommandTest.php
@@ -19,7 +19,7 @@ class InfoCommandTest extends CommandTestCase
     {
         parent::setUp();
         $this->command = new InfoCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
 

--- a/tests/new_unit_tests/Commands/Site/ListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/ListCommandTest.php
@@ -13,22 +13,13 @@ use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 class ListCommandTest extends CommandTestCase
 {
     /**
-     * @var Session
-     */
-    private $session;
-
-    /**
      * @inheritdoc
      */
     protected function setup()
     {
         parent::setUp();
-        $this->session = $this->getMockBuilder(Session::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $this->command = new ListCommand($this->getConfig());
-        $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
         $this->command->setSession($this->session);
     }
@@ -55,8 +46,6 @@ class ListCommandTest extends CommandTestCase
             ->willReturn($this->sites);
         $this->sites->expects($this->never())
             ->method('filterByName');
-        $this->session->expects($this->never())
-            ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
         $this->site->expects($this->any())
@@ -97,8 +86,6 @@ class ListCommandTest extends CommandTestCase
             ->willReturn($this->sites);
         $this->sites->expects($this->never())
             ->method('filterByName');
-        $this->session->expects($this->never())
-            ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
         $this->site->expects($this->any())
@@ -139,8 +126,6 @@ class ListCommandTest extends CommandTestCase
             ->willReturn($this->sites);
         $this->sites->expects($this->never())
             ->method('filterByName');
-        $this->session->expects($this->never())
-            ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
         $this->site->expects($this->any())
@@ -184,8 +169,6 @@ class ListCommandTest extends CommandTestCase
             ->method('filterByName')
             ->with($this->equalTo($regex))
             ->willReturn($this->sites);
-        $this->session->expects($this->never())
-            ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
         $this->site->expects($this->any())
@@ -227,8 +210,6 @@ class ListCommandTest extends CommandTestCase
             ->willReturn($this->sites);
         $this->session->expects($this->never())
             ->method('filterByName');
-        $this->session->expects($this->never())
-            ->method('getUser');
         $this->sites->expects($this->once())
             ->method('filterByOwner')
             ->with($this->equalTo($user_id))
@@ -264,10 +245,8 @@ class ListCommandTest extends CommandTestCase
             'created' => '1984-07-28 16:40',
             'memberships' => 'org_id: org_url',
         ];
-        $user = $this->getMockBuilder(User::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $user->id = $user_id;
+
+        $this->user->id = $user_id;
 
         $this->site->memberships = ['org_id: org_url'];
         $this->sites->expects($this->once())
@@ -276,10 +255,6 @@ class ListCommandTest extends CommandTestCase
             ->willReturn($this->sites);
         $this->session->expects($this->never())
             ->method('filterByName');
-        $this->session->expects($this->once())
-            ->method('getUser')
-            ->with()
-            ->willReturn($user);
         $this->sites->expects($this->once())
             ->method('filterByOwner')
             ->with($this->equalTo($user_id))

--- a/tests/new_unit_tests/Commands/Site/LookupCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/LookupCommandTest.php
@@ -19,7 +19,7 @@ class LookupCommandTest extends CommandTestCase
     {
         parent::setUp();
         $this->command = new LookupCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
 

--- a/tests/new_unit_tests/Commands/Site/Team/AddCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/Team/AddCommandTest.php
@@ -17,7 +17,7 @@ class TeamCommandsTest extends TeamCommandTest
         parent::setUp();
         $this->command = new AddCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Site/Team/ListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/Team/ListCommandTest.php
@@ -17,7 +17,7 @@ class ListCommandTest extends TeamCommandTest
         parent::setUp();
         $this->command = new ListCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Site/Team/RemoveCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/Team/RemoveCommandTest.php
@@ -17,7 +17,7 @@ class RemoveCommandTest extends TeamCommandTest
         parent::setUp();
         $this->command = new RemoveCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Site/Team/RoleCommandTest.php
+++ b/tests/new_unit_tests/Commands/Site/Team/RoleCommandTest.php
@@ -17,7 +17,7 @@ class RoleCommandTest extends TeamCommandTest
         parent::setUp();
         $this->command = new RoleCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/Commands/Upstream/UpstreamUpdatesApplyCommandTest.php
+++ b/tests/new_unit_tests/Commands/Upstream/UpstreamUpdatesApplyCommandTest.php
@@ -14,7 +14,7 @@ class UpstreamUpdatesApplyCommand extends UpstreamCommandTest
         parent::setUp();
 
         $this->command = new UpdatesApplyCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
 

--- a/tests/new_unit_tests/Commands/Upstream/UpstreamUpdatesListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Upstream/UpstreamUpdatesListCommandTest.php
@@ -11,7 +11,7 @@ class UpstreamUpdatesListCommandTest extends UpstreamCommandTest
         parent::setUp();
 
         $this->command = new UpdatesListCommand($this->getConfig());
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
     }
 

--- a/tests/new_unit_tests/Commands/Workflow/ListCommandTest.php
+++ b/tests/new_unit_tests/Commands/Workflow/ListCommandTest.php
@@ -17,7 +17,7 @@ class ListCommandTest extends WorkflowCommandTest
         parent::setUp();
         $this->command = new ListCommand($this->getConfig());
         $this->command->setLogger($this->logger);
-        $this->command->setSites($this->sites);
+        $this->command->setSession($this->session);
     }
 
     /**

--- a/tests/new_unit_tests/DataStore/FileStoreTest.php
+++ b/tests/new_unit_tests/DataStore/FileStoreTest.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\DataStore;
+
+
+class FileStoreTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testSet()
+    {
+    }
+
+    public function testGet()
+    {
+    }
+
+    public function testKeys()
+    {
+    }
+
+    public function testHas()
+    {
+    }
+}

--- a/tests/new_unit_tests/DataStore/FileStoreTest.php
+++ b/tests/new_unit_tests/DataStore/FileStoreTest.php
@@ -3,7 +3,6 @@
 
 namespace Pantheon\Terminus\UnitTests\DataStore;
 
-
 class FileStoreTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/new_unit_tests/DataStore/MemoryStoreTest.php
+++ b/tests/new_unit_tests/DataStore/MemoryStoreTest.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\DataStore;
+
+
+class MemoryStoreTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSet()
+    {
+    }
+
+    public function testGet()
+    {
+    }
+
+    public function testKeys()
+    {
+    }
+
+    public function testHas()
+    {
+    }
+}

--- a/tests/new_unit_tests/DataStore/MemoryStoreTest.php
+++ b/tests/new_unit_tests/DataStore/MemoryStoreTest.php
@@ -3,7 +3,6 @@
 
 namespace Pantheon\Terminus\UnitTests\DataStore;
 
-
 class MemoryStoreTest extends \PHPUnit_Framework_TestCase
 {
     public function testSet()

--- a/tests/new_unit_tests/Session/SessionTest.php
+++ b/tests/new_unit_tests/Session/SessionTest.php
@@ -138,6 +138,4 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testGetMachineTokenCreationUrl()
     {
     }
-
-
 }


### PR DESCRIPTION
Ok this one is a bit of a beast. I will break it apart as needed.

It does a few things:

1) It makes config and sessions more injectable. No more static access methods or buried `new` statements.

2) It merges Session and Auth. This reduced a hard dependency at the cost of complicating Session. Otherwise we would need to manage the dependency injection of Auth into Session and Auth into Authorizor and LoginCommand. This way the graph is simpler. If you guys don't like Session being in control of all of this stuff then I can break it up again.

3) It makes access to the SitesCollection go through the User object of the currently logged in user. This again reduces the dependency graph somewhat but it creates a rather long dependency chain. There are pros and cons to this.

4) It makes all of the unit tests unit tests, eliminating the need for a runner or VCR or any of that stuff for unit testing.

Let me know what y'all think. It may be too far but I think there are some testability improvements with this approach.
