### PR TITLE
Convert users and immediate dependencies to DI

### DIFF
--- a/src/Authorizer.php
+++ b/src/Authorizer.php
@@ -25,10 +25,10 @@ class Authorizer implements ConfigAwareInterface, LoggerAwareInterface, SessionA
     public function ensureLogin()
     {
         if (!$this->session()->isActive()) {
-            if (count($tokens = $this->session()->tokens->all()) == 1) {
+            if (count($tokens = $this->session()->getTokens()->all()) == 1) {
                 $token = array_shift($tokens);
-            } elseif (!empty($email = $this->config->get('user'))) {
-                $token = $this->session()->tokens->get($email);
+            } elseif (!empty($email = $this->getConfig()->get('user'))) {
+                $token = $this->session()->getTokens()->get($email);
             } else {
                 throw new \Exception(
                     'You are not logged in. Run `auth:login` to authenticate or `help auth:login` for more info.'

--- a/src/Collections/Instruments.php
+++ b/src/Collections/Instruments.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+class Instruments extends UserOwnedCollection
+{
+    /**
+     * @var string
+     */
+    protected $url = 'users/{user_id}/instruments';
+
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Terminus\Models\Instrument';
+}

--- a/src/Collections/MachineTokens.php
+++ b/src/Collections/MachineTokens.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+class MachineTokens extends UserOwnedCollection
+{
+    /**
+     * @var string
+     */
+    protected $url = 'users/{user_id}/machine_tokens';
+
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\MachineToken';
+}

--- a/src/Collections/SshKeys.php
+++ b/src/Collections/SshKeys.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Terminus\Exceptions\TerminusException;
+
+class SshKeys extends UserOwnedCollection
+{
+    /**
+     * @var string
+     */
+    protected $url = 'users/{user_id}/keys';
+
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\SshKey';
+
+    /**
+     * Adds an SSH key to the user's Pantheon account
+     *
+     * @param string $key_file Full path of the SSH key to add
+     * @return array
+     * @throws TerminusException
+     */
+    public function addKey($key_file)
+    {
+        if (!file_exists($key_file)) {
+            throw new TerminusException(
+                'The file {file} cannot be accessed by Terminus.',
+                ['file' => $key_file,],
+                1
+            );
+        }
+        $response = $this->request->request(
+            'users/' . $this->user->id . '/keys',
+            [
+                'form_params' => rtrim(file_get_contents($key_file)),
+                'method' => 'post',
+            ]
+        );
+        return (array)$response['data'];
+    }
+
+    /**
+     * Deletes all SSH keys from account
+     *
+     * @return array
+     */
+    public function deleteAll()
+    {
+        $response = $this->request->request(
+            'users/' . $this->user->id . '/keys',
+            ['method' => 'delete',]
+        );
+        return (array)$response['data'];
+    }
+
+    /**
+     * Fetches model data from API and instantiates its model instances
+     *
+     * @param array $options params to pass to url request
+     * @return SshKeys $this
+     */
+    public function fetch(array $options = [])
+    {
+        $results = $this->getCollectionData($options);
+        foreach ($results as $uuid => $ssh_key) {
+            $model_data = (object)['id' => $uuid, 'key' => $ssh_key,];
+            $this->add($model_data);
+        }
+
+        return $this;
+    }
+}

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+use Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Request;
+
+abstract class TerminusCollection implements RequestAwareInterface, ContainerAwareInterface
+{
+    use RequestAwareTrait;
+    use ContainerAwareTrait;
+
+    /**
+     * @var array
+     */
+    protected $args = [];
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\TerminusModel';
+    /**
+     * @var TerminusModel[]
+     */
+    protected $models = [];
+    /**
+     * @var boolean
+     */
+    protected $paged = false;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * Instantiates the collection, sets param members as properties
+     *
+     * @param array $options Options with which to configure this collection
+     */
+    public function __construct(array $options = [])
+    {
+    }
+
+    /**
+     * Get the listing URL for this collection
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Adds a model to this collection
+     *
+     * @param object $model_data Data to feed into attributes of new model
+     * @param array $options Data to make properties of the new model
+     * @return TerminusModel
+     */
+    public function add($model_data, array $options = [])
+    {
+        $options = array_merge(
+            ['id' => $model_data->id, 'collection' => $this,],
+            $options
+        );
+        $model = $this->getContainer()->get($this->collected_class, [$model_data, $options]);
+        $this->models[$model_data->id] = $model;
+        return $model;
+    }
+
+    /**
+     * Retrieves all models
+     * TODO: Remove automatic fetching and make fetches explicit
+     *
+     * @return TerminusModel[]
+     */
+    public function all()
+    {
+        $models = array_values($this->getMembers());
+        return $models;
+    }
+
+    /**
+     * Fetches model data from API and instantiates its model instances
+     *
+     * @param array $options params to pass to url request
+     * @return TerminusCollection $this
+     */
+    public function fetch(array $options = [])
+    {
+        $results = $this->getCollectionData($options);
+
+        foreach ($results as $id => $model_data) {
+            if (!isset($model_data->id)) {
+                $model_data->id = $id;
+            }
+            $this->add($model_data);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the model of the given ID
+     *
+     * @param string $id ID of desired model instance
+     * @return TerminusModel $this->models[$id]
+     * @throws TerminusException
+     */
+    public function get($id)
+    {
+        $models = $this->getMembers();
+        if (isset($models[$id])) {
+            return $models[$id];
+        }
+        throw new TerminusException(
+            'Could not find {model} "{id}"',
+            ['model' => $this->collected_class, 'id' => $id,],
+            1
+        );
+    }
+
+    /**
+     * List Model IDs
+     *
+     * @return string[] Array of all model IDs
+     */
+    public function ids()
+    {
+        $models = $this->getMembers();
+        $ids = array_keys($models);
+        return $ids;
+    }
+
+    /**
+     * Returns an array of data where the keys are the attribute $key and the
+     *   values are the attribute $value
+     *
+     * @param string $key Name of attribute to make array keys
+     * @param mixed $value Name(s) of attribute(s) to comprise array values
+     * @return array Array rendered as requested
+     *         $this->attribute->$key = $this->attribute->$value
+     */
+    public function listing($key = 'id', $value = 'name')
+    {
+        $members = array_combine(
+            array_map(
+                function ($member) use ($key) {
+                    return $member->get($key);
+                },
+                $this->models
+            ),
+            array_map(
+                function ($member) use ($value) {
+                    if (is_scalar($value)) {
+                        return $member->get($value);
+                    }
+                    $list = [];
+                    foreach ($value as $item) {
+                        $list[$item] = $member->get($item);
+                    }
+                    return $list;
+                },
+                $this->models
+            )
+        );
+        return $members;
+    }
+
+    /**
+     * Retrieves collection data from the API
+     *
+     * @param array $options params to pass to url request
+     * @return array
+     */
+    protected function getCollectionData($options = [])
+    {
+        $args = array_merge(['options' => ['method' => 'get',],], $this->args);
+        if (isset($options['fetch_args'])) {
+            $args = array_merge($args, $options['fetch_args']);
+        }
+
+        if ($this->paged) {
+            $results = $this->request()->pagedRequest($this->getUrl(), $args);
+        } else {
+            $results = $this->request()->request($this->getUrl(), $args);
+        }
+
+        return $results['data'];
+    }
+
+    /**
+     * Returns an array of data where the keys are the attribute $key and the
+     *   values are the attribute $value, filtered by the given array
+     *
+     * @param array $filters Attributes to match during filtration
+     *   e.g. array('category' => 'other')
+     * @param string $key Name of attribute to make array keys
+     * @param string|array $value Name(s) of attribute to make array values
+     * @return array Array rendered as requested
+     *         $this->attribute->$key = $this->attribute->$value
+     */
+    public function getFilteredMemberList(
+        array $filters,
+        $key = 'id',
+        $value = 'name'
+    ) {
+        $members = $this->getMembers();
+        $member_list = [];
+
+        $values = $value;
+        if (!is_array($values)) {
+            $values = [$value,];
+        }
+        foreach ($members as $member) {
+            $member_list[$member->get($key)] = [];
+            foreach ($values as $item) {
+                $member_list[$member->get($key)][$item] = $member->get($item);
+            }
+            if (count($member_list[$member->get($key)]) < 2) {
+                $member_list[$member->get($key)] =
+                    array_pop($member_list[$member->get($key)]);
+            }
+            foreach ($filters as $attribute => $match_value) {
+                if ($member->get($attribute) != $match_value) {
+                    unset($member_list[$member->get($key)]);
+                    break;
+                }
+            }
+        }
+        return $member_list;
+    }
+
+    /**
+     * Returns an array of data where the keys are the attribute $key and the
+     *   values are the attribute $value
+     *
+     * @param string $key Name of attribute to make array keys
+     * @param string $value Name of attribute to make array values
+     * @return array Array rendered as requested
+     *         $this->attribute->$key = $this->attribute->$value
+     */
+    public function getMemberList($key = 'id', $value = 'name')
+    {
+        $member_list = $this->getFilteredMemberList([], $key, $value);
+        return $member_list;
+    }
+
+    /**
+     * Retrieves all members of this collection
+     *
+     * @return TerminusModel[]
+     */
+    protected function getMembers()
+    {
+        if (empty($this->models)) {
+            $this->fetch();
+        }
+        return $this->models;
+    }
+}

--- a/src/Collections/UserOrganizationMemberships.php
+++ b/src/Collections/UserOrganizationMemberships.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+class UserOrganizationMemberships extends UserOwnedCollection
+{
+    /**
+     * @var string
+     */
+    protected $url = 'users/{user_id}/memberships/organizations';
+
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\UserOrganizationMembership';
+
+    /**
+     * @var boolean
+     */
+    protected $paged = true;
+}

--- a/src/Collections/UserOwnedCollection.php
+++ b/src/Collections/UserOwnedCollection.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+class UserOwnedCollection extends TerminusCollection
+{
+    protected $user;
+
+    /**
+     * Object constructor
+     *
+     * @param array $options Options to set as $this->key
+     */
+    public function __construct($options = [])
+    {
+        parent::__construct($options);
+        $this->setUser($options['user']);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param mixed $user
+     */
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUrl()
+    {
+        // Replace the {user_id} token with the actual user id.
+        return str_replace('{user_id}', $this->getUser()->get('id'), parent::getUrl());
+    }
+}

--- a/src/Collections/UserSiteMemberships.php
+++ b/src/Collections/UserSiteMemberships.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+class UserSiteMemberships extends UserOwnedCollection
+{
+
+    /**
+     * @var string
+     */
+    protected $url = 'users/{user_id}/memberships/sites';
+
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\UserSiteMembership';
+
+    /**
+     * @var boolean
+     */
+    protected $paged = true;
+}

--- a/src/Collections/Workflows.php
+++ b/src/Collections/Workflows.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Session\SessionAwareTrait;
+use Terminus\Session;
+
+class Workflows extends TerminusCollection implements SessionAwareInterface
+{
+    use SessionAwareTrait;
+
+    /**
+     * @var mixed
+     */
+    protected $owner;
+    /**
+     * @var Environment
+     */
+    private $environment;
+    /**
+     * @var Organization
+     */
+    private $organization;
+    /**
+     * @var Site
+     */
+    private $site;
+    /**
+     * @var User
+     */
+    private $user;
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\Workflow';
+
+    /**
+     * Instantiates the collection, sets param members as properties
+     *
+     * @param array $options Options with which to configure this collection
+     */
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+        if (isset($options['environment'])) {
+            $this->owner = $this->environment = $options['environment'];
+        } elseif (isset($options['organization'])) {
+            $this->owner = $this->organization = $options['organization'];
+        } elseif (isset($options['site'])) {
+            $this->owner = $this->site = $options['site'];
+        } elseif (isset($options['user'])) {
+            $this->owner = $this->user = $options['user'];
+        }
+    }
+
+    /**
+     * Get the URL for this model
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        if (!empty($this->url)) {
+            return $this->url;
+        }
+
+        // Determine the url based on the workflow owner.
+        $owner = $this->getOwnerObject();
+        switch (get_class($owner)) {
+            case 'Terminus\Models\Environment':
+                $this->url = sprintf(
+                    'sites/%s/environments/%s/workflows',
+                    $owner->site->id,
+                    $owner->id
+                );
+                break;
+            case 'Terminus\Models\Organization':
+                $this->url = sprintf(
+                    'users/%s/organizations/%s/workflows',
+                    // @TODO: This should be passed in rather than read from the current session.
+                    $this->session()->getUser()->id,
+                    $owner->id
+                );
+                break;
+            case 'Terminus\Models\Site':
+                $this->url = sprintf(
+                    'sites/%s/workflows',
+                    $owner->id
+                );
+                break;
+            case 'Pantheon\Terminus\Models\User':
+                $this->url = sprintf(
+                    'users/%s/workflows',
+                    $owner->id
+                );
+                break;
+        }
+        return $this->url;
+    }
+
+    /**
+     * Returns all existing workflows that have finished
+     *
+     * @return Workflow[]
+     */
+    public function allFinished()
+    {
+        $workflows = array_filter(
+            $this->all(),
+            function ($workflow) {
+                $is_finished = $workflow->isFinished();
+                return $is_finished;
+            }
+        );
+        return $workflows;
+    }
+
+    /**
+     * Returns all existing workflows that contain logs
+     *
+     * @return Workflow[]
+     */
+    public function allWithLogs()
+    {
+        $workflows = $this->allFinished();
+        $workflows = array_filter(
+            $workflows,
+            function ($workflow) {
+                $has_logs = $workflow->get('has_operation_log_output');
+                return $has_logs;
+            }
+        );
+
+        return $workflows;
+    }
+
+    /**
+     * Creates a new workflow and adds its data to the collection
+     *
+     * @param string $type Type of workflow to create
+     * @param array $options Additional information for the request, with the
+     *   following possible keys:
+     *   - environment: string
+     *   - params: associative array of parameters for the request
+     * @return Workflow $model
+     */
+    public function create($type, array $options = [])
+    {
+        $options = array_merge(['params' => [],], $options);
+        $params = array_merge($this->args, $options['params']);
+
+        $results = $this->request()->request(
+            $this->getUrl(),
+            [
+                'method' => 'post',
+                'form_params' => [
+                    'type' => $type,
+                    'params' => (object)$params,
+                ],
+            ]
+        );
+
+        $model = $this->getContainer()->get(
+            $this->collected_class,
+            [
+                $results['data'],
+                ['id' => $results['data']->id, 'collection' => $this,]
+            ]
+        );
+        $this->add($model);
+        return $model;
+    }
+
+    /**
+     * Returns the object which controls this collection
+     *
+     * @return mixed
+     */
+    public function getOwnerObject()
+    {
+        return $this->owner;
+    }
+
+    /**
+     * Fetches workflow data hydrated with operations
+     *
+     * @param array $options Additional information for the request
+     * @return void
+     */
+    public function fetchWithOperations($options = [])
+    {
+        $options = array_merge(
+            $options,
+            ['fetch_args' => ['query' => ['hydrate' => 'operations',],],]
+        );
+        $this->fetch($options);
+    }
+
+    /**
+     * Get most-recent workflow from existing collection that has logs
+     *
+     * @return Workflow|null
+     */
+    public function findLatestWithLogs()
+    {
+        $workflows = $this->allWithLogs();
+        usort(
+            $workflows,
+            function ($a, $b) {
+                $a_finished_after_b = $a->get('finished_at') >= $b->get('finished_at');
+                if ($a_finished_after_b) {
+                    $cmp = -1;
+                } else {
+                    $cmp = 1;
+                }
+                return $cmp;
+            }
+        );
+
+        if (count($workflows) > 0) {
+            $workflow = $workflows[0];
+        } else {
+            $workflow = null;
+        }
+        return $workflow;
+    }
+
+    /**
+     * Get timestamp of most recently created Workflow
+     *
+     * @return int|null Timestamp
+     */
+    public function lastCreatedAt()
+    {
+        $workflows = $this->all();
+        usort(
+            $workflows,
+            function ($a, $b) {
+                $a_created_after_b = $a->get('created_at') >= $b->get('created_at');
+                if ($a_created_after_b) {
+                    $cmp = -1;
+                } else {
+                    $cmp = 1;
+                }
+                return $cmp;
+            }
+        );
+        if (count($workflows) > 0) {
+            $timestamp = $workflows[0]->get('created_at');
+        } else {
+            $timestamp = null;
+        }
+        return $timestamp;
+    }
+
+    /**
+     * Get timestamp of most recently finished workflow
+     *
+     * @return int|null Timestamp
+     */
+    public function lastFinishedAt()
+    {
+        $workflows = $this->all();
+        usort(
+            $workflows,
+            function ($a, $b) {
+                $a_finished_after_b = $a->get('finished_at') >= $b->get('finished_at');
+                if ($a_finished_after_b) {
+                    $cmp = -1;
+                } else {
+                    $cmp = 1;
+                }
+                return $cmp;
+            }
+        );
+        if (count($workflows) > 0) {
+            $timestamp = $workflows[0]->get('finished_at');
+        } else {
+            $timestamp = null;
+        }
+        return $timestamp;
+    }
+}

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -24,7 +24,7 @@ class LoginCommand extends TerminusCommand
      */
     public function logIn(array $options = ['machine-token' => null, 'email' => null,])
     {
-        $tokens = $this->session()->tokens;
+        $tokens = $this->session()->getTokens();
 
         if (isset($options['machine-token']) && !is_null($token_string = $options['machine-token'])) {
             try {

--- a/src/Commands/MachineToken/DeleteCommand.php
+++ b/src/Commands/MachineToken/DeleteCommand.php
@@ -23,7 +23,7 @@ class DeleteCommand extends TerminusCommand
     public function delete($machine_token_id)
     {
         // Find the token. Will throw an exception if it doesn't exist.
-        $machine_token = $this->session()->getUser()->machine_tokens->get($machine_token_id);
+        $machine_token = $this->session()->getUser()->getMachineTokens()->get($machine_token_id);
         $name = $machine_token->get('device_name');
 
         $this->log()->notice('Deleting {token} ...', ['token' => $name]);

--- a/src/Commands/MachineToken/ListCommand.php
+++ b/src/Commands/MachineToken/ListCommand.php
@@ -27,7 +27,7 @@ class ListCommand extends TerminusCommand
     public function listTokens()
     {
 
-        $machine_tokens = $this->session()->getUser()->machine_tokens->all();
+        $machine_tokens = $this->session()->getUser()->getMachineTokens()->all();
         $data = array();
         foreach ($machine_tokens as $id => $machine_token) {
             $data[] = array(

--- a/src/Commands/SSHKey/AddCommand.php
+++ b/src/Commands/SSHKey/AddCommand.php
@@ -26,7 +26,7 @@ class AddCommand extends TerminusCommand
      */
     public function add($file)
     {
-        $this->session()->getUser()->ssh_keys->addKey($file);
+        $this->session()->getUser()->getSshKeys()->addKey($file);
         $this->log()->notice('Added SSH key from file {file}.', compact('file'));
     }
 }

--- a/src/Commands/SSHKey/DeleteCommand.php
+++ b/src/Commands/SSHKey/DeleteCommand.php
@@ -30,7 +30,7 @@ class DeleteCommand extends TerminusCommand
         // Remove ':' to allow the id to be specified in ssh thumbnail format.
         $ssh_key_id = str_replace(':', '', $ssh_key_id);
         // Find the key. Will throw an exception if it doesn't exist.
-        $key = $this->session()->getUser()->ssh_keys->get($ssh_key_id);
+        $key = $this->session()->getUser()->getSshKeys()->get($ssh_key_id);
         $name = $key->get('id');
 
         $this->log()->notice('Deleting SSH key {key} ...', ['key' => $name]);

--- a/src/Commands/SSHKey/ListCommand.php
+++ b/src/Commands/SSHKey/ListCommand.php
@@ -33,7 +33,7 @@ class ListCommand extends TerminusCommand
      */
     public function listSSHKeys($options = ['format' => 'table', 'fields' => ''])
     {
-        $ssh_keys = $this->session()->getUser()->ssh_keys->all();
+        $ssh_keys = $this->session()->getUser()->getSshKeys()->all();
 
         $data = [];
         foreach ($ssh_keys as $id => $ssh_key) {

--- a/src/Models/Instrument.php
+++ b/src/Models/Instrument.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+class Instrument extends TerminusModel
+{
+}

--- a/src/Models/MachineToken.php
+++ b/src/Models/MachineToken.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Terminus\Exceptions\TerminusException;
+
+class MachineToken extends TerminusModel
+{
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     */
+    public function __construct($attributes, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->user = $options['collection']->getUser();
+    }
+
+    /**
+     * Deletes machine token
+     * @return void
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function delete()
+    {
+        $response = $this->request->request(
+            "users/{$this->user->id}/machine_tokens/{$this->id}",
+            ['method' => 'delete',]
+        );
+        if ($response['status_code'] !== 200) {
+            throw new TerminusException('There was an problem deleting the machine token.');
+        }
+    }
+}

--- a/src/Models/SavedToken.php
+++ b/src/Models/SavedToken.php
@@ -4,25 +4,26 @@ namespace Pantheon\Terminus\Models;
 
 use Pantheon\Terminus\Config;
 use Pantheon\Terminus\Session\Session;
-use Terminus\Models\TerminusModel;
+use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Session\SessionAwareTrait;
+use Robo\Common\ConfigAwareTrait;
+use Robo\Contract\ConfigAwareInterface;
 
 /**
  * Class SavedToken
  * @package Pantheon\Terminus\Models
  */
-class SavedToken extends TerminusModel
+class SavedToken extends TerminusModel implements SessionAwareInterface, ConfigAwareInterface
 {
-    /**
-     * @var Session
-     */
-    public $session;
+    use SessionAwareTrait;
+    use ConfigAwareTrait;
+
     /**
      * @inheritdoc
      */
     public function __construct($attributes = null, array $options = [])
     {
         parent::__construct($attributes, $options);
-        $this->session = $options['collection']->session;
     }
 
     /**
@@ -37,7 +38,7 @@ class SavedToken extends TerminusModel
             'method' => 'post',
         ];
         $response = $this->request->request('authorize/machine-token', $options);
-        $this->session->setData((array)$response['data']);
+        $this->session()->setData((array)$response['data']);
         return $this->session->getUser();
     }
 
@@ -47,8 +48,7 @@ class SavedToken extends TerminusModel
     public function saveToDir()
     {
         $this->set('date', time());
-        $config = new Config();
-        $token_path = $config->get('tokens_dir') . "/{$this->id}";
+        $token_path = $this->getConfig()->get('tokens_dir') . "/{$this->id}";
         file_put_contents($token_path, json_encode($this->attributes));
     }
 

--- a/src/Models/SshKey.php
+++ b/src/Models/SshKey.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Terminus\Exceptions\TerminusException;
+
+class SshKey extends TerminusModel
+{
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options to configure this model
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->user = $options['collection']->getUser();
+    }
+
+    /**
+     * Deletes a specific SSH key
+     * @return array
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function delete()
+    {
+        $response = $this->request->request(
+            'users/' . $this->user->id . '/keys/' . $this->id,
+            ['method' => 'delete',]
+        );
+        if ($response['status_code'] !== 200) {
+            throw new TerminusException('There was an problem deleting the SSH key.');
+        }
+    }
+
+    /**
+     * Returns the comment for this SSH key
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        $key_parts = explode(' ', $this->get('key'));
+        $comment = $key_parts[2];
+        return $comment;
+    }
+
+    /**
+     * Returns the hex for this SSH key
+     *
+     * @return string
+     */
+    public function getHex()
+    {
+        $hex = implode(':', str_split($this->id, 2));
+        return $hex;
+    }
+}

--- a/src/Models/TerminusModel.php
+++ b/src/Models/TerminusModel.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\Request\RequestAwareTrait;
+
+abstract class TerminusModel implements RequestAwareInterface
+{
+    use RequestAwareTrait;
+
+    /**
+     * @var string
+     */
+    public $id;
+    /**
+     * @var array Arguments for fetching this model's information
+     */
+    protected $args = [];
+    /**
+     * @var object
+     */
+    protected $attributes;
+
+    /**
+     * @var string The URL at which to fetch this model's information
+     */
+    protected $url;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        if (is_object($attributes)) {
+            $this->attributes = $this->parseAttributes($attributes);
+            if (isset($this->attributes->id)) {
+                $this->id = $this->attributes->id;
+            }
+        } else {
+            $this->attributes = (object)[];
+        }
+    }
+
+    /**
+     * Fetches this object from Pantheon
+     *
+     * @param array $args Params to pass to request
+     * @return TerminusModel $this
+     */
+    public function fetch(array $args = [])
+    {
+        $options = array_merge(
+            ['options' => ['method' => 'get',],],
+            $this->args,
+            $args
+        );
+        $results = $this->request->request($this->getUrl(), $options);
+        $this->attributes = (object)array_merge(
+            (array)$this->attributes,
+            (array)$this->parseAttributes($results['data'])
+        );
+
+        return $this;
+    }
+
+    /**
+     * Retrieves attribute of given name
+     *
+     * @param string $attribute Name of the key of the desired attribute
+     * @return mixed Value of the attribute, or null if not set.
+     */
+    public function get($attribute)
+    {
+        if ($this->has($attribute)) {
+            return $this->attributes->$attribute;
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether the model has an attribute
+     *
+     * @param string $attribute Name of the attribute key
+     * @return boolean True if attribute exists, false otherwise
+     */
+    public function has($attribute)
+    {
+        $isset = isset($this->attributes->$attribute);
+        return $isset;
+    }
+
+    /**
+     * Sets an attribute
+     *
+     * @param string $attribute Name of the attribute key
+     * @param mixed $value The value to assign to the attribute
+     */
+    public function set($attribute, $value)
+    {
+        $this->attributes->$attribute = $value;
+    }
+
+    /**
+     * Modify response data between fetch and assignment
+     *
+     * @param object $data attributes received from API response
+     * @return object $data
+     */
+    protected function parseAttributes($data)
+    {
+        return $data;
+    }
+
+    /**
+     * Get the URL for this model
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Collections\Instruments;
+use Pantheon\Terminus\Collections\MachineTokens;
+use Pantheon\Terminus\Collections\SshKeys;
+use Pantheon\Terminus\Collections\UserOrganizationMemberships;
+use Pantheon\Terminus\Collections\UserSiteMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+
+class User extends TerminusModel implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var \stdClass
+     * @todo Wrap this in a proper class.
+     */
+    protected $aliases;
+    /**
+     * @var Instruments
+     */
+    protected $instruments;
+    /**
+     * @var Instruments
+     */
+    protected $machine_tokens;
+    /**
+     * @var UserOrganizationMemberships
+     */
+    protected $org_memberships;
+    /**
+     * @var UserSiteMemberships
+     */
+    protected $site_memberships;
+    /**
+     * @var SshKeys
+     */
+    protected $ssh_keys;
+    /**
+     * @var Workflows
+     */
+    protected $workflows;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->url = "users/{$this->id}";
+    }
+
+    /**
+     * Retrieves organization data for this user
+     *
+     * @return Organization[]
+     */
+    public function getOrganizations()
+    {
+        $org_memberships = $this->getOrgMemberships()->all();
+        $organizations = array_combine(
+            array_map(
+                function ($membership) {
+                    return $membership->organization->id;
+                },
+                $org_memberships
+            ),
+            array_map(
+                function ($membership) {
+                    return $membership->organization;
+                },
+                $org_memberships
+            )
+        );
+        return $organizations;
+    }
+
+    /**
+     * Requests API data and returns an object of user site data
+     *
+     * @return Site[]
+     */
+    public function getSites()
+    {
+        $site_memberships = $this->getSiteMemberships()->all();
+        $sites = array_combine(
+            array_map(
+                function ($membership) {
+                    return $membership->site->id;
+                },
+                $site_memberships
+            ),
+            array_map(
+                function ($membership) {
+                    return $membership->site;
+                },
+                $site_memberships
+            )
+        );
+        return $sites;
+    }
+
+    /**
+     * Formats User object into an associative array for output
+     *
+     * @return array $data associative array of data for output
+     */
+    public function serialize()
+    {
+        $first_name = $last_name = null;
+        if (isset($this->get('profile')->firstname)) {
+            $first_name = $this->get('profile')->firstname;
+        }
+        if (isset($this->get('profile')->lastname)) {
+            $last_name = $this->get('profile')->lastname;
+        }
+
+        $data = [
+            'firstname' => $first_name,
+            'lastname' => $last_name,
+            'email' => $this->get('email'),
+            'id' => $this->id,
+        ];
+        return $data;
+    }
+
+    /**
+     * Retrieves Drush aliases for this user
+     *
+     * @return \stdClass
+     */
+    public function getAliases()
+    {
+        if (!$this->aliases) {
+            $this->fetchAliases();
+        }
+        return $this->aliases;
+    }
+
+    /**
+     * Requests API data and populates $this->aliases
+     *
+     * @return void
+     */
+    private function fetchAliases()
+    {
+        $path = "users/{$this->id}/drush_aliases";
+        $options = ['method' => 'get',];
+        $response = $this->request->request($path, $options);
+
+        $this->aliases = $response['data']->drush_aliases;
+    }
+
+    /**
+     * @return \Terminus\Collections\Instruments
+     */
+    public function getInstruments()
+    {
+        if (empty($this->instruments)) {
+            $this->instruments = $this->getContainer()->get(Instruments::class, [['user' => $this,]]);
+        }
+        return $this->instruments;
+    }
+
+    /**
+     * @return \Terminus\Collections\Instruments
+     */
+    public function getMachineTokens()
+    {
+        if (empty($this->machine_tokens)) {
+            $this->machine_tokens = $this->getContainer()->get(MachineTokens::class, [['user' => $this,]]);
+        }
+        return $this->machine_tokens;
+    }
+
+    /**
+     * @return \Terminus\Collections\UserOrganizationMemberships
+     */
+    public function getOrgMemberships()
+    {
+        if (empty($this->org_memberships)) {
+            $this->org_memberships = $this->getContainer()
+                ->get(UserOrganizationMemberships::class, [['user' => $this,]]);
+        }
+        return $this->org_memberships;
+    }
+
+    /**
+     * @return \Terminus\Collections\UserSiteMemberships
+     */
+    public function getSiteMemberships()
+    {
+        if (empty($this->site_memberships)) {
+            $this->site_memberships = $this->getContainer()->get(UserSiteMemberships::class, [['user' => $this,]]);
+        }
+        return $this->site_memberships;
+    }
+
+    /**
+     * @return \Terminus\Collections\SshKeys
+     */
+    public function getSshKeys()
+    {
+        if (empty($this->ssh_keys)) {
+            $this->ssh_keys = $this->getContainer()->get(SshKeys::class, [['user' => $this,]]);
+        }
+        return $this->ssh_keys;
+    }
+
+    /**
+     * @return \Terminus\Collections\Workflows
+     */
+    public function getWorkflows()
+    {
+        if (empty($this->workflows)) {
+            $this->workflows = $this->getContainer()->get(Workflows::class, [['user' => $this,]]);
+        }
+        return $this->workflows;
+    }
+}

--- a/src/Models/UserOrganizationMembership.php
+++ b/src/Models/UserOrganizationMembership.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Terminus\Models\Organization;
+
+class UserOrganizationMembership extends TerminusModel
+{
+    /**
+     * @var Organization
+     */
+    public $organization;
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->user = $options['collection']->getUser();
+        // @TODO: Follow this dependency chain and invert it.
+        $this->organization = new Organization($attributes->organization);
+        $this->organization->memberships = [$this,];
+    }
+}

--- a/src/Models/UserSiteMembership.php
+++ b/src/Models/UserSiteMembership.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Terminus\Models\Site;
+
+class UserSiteMembership extends TerminusModel
+{
+    /**
+     * @var Site
+     */
+    public $site;
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        // @TODO: Follow this dependency chain and invert it.
+        $this->site = new Site($attributes->site);
+        $this->site->memberships = [$this,];
+        $this->user = $options['collection']->getUser();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        return "{$this->user->id}: Team";
+    }
+}

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Session\SessionAwareTrait;
+use Terminus\Exceptions\TerminusException;
+use Terminus\Session;
+
+class Workflow extends TerminusModel implements ContainerAwareInterface, SessionAwareInterface
+{
+    use ContainerAwareTrait;
+    use SessionAwareTrait;
+
+    /**
+     * @var mixed
+     */
+    protected $owner;
+
+    /**
+     * @var Environment
+     */
+    private $environment;
+    /**
+     * @var Organization
+     */
+    private $organization;
+    /**
+     * @var Site
+     */
+    private $site;
+    /**
+     * @var User
+     */
+    private $user;
+
+    // @TODO: Make this configurable.
+    const POLLING_PERIOD = 3;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     * @return Workflow
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->owner = null;
+        if (isset($options['collection'])) {
+            $this->owner = $options['collection']->getOwnerObject();
+        } elseif (isset($options['environment'])) {
+            $this->owner = $options['environment'];
+        } elseif (isset($options['organization'])) {
+            $this->owner = $options['organization'];
+        } elseif (isset($options['site'])) {
+            $this->owner = $options['site'];
+        } elseif (isset($options['user'])) {
+            $this->owner = $options['user'];
+        }
+    }
+
+    /**
+     * Get the URL for this model
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        if (!empty($this->url)) {
+            return $this->url;
+        }
+
+        // Determine the url based on the workflow owner.
+        switch (get_class($this->owner)) {
+            case 'Terminus\Models\Environment':
+                $this->environment = $this->owner;
+                $this->url = sprintf(
+                    'sites/%s/workflows/%s',
+                    $this->environment->site->id,
+                    $this->id
+                );
+                break;
+            case 'Terminus\Models\Organization':
+                $this->organization = $this->owner;
+                $this->url = sprintf(
+                    'users/%s/organizations/%s/workflows/%s',
+                    // @TODO: This should be passed in rather than read from the current session.
+                    $this->session()->getUser()->id,
+                    $this->organization->id,
+                    $this->id
+                );
+                break;
+            case 'Terminus\Models\Site':
+                $this->site = $this->owner;
+                $this->url = sprintf(
+                    'sites/%s/workflows/%s',
+                    $this->site->id,
+                    $this->id
+                );
+                break;
+            case 'Pantheon\Terminus\Models\User':
+                $this->user = $this->owner;
+                $this->url = sprintf(
+                    'users/%s/workflows/%s',
+                    $this->user->id,
+                    $this->id
+                );
+                break;
+        }
+        return $this->url;
+    }
+
+    /**
+     * Re-fetches workflow data hydrated with logs
+     *
+     * @return Workflow
+     */
+    public function fetchWithLogs()
+    {
+        $options = ['query' => ['hydrate' => 'operations_with_logs',],];
+        $this->fetch($options);
+        return $this;
+    }
+
+    /**
+     * Returns the status of this workflow
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        $status = 'running';
+        if ($this->isFinished()) {
+            $status = 'failed';
+            if ($this->isSuccessful()) {
+                $status = 'succeeded';
+            }
+        }
+        return $status;
+    }
+
+    /**
+     * Detects if the workflow has finished
+     *
+     * @return bool True if workflow has finished
+     */
+    public function isFinished()
+    {
+        $is_finished = (boolean)$this->get('result');
+        return $is_finished;
+    }
+
+    /**
+     * Detects if the workflow was successful
+     *
+     * @return bool True if workflow succeeded
+     */
+    public function isSuccessful()
+    {
+        $is_successful = ($this->get('result') == 'succeeded');
+        return $is_successful;
+    }
+
+    /**
+     * Returns a list of WorkflowOperations for this workflow
+     *
+     * @return WorkflowOperation[]
+     */
+    public function operations()
+    {
+        if (is_array($this->get('operations'))) {
+            $operations_data = $this->get('operations');
+        } else {
+            $operations_data = [];
+        }
+
+        $operations = [];
+        foreach ($operations_data as $operation_data) {
+            $operations[] = $this->getContainer()->get(WorkflowOperation::class, [$operation_data]);
+        }
+
+        return $operations;
+    }
+
+    /**
+     * Formats workflow object into an associative array for output
+     *
+     * @return array Associative array of data for output
+     */
+    public function serialize()
+    {
+        $user = 'Pantheon';
+        if (isset($this->get('user')->email)) {
+            $user = $this->get('user')->email;
+        }
+        if ($this->get('total_time')) {
+            $elapsed_time = $this->get('total_time');
+        } else {
+            $elapsed_time = time() - $this->get('created_at');
+        }
+
+        $operations_data = [];
+        foreach ($this->operations() as $operation) {
+            $operations_data[] = $operation->serialize();
+        }
+
+        $data = [
+            'id' => $this->id,
+            'env' => $this->get('environment'),
+            'workflow' => $this->get('description'),
+            'user' => $user,
+            'status' => $this->getStatus(),
+            'time' => sprintf("%ds", $elapsed_time),
+            'operations' => $operations_data,
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Waits on this workflow to finish
+     *
+     * @return Workflow|void
+     * @throws TerminusException
+     */
+    public function wait()
+    {
+        while (!$this->isFinished()) {
+            $this->fetch();
+            sleep(3);
+            /**
+             * TODO: Output this to stdout so that it doesn't get mixed with any
+             *   actual output. We can't use the logger here because that might be
+             *   redirected to a log file where each line is timestamped.
+             */
+            fwrite(STDERR, '.');
+        }
+        echo "\n";
+        if ($this->isSuccessful()) {
+            return $this;
+        } else {
+            $final_task = $this->get('final_task');
+            if (($final_task != null) && !empty($final_task->messages)) {
+                foreach ($final_task->messages as $data => $message) {
+                    if (!is_string($message->message)) {
+                        $message->message = print_r($message->message, true);
+                    }
+                    throw new TerminusException((string)$message->message);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check on the progress of a workflow. This can be called repeatedly and will apply a polling
+     * period to prevent flooding the API with requests.
+     *
+     * @return bool Whether the workflow is finished or not
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function checkProgress()
+    {
+        // Fetch the workflow status from the API.
+        $this->poll();
+
+        if ($this->isFinished()) {
+            // If the workflow failed then figure out the correct output message and throw an exception.
+            if (!$this->isSuccessful()) {
+                throw new TerminusException($this->getMessage());
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the success message of a workflow or throw an exception of the workflow failed.
+     *
+     * @return string The message to output to the user
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function getMessage()
+    {
+        if (!$this->isSuccessful()) {
+            $message = 'Workflow failed.';
+            $final_task = $this->get('final_task');
+            if (!empty($final_task) && !empty($final_task->reason)) {
+                $message = $final_task->reason;
+            } elseif (!empty($final_task) && !empty($final_task->messages)) {
+                foreach ($final_task->messages as $data => $message) {
+                    if (!is_string($message->message)) {
+                        $message = print_r($message->message, true);
+                    } else {
+                        $message = $message->message;
+                    }
+                }
+            }
+        } else {
+            $message = $this->get('active_description');
+        }
+
+        return $message;
+    }
+
+    /**
+     * Fetches this object from Pantheon. Waits a given length of time between checks.
+     *
+     * @return void
+     */
+    private function poll()
+    {
+        static $last_check = 0;
+
+        // Poll for the workflow status. Don't check more often than the polling period
+        $now = time();
+        if ($last_check + Workflow::POLLING_PERIOD <= $now) {
+            $this->fetch();
+            $last_check = $now;
+        }
+    }
+}

--- a/src/Models/WorkflowOperation.php
+++ b/src/Models/WorkflowOperation.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+class WorkflowOperation extends TerminusModel
+{
+
+    /**
+     * Formats operation object into an associative array for output
+     *
+     * @return array
+     */
+    public function serialize()
+    {
+        $data = [
+            'id' => $this->id,
+            'type' => $this->get('type'),
+            'description' => $this->get('description'),
+            'result' => $this->get('result'),
+            'duration' => $this->duration(),
+        ];
+
+        if ($this->has('log_output')) {
+            $data['log_output'] = $this->get('log_output');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Formats operation object into a descriptive string
+     *
+     * @return string
+     */
+    public function description()
+    {
+        $description = sprintf(
+            'Operation: %s finished in %s',
+            $this->get('description'),
+            $this->duration()
+        );
+        return $description;
+    }
+
+    /**
+     * Formats operation duration into a string
+     *
+     * @return string
+     */
+    protected function duration()
+    {
+        if ($this->has('run_time')) {
+            $duration = sprintf('%ss', round($this->get('run_time')));
+        } else {
+            $duration = null;
+        }
+        return $duration;
+    }
+}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -5,6 +5,21 @@ namespace Pantheon\Terminus;
 use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use League\Container\Container;
 use League\Container\ContainerInterface;
+use Pantheon\Terminus\Collections\Instruments;
+use Pantheon\Terminus\Collections\MachineTokens;
+use Pantheon\Terminus\Collections\SavedTokens;
+use Pantheon\Terminus\Collections\SshKeys;
+use Pantheon\Terminus\Collections\UserOrganizationMemberships;
+use Pantheon\Terminus\Collections\UserSiteMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Instrument;
+use Pantheon\Terminus\Models\MachineToken;
+use Pantheon\Terminus\Models\SavedToken;
+use Pantheon\Terminus\Models\SshKey;
+use Pantheon\Terminus\Models\UserOrganizationMembership;
+use Pantheon\Terminus\Models\UserSiteMembership;
+use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\Models\WorkflowOperation;
 use Pantheon\Terminus\Request\Request;
 use Pantheon\Terminus\Request\RequestAwareInterface;
 use Pantheon\Terminus\Session\Session;
@@ -15,7 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Terminus\Caches\FileCache;
 use Terminus\Collections\Sites;
-use Terminus\Models\User;
+use Pantheon\Terminus\Models\User;
 use VCR\VCR;
 
 class Runner
@@ -101,15 +116,29 @@ class Runner
         $container->inflector(SessionAwareInterface::class)
             ->invokeMethod('setSession', ['session']);
 
-        // Add the models.
+        // Add the models and collections
         $container->add(User::class);
+        $container->add(SavedTokens::class);
+        $container->add(SavedToken::class);
+        $container->add(Instruments::class);
+        $container->add(Instrument::class);
+        $container->add(SshKeys::class);
+        $container->add(SshKey::class);
+        $container->add(Workflows::class);
+        $container->add(Workflow::class);
+        $container->add(WorkflowOperation::class);
+        $container->add(MachineTokens::class);
+        $container->add(MachineToken::class);
+        $container->add(UserSiteMemberships::class);
+        $container->add(UserSiteMembership::class);
+        $container->add(UserOrganizationMemberships::class);
+        $container->add(UserOrganizationMembership::class);
 
-        // Add the collections.
         $container->share('sites', Sites::class);
         $container->inflector(SiteAwareInterface::class)
             ->invokeMethod('setSites', ['sites']);
 
-        // TODO: Add 21 more models and 18 collections :)
+        // TODO: Add more models and collections
 
         // Add the commands.
         $factory = $container->get('commandFactory');

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -9,7 +9,7 @@ use Robo\Common\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Terminus\Caches\FileCache;
 use Terminus\Exceptions\TerminusException;
-use Terminus\Models\User;
+use Pantheon\Terminus\Models\User;
 
 class Session implements ContainerAwareInterface, ConfigAwareInterface
 {
@@ -38,7 +38,6 @@ class Session implements ContainerAwareInterface, ConfigAwareInterface
     {
         $this->cache = $file_cache;
         $this->data = (object)$this->cache->getData('session');
-        $this->tokens = new SavedTokens(['session' => $this,]);
     }
 
     /**
@@ -62,12 +61,12 @@ class Session implements ContainerAwareInterface, ConfigAwareInterface
         if (isset($this->data->$key)) {
             return $this->data->$key;
         }
-        throw new TerminusException('The {key} property cannot be found in the cache data.', compact('key'));
+        return null;
     }
 
     /**
      * Returns a user with the current session user id
-     * @return \Terminus\Models\User [user] $session user
+     * @return \Pantheon\Terminus\Models\User [user] $session user
      */
     public function getUser()
     {
@@ -98,5 +97,16 @@ class Session implements ContainerAwareInterface, ConfigAwareInterface
     {
         $this->cache->putData('session', $data);
         $this->data = (object)$data;
+    }
+
+    /**
+     * @return \Pantheon\Terminus\Collections\SavedTokens
+     */
+    public function getTokens()
+    {
+        if (empty($this->tokens)) {
+            $this->tokens = $this->getContainer()->get(SavedTokens::class, [['session' => $this,]]);
+        }
+        return $this->tokens;
     }
 }

--- a/tests/unit_tests/new/Collection/CollectionTestCase.php
+++ b/tests/unit_tests/new/Collection/CollectionTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+use League\Container\Container;
+use Pantheon\Terminus\Request\Request;
+
+class CollectionTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected $request;
+    protected $container;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/unit_tests/new/Collection/InstrumentsTest.php
+++ b/tests/unit_tests/new/Collection/InstrumentsTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+class InstrumentsTest extends UserOwnedCollectionTest
+{
+    protected $url = 'users/USERID/instruments';
+    protected $class = 'Pantheon\Terminus\Collections\Instruments';
+}

--- a/tests/unit_tests/new/Collection/MachineTokensTest.php
+++ b/tests/unit_tests/new/Collection/MachineTokensTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+class MachineTokensTest extends UserOwnedCollectionTest
+{
+    protected $url = 'users/USERID/machine_tokens';
+    protected $class = 'Pantheon\Terminus\Collections\MachineTokens';
+}

--- a/tests/unit_tests/new/Collection/SshKeysTest.php
+++ b/tests/unit_tests/new/Collection/SshKeysTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+use Pantheon\Terminus\Models\SshKey;
+use Terminus\Exceptions\TerminusException;
+
+class SshKeysTest extends UserOwnedCollectionTest
+{
+    protected $url = 'users/USERID/keys';
+    protected $class = 'Pantheon\Terminus\Collections\SshKeys';
+
+    public function testAddKey()
+    {
+        $key = 'ssh-rsa AAAAB3xxx0uj+Q== dev@example.com';
+        $file = tempnam(sys_get_temp_dir(), 'sshkey_');
+        file_put_contents($file, $key . "\n");
+
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with(
+                $this->url,
+                [
+                    'form_params' => $key,
+                    'method' => 'post',
+                ]
+            );
+        $this->collection->addKey($file);
+        unlink($file);
+
+        $this->setExpectedException(TerminusException::class);
+        $this->collection->addKey($file);
+    }
+
+    public function testDeleteAll()
+    {
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with($this->url, ['method' => 'delete']);
+
+        $this->collection->deleteAll();
+    }
+    
+    public function testFetch()
+    {
+        $data = [
+            'a' => 'ssh-rsa AAAAB3xxx0uj+Q== dev@example.com',
+            'b' => 'ssh-rsa AAAAB3xxx000+Q== dev2@example.com',
+        ];
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with($this->url, ['options' => ['method' => 'get']])
+            ->willReturn(['data' => $data]);
+
+
+        $i = 0;
+        $models = [];
+        $options = ['collection' => $this->collection];
+        foreach ($data as $id => $key) {
+            $options['id'] = $id;
+            $model_data = (object)['id' => $id, 'key' => $key];
+            $model = $models[$i] = new SshKey($model_data, $options);
+            $this->container->expects($this->at($i++))
+                ->method('get')
+                ->with(SshKey::class, [$model_data, $options])
+                ->willReturn($model);
+        }
+
+        $this->collection->fetch();
+        $this->assertEquals($models, $this->collection->all());
+    }
+}

--- a/tests/unit_tests/new/Collection/TerminusCollectionTest.php
+++ b/tests/unit_tests/new/Collection/TerminusCollectionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+use Pantheon\Terminus\Collections\TerminusCollection;
+use Pantheon\Terminus\Models\TerminusModel;
+
+class TerminusCollectionTest extends CollectionTestCase
+{
+    public function testAdd()
+    {
+        $collection = $this->getMockForAbstractClass(TerminusCollection::class);
+
+        $model_data = (object)[
+            'id' => '123',
+            'foo' => 'bar',
+        ];
+        $options = [
+            'id' => '123',
+            'collection' => $collection,
+            'baz' => 'boo'
+        ];
+        $model = $this->getMockForAbstractClass(TerminusModel::class, [$model_data, $options]);
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with(TerminusModel::class, [$model_data, $options])
+            ->willReturn($model);
+
+        $collection->setContainer($this->container);
+        $out = $collection->add($model_data, ['baz' => 'boo']);
+        $this->assertEquals($model, $out);
+    }
+
+    public function testFetch()
+    {
+        $data = [
+            'a' => (object)['id' => 'a', 'foo' => '123', 'category' => 'a'],
+            'b' => (object)['id' => 'b', 'foo' => '456', 'category' => 'a'],
+            'c' => (object)['id' => 'c', 'foo' => '678', 'category' => 'b']
+        ];
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with('TESTURL', ['options' => ['method' => 'get']])
+            ->willReturn(['data' => $data]);
+
+        $collection = $this->getMockBuilder(TerminusCollection::class)
+            ->setMethods(['getUrl'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUrl')
+            ->willReturn('TESTURL');
+
+        $models = [];
+        $options = ['collection' => $collection];
+        $i = 0;
+        foreach ($data as $key => $model_data) {
+            $models[$model_data->id] = $this->getMockForAbstractClass(TerminusModel::class, [$model_data, $options]);
+            $options['id'] = $model_data->id;
+            $this->container->expects($this->at($i++))
+                ->method('get')
+                ->with(TerminusModel::class, [$model_data, $options])
+                ->willReturn($models[$key]);
+        }
+
+        $collection->setRequest($this->request);
+        $collection->setContainer($this->container);
+
+        $collection->fetch();
+
+        $this->assertEquals(array_keys($models), $collection->ids());
+        $this->assertEquals(array_values($models), $collection->all());
+        foreach ($models as $id => $model) {
+            $this->assertEquals($model, $collection->get($id));
+        }
+
+        $listing = [
+            'a' => '123',
+            'b' => '456',
+            'c' => '678',
+        ];
+        $this->assertEquals($listing, $collection->listing('id', 'foo'));
+        $this->assertEquals($listing, $collection->getMemberList('id', 'foo'));
+
+        $listing = [
+            'a' => '123',
+            'b' => '456',
+        ];
+        $this->assertEquals($listing, $collection->getFilteredMemberList(['category' => 'a'], 'id', 'foo'));
+        $listing = [
+            'c' => '678',
+        ];
+        $this->assertEquals($listing, $collection->getFilteredMemberList(['category' => 'b'], 'id', 'foo'));
+    }
+}

--- a/tests/unit_tests/new/Collection/UserOrganizationMembershipTest.php
+++ b/tests/unit_tests/new/Collection/UserOrganizationMembershipTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+class UserOrganizationMembershipTest extends UserOwnedCollectionTest
+{
+    protected $url = 'users/USERID/memberships/organizations';
+    protected $class = 'Pantheon\Terminus\Collections\UserOrganizationMemberships';
+}

--- a/tests/unit_tests/new/Collection/UserOwnedCollectionTest.php
+++ b/tests/unit_tests/new/Collection/UserOwnedCollectionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+use Pantheon\Terminus\Collections\UserOwnedCollection;
+use Pantheon\Terminus\Models\User;
+
+class UserOwnedCollectionTest extends CollectionTestCase
+{
+    protected $url = null;
+    protected $class = 'Pantheon\Terminus\Collections\UserOwnedCollection';
+
+    protected $collection;
+
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $user = new User((object)['id' => 'USERID']);
+        $this->collection = new $this->class(['user' => $user]);
+        $this->collection->setRequest($this->request);
+        $this->collection->setContainer($this->container);
+    }
+
+    public function testGetURL()
+    {
+        $this->assertEquals($this->url, $this->collection->getUrl());
+    }
+}

--- a/tests/unit_tests/new/Collection/UserSiteMembershipsTest.php
+++ b/tests/unit_tests/new/Collection/UserSiteMembershipsTest.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collection;
+
+class UserSiteMembershipsTest extends UserOwnedCollectionTest
+{
+    protected $url = 'users/USERID/memberships/sites';
+    protected $class = 'Pantheon\Terminus\Collections\UserSiteMemberships';
+}

--- a/tests/unit_tests/new/Commands/Auth/LoginCommandTest.php
+++ b/tests/unit_tests/new/Commands/Auth/LoginCommandTest.php
@@ -8,6 +8,7 @@ use Pantheon\Terminus\Models\SavedToken;
 
 class LoginCommandTest extends AuthTest
 {
+    protected $tokens;
     /**
      * @var SavedToken
      */
@@ -23,10 +24,18 @@ class LoginCommandTest extends AuthTest
         $this->token = $this->getMockBuilder(SavedToken::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->token->session = $this->session;
-        $this->session->tokens = $this->getMockBuilder(SavedTokens::class)
+
+        $this->token->expects($this->any())
+            ->method('session')
+            ->willReturn($this->session);
+
+        $this->tokens = $this->getMockBuilder(SavedTokens::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->session->expects($this->any())
+            ->method('getTokens')
+            ->willReturn($this->tokens);
 
         $this->command = new LoginCommand();
         $this->command->setConfig($this->config);
@@ -41,7 +50,7 @@ class LoginCommandTest extends AuthTest
     {
         $token_string = 'token_string';
 
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('get')
             ->with($this->equalTo($token_string))
             ->will($this->throwException(new \Exception));
@@ -51,7 +60,7 @@ class LoginCommandTest extends AuthTest
                 $this->equalTo('notice'),
                 $this->equalTo('Logging in via machine token.')
             );
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('create')
             ->with($this->equalTo($token_string));
 
@@ -66,7 +75,7 @@ class LoginCommandTest extends AuthTest
     {
         $email = "email@ddr.ess";
 
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('get')
             ->with($this->equalTo($email))
             ->willReturn($this->token);
@@ -91,7 +100,7 @@ class LoginCommandTest extends AuthTest
     {
         $email = "email@ddr.ess";
 
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('all')
             ->with()
             ->willReturn([$this->token,]);
@@ -127,7 +136,7 @@ class LoginCommandTest extends AuthTest
      */
     public function testCannotLogInWithoutTokens()
     {
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('all')->willReturn([]);
 
         $out = $this->command->logIn();
@@ -142,10 +151,10 @@ class LoginCommandTest extends AuthTest
      */
     public function testCannotLogInWithoutIndicatingWhichToken()
     {
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('all')
             ->willReturn([$this->token, $this->token,]);
-        $this->session->tokens->expects($this->once())
+        $this->tokens->expects($this->once())
             ->method('ids')
             ->willReturn(['token1', 'token2',]);
 

--- a/tests/unit_tests/new/Commands/MachineToken/MachineTokenCommandTest.php
+++ b/tests/unit_tests/new/Commands/MachineToken/MachineTokenCommandTest.php
@@ -8,11 +8,12 @@
 namespace Pantheon\Terminus\UnitTests\Commands\Auth;
 
 use Pantheon\Terminus\Session\Session;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 use Psr\Log\NullLogger;
 use Terminus\Collections\MachineTokens;
-use Terminus\Models\User;
+use Pantheon\Terminus\Models\User;
 
-abstract class MachineTokenCommandTest extends \PHPUnit_Framework_TestCase
+abstract class MachineTokenCommandTest extends CommandTestCase
 {
     protected $session;
     protected $machine_tokens;
@@ -33,7 +34,10 @@ abstract class MachineTokenCommandTest extends \PHPUnit_Framework_TestCase
         $this->user = $this->getMockBuilder(User::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user->machine_tokens = $this->machine_tokens;
+
+        $this->user->expects($this->any())
+            ->method('getMachineTokens')
+            ->willReturn($this->machine_tokens);
 
         $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/new/Commands/SSHKeys/SSHKeysCommandTest.php
+++ b/tests/unit_tests/new/Commands/SSHKeys/SSHKeysCommandTest.php
@@ -3,9 +3,8 @@
 namespace Pantheon\Terminus\UnitTests\Commands;
 
 use Pantheon\Terminus\Session\Session;
-use Psr\Log\NullLogger;
 use Terminus\Collections\SshKeys;
-use Terminus\Models\User;
+use Pantheon\Terminus\Models\User;
 
 /**
  * @property \PHPUnit_Framework_MockObject_MockObject ssh_keys
@@ -33,7 +32,10 @@ abstract class SSHKeysCommandTest extends CommandTestCase
         $this->user = $this->getMockBuilder(User::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user->ssh_keys = $this->ssh_keys;
+
+        $this->user->expects($this->any())
+            ->method('getSshKeys')
+            ->willReturn($this->ssh_keys);
 
         $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/new/Commands/SSHKeys/SSHKeysDeleteCommandTest.php
+++ b/tests/unit_tests/new/Commands/SSHKeys/SSHKeysDeleteCommandTest.php
@@ -103,8 +103,7 @@ class SSHKeysDeleteCommandTest extends SSHKeysCommandTest
             ->willReturn(
                 $token
             );
-
-
+        
         $this->setExpectedException(
             \Exception::class,
             'There was an problem deleting the SSH key.'

--- a/tests/unit_tests/new/Model/MachineTokenTest.php
+++ b/tests/unit_tests/new/Model/MachineTokenTest.php
@@ -1,0 +1,56 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Collections\MachineTokens;
+use Pantheon\Terminus\Models\MachineToken;
+use Pantheon\Terminus\Request\Request;
+use Terminus\Exceptions\TerminusException;
+
+class MachineTokenTest extends ModelTestCase
+{
+    public function testDelete()
+    {
+        $collection = $this->getMockBuilder(MachineTokens::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUser')
+            ->willReturn((object)['id' => '123']);
+
+        $mt = new MachineToken((object)['id' => '456'], ['collection' => $collection]);
+
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with("users/123/machine_tokens/456", ['method' => 'delete'])
+            ->willReturn(['status_code' => 200]);
+
+        $mt->setRequest($this->request);
+
+        $mt->delete();
+    }
+
+    public function testDeleteFail()
+    {
+        $collection = $this->getMockBuilder(MachineTokens::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUser')
+            ->willReturn((object)['id' => '123']);
+
+        $mt = new MachineToken((object)['id' => '456'], ['collection' => $collection]);
+
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with("users/123/machine_tokens/456", ['method' => 'delete'])
+            ->willReturn(['status_code' => 404]);
+
+        $mt->setRequest($this->request);
+
+        $this->setExpectedException(TerminusException::class);
+        
+        $mt->delete();
+    }
+}

--- a/tests/unit_tests/new/Model/ModelTestCase.php
+++ b/tests/unit_tests/new/Model/ModelTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Request\Request;
+
+class ModelTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/unit_tests/new/Model/SavedTokenTest.php
+++ b/tests/unit_tests/new/Model/SavedTokenTest.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Config;
+use Pantheon\Terminus\Models\SavedToken;
+use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Session\Session;
+
+class SavedTokenTest extends ModelTestCase
+{
+
+    public function testConstuct()
+    {
+        $token = new SavedToken((object)['email' => 'dev@example.com']);
+        $this->assertEquals('dev@example.com', $token->id);
+    }
+
+
+    public function testLogIn()
+    {
+        $token = new SavedToken((object)['token' => '123']);
+
+        $session_data = ['session' => '123', 'expires_at' => 12345];
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with('authorize/machine-token', [
+                'form_params' => ['machine_token' => '123', 'client' => 'terminus',],
+                'method' => 'post',
+            ])
+            ->willReturn(['data' => (object)$session_data]);
+
+        $session = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $session->expects($this->once())
+            ->method('setData')
+            ->with($session_data);
+
+        $user = new User();
+        $session->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $token->setRequest($this->request);
+        $token->setSession($session);
+        $out = $token->logIn();
+        $this->assertEquals($user, $out);
+    }
+
+    public function testSaveToDir()
+    {
+        // Create a temp directory to write to.
+        // @TODO: Separate file writing so that this test can be run without writing to disk.
+        $dir = tempnam(sys_get_temp_dir(), 'savedtoken_');
+        unlink($dir);
+        mkdir($dir);
+
+        $attributes = ['email' => 'dev@example.com', 'token' => '123'];
+        $token = new SavedToken((object)$attributes);
+
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $config->expects($this->once())
+            ->method('get')
+            ->with('tokens_dir')
+            ->willReturn($dir);
+
+        $token->setConfig($config);
+
+        $token->saveToDir();
+        $file = "$dir/dev@example.com";
+        $this->assertFileExists($file);
+        $file_attributes = json_decode(file_get_contents($file));
+        foreach ($attributes as $key => $val) {
+            $this->assertEquals($val, $file_attributes->{$key}, 'Mismatch on key ' . $key);
+        }
+
+        // Clean up
+        unlink($file);
+        rmdir($dir);
+    }
+}

--- a/tests/unit_tests/new/Model/SshKeyTest.php
+++ b/tests/unit_tests/new/Model/SshKeyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Collections\SshKeys;
+use Pantheon\Terminus\Models\SshKey;
+use Terminus\Exceptions\TerminusException;
+
+class SshKeyTest extends ModelTestCase
+{
+    public function testDelete()
+    {
+        $collection = $this->getMockBuilder(SshKeys::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUser')
+            ->willReturn((object)['id' => '123']);
+        $sshkey = new SshKey((object)['id' => '456'], ['collection' => $collection]);
+
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with("users/123/keys/456", ['method' => 'delete'])
+            ->willReturn(['status_code' => 200]);
+
+        $sshkey->setRequest($this->request);
+
+        $sshkey->delete();
+    }
+
+    public function testDeleteFail()
+    {
+        $collection = $this->getMockBuilder(SshKeys::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUser')
+            ->willReturn((object)['id' => '123']);
+        $sshkey = new SshKey((object)['id' => '456'], ['collection' => $collection]);
+
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with("users/123/keys/456", ['method' => 'delete'])
+            ->willReturn(['status_code' => 404]);
+
+        $sshkey->setRequest($this->request);
+
+        $this->setExpectedException(TerminusException::class);
+
+        $sshkey->delete();
+    }
+
+    public function testGetCommentHex()
+    {
+        $collection = $this->getMockBuilder(SshKeys::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->once())
+            ->method('getUser')
+            ->willReturn((object)['id' => '123']);
+        $sshkey = new SshKey(
+            (object)[
+                'id' => '1234567890abcdef',
+                'key' => 'ssh-rsa AAAAB3xxx0uj+Q== dev@example.com'
+            ],
+            ['collection' => $collection]
+        );
+
+        $this->assertEquals('12:34:56:78:90:ab:cd:ef', $sshkey->getHex());
+        $this->assertEquals('dev@example.com', $sshkey->getComment());
+    }
+}

--- a/tests/unit_tests/new/Model/TerminusModelTest.php
+++ b/tests/unit_tests/new/Model/TerminusModelTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Models\TerminusModel;
+use Pantheon\Terminus\Request\Request;
+
+class TerminusModelTest extends ModelTestCase
+{
+    public function testConstructGetSet()
+    {
+        $model = $this->getMockForAbstractClass(TerminusModel::class, [(object)['id' => '123', 'foo' => 'bar']]);
+
+        $this->assertEquals('123', $model->id);
+        $this->assertTrue($model->has('foo'));
+        $this->assertEquals('bar', $model->get('foo'));
+        $this->assertFalse($model->has('baz'));
+        $model->set('baz', 'abc');
+        $this->assertTrue($model->has('baz'));
+        $this->assertEquals('abc', $model->get('baz'));
+        $this->assertEquals('bar', $model->get('foo'));
+    }
+
+    public function testFetch()
+    {
+        $model = $this->getMockBuilder(TerminusModel::class)
+            ->setMethods(['getUrl'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $model->expects($this->once())
+            ->method('getUrl')
+            ->willReturn('TESTURL');
+        
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with('TESTURL', ['options' => ['method' => 'get',], 'foo' => 'bar'])
+            ->willReturn(['data' => ['baz' => '123']]);
+
+        $model->setRequest($this->request);
+
+        $model->fetch(['foo' => 'bar']);
+    }
+}

--- a/tests/unit_tests/new/Model/UserTest.php
+++ b/tests/unit_tests/new/Model/UserTest.php
@@ -1,0 +1,184 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use League\Container\Container;
+use Pantheon\Terminus\Collections\Instruments;
+use Pantheon\Terminus\Collections\MachineTokens;
+use Pantheon\Terminus\Collections\SshKeys;
+use Pantheon\Terminus\Collections\UserOrganizationMemberships;
+use Pantheon\Terminus\Collections\UserSiteMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\User;
+use Robo\Collection\Collection;
+
+class UserTest extends ModelTestCase
+{
+    /**
+     * @var User
+     */
+    protected $user;
+    protected $user_data;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user_data = [
+            'id' => '123',
+            'email' => 'dev@example.com',
+            'profile' => (object)[
+                'firstname' => 'Peter',
+                'lastname' => 'Pantheor',
+            ]
+        ];
+        $this->user = new User((object)$this->user_data);
+        $this->user->setRequest($this->request);
+    }
+
+    public function testGetAliases()
+    {
+
+        $aliases = ['foo', 'bar'];
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with("users/123/drush_aliases", ['method' => 'get'])
+            ->willReturn(['data' => (object)['drush_aliases' => $aliases]]);
+
+        $out = $this->user->getAliases();
+        $this->assertEquals($aliases, $out);
+        // Confirm that it returns the same output twice without calling to the API twice.
+        $this->assertEquals($aliases, $this->user->getAliases());
+    }
+
+    public function testGetSubCollections()
+    {
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $classes = [
+            Instruments::class,
+            MachineTokens::class,
+            UserOrganizationMemberships::class,
+            UserSiteMemberships::class,
+            SshKeys::class,
+            Workflows::class
+        ];
+        foreach ($classes as $i => $class) {
+            $container->expects($this->at($i))
+                ->method('get')
+                ->with($class, [['user' => $this->user]])
+                ->willReturn(new $class(['user' => $this->user]));
+        }
+
+        $this->user->setContainer($container);
+
+        $this->user->getInstruments();
+        $this->user->getMachineTokens();
+        $this->user->getOrgMemberships();
+        $this->user->getSiteMemberships();
+        $this->user->getSshKeys();
+        $this->user->getWorkflows();
+    }
+
+    public function testSerialize()
+    {
+        $expected = array_merge($this->user_data, (array)$this->user_data['profile']);
+        unset($expected['profile']);
+
+        $data = $this->user->serialize();
+        $this->assertEquals($expected, $data);
+    }
+
+    public function testGetSites()
+    {
+        $memberships = [
+            (object)[
+                'id' => '1',
+                'site' => (object)[
+                    'id' => 'site1',
+                    'other' => 'abc'
+                ]
+            ],
+            (object)[
+                'id' => '2',
+                'site' => (object)[
+                    'id' => 'site2',
+                    'other' => 'cdf'
+                ]
+            ]
+        ];
+        $sites = [
+            'site1' => $memberships[0]->site,
+            'site2' => $memberships[1]->site
+        ];
+
+        $sitememberships = $this->getMockBuilder(UserSiteMemberships::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sitememberships->expects($this->once())
+            ->method('all')
+            ->willReturn($memberships);
+
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('get')
+            ->with(UserSiteMemberships::class, [['user' => $this->user]])
+            ->willReturn($sitememberships);
+
+        $this->user->setContainer($container);
+
+        $this->assertEquals($sites, $this->user->getSites());
+    }
+
+    public function testGetOrgs()
+    {
+        $memberships = [
+            (object)[
+                'id' => '1',
+                'organization' => (object)[
+                    'id' => 'org1',
+                    'other' => 'abc'
+                ]
+            ],
+            (object)[
+                'id' => '2',
+                'organization' => (object)[
+                    'id' => 'org2',
+                    'other' => 'cdf'
+                ]
+            ]
+        ];
+        $orgs = [
+            'org1' => $memberships[0]->organization,
+            'org2' => $memberships[1]->organization
+        ];
+
+        $orgmemberships = $this->getMockBuilder(UserOrganizationMemberships::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $orgmemberships ->expects($this->once())
+            ->method('all')
+            ->willReturn($memberships);
+
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('get')
+            ->with(UserOrganizationMemberships::class, [['user' => $this->user]])
+            ->willReturn($orgmemberships);
+
+        $this->user->setContainer($container);
+
+        $this->assertEquals($orgs, $this->user->getOrganizations());
+    }
+}

--- a/tests/unit_tests/new/Model/WorkflowOperationTest.php
+++ b/tests/unit_tests/new/Model/WorkflowOperationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use Pantheon\Terminus\Models\WorkflowOperation;
+
+class WorkflowOperationTest extends ModelTestCase
+{
+    public function testDescription()
+    {
+        $wfop = new WorkflowOperation((object)['description' => 'Dumbo Drop', 'run_time' => 1.2345]);
+
+        $this->assertEquals("Operation: Dumbo Drop finished in 1s", $wfop->description());
+    }
+
+    public function testSerialize()
+    {
+        $data = [
+            'id' => '123',
+            'description' => 'Dumbo Drop',
+            'run_time' => 1.2345,
+            'type' => 'platform',
+            'result' => 'success',
+            'log_output' => 'The operation was a total success',
+            'other' => 'something else',
+        ];
+        $wfop = new WorkflowOperation((object)$data);
+
+        $data['duration'] = '1s';
+        unset($data['other']);
+        unset($data['run_time']);
+        $this->assertEquals($data, $wfop->serialize());
+    }
+}

--- a/tests/unit_tests/new/Model/WorkflowTest.php
+++ b/tests/unit_tests/new/Model/WorkflowTest.php
@@ -1,0 +1,125 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Model;
+
+use League\Container\Container;
+use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\Models\WorkflowOperation;
+use Pantheon\Terminus\Session\Session;
+use Terminus\Models\Environment;
+use Terminus\Models\Organization;
+use Terminus\Models\Site;
+
+class WorkflowTest extends ModelTestCase
+{
+
+    /**
+     * @var Workflow
+     */
+    protected $workflow;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->workflow = new Workflow(['id' => '123']);
+    }
+
+    public function testStatus()
+    {
+        $this->assertEquals('running', $this->workflow->getStatus());
+        $this->assertEquals(false, $this->workflow->isSuccessful());
+        $this->assertEquals(false, $this->workflow->isFinished());
+
+
+        $this->workflow->set('result', 'succeeded');
+        $this->assertEquals('succeeded', $this->workflow->getStatus());
+        $this->assertEquals(true, $this->workflow->isSuccessful());
+        $this->assertEquals(true, $this->workflow->isFinished());
+
+        $this->workflow->set('result', 'failed');
+        $this->assertEquals('failed', $this->workflow->getStatus());
+        $this->assertEquals(false, $this->workflow->isSuccessful());
+        $this->assertEquals(true, $this->workflow->isFinished());
+    }
+
+    public function testOperations()
+    {
+        $operations = [
+            ['id' => 'bar', 'description' => 'Dumbo Drop',],
+            ['id' => 'baz', 'description' => 'Dumbo Pick Back Up Again',],
+        ];
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        foreach ($operations as $i => $op) {
+            $container->expects($this->at($i))
+                ->method('get')
+                ->with(WorkflowOperation::class, [$op])
+                ->willReturn(new WorkflowOperation($op));
+        }
+
+        $this->workflow->setContainer($container);
+        $this->workflow->set('operations', $operations);
+
+        $this->workflow->operations();
+    }
+
+    /**
+     *
+     */
+    public function testFetchWithLogs()
+    {
+        $data = ['id' => 'workflow_id'];
+
+        $site = new Site((object)['id' => 'site_id']);
+        $env = new Environment((object)['id' => 'env_id'], ['collection' => (object)['site' => $site]]);
+        $user = new User((object)['id' => 'user_id']);
+        $org = new Organization((object)['id' => 'org_id']);
+
+
+        $this->workflow = new Workflow((object)$data, ['environment' => $env]);
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with('sites/site_id/workflows/workflow_id', ['options' => ['method' => 'get',], 'query' => ['hydrate' => 'operations_with_logs']])
+            ->willReturn(['data' => ['baz' => '123']]);
+        $this->workflow->setRequest($this->request);
+        $this->workflow->fetchWithLogs();
+
+        $this->workflow = new Workflow((object)$data, ['site' => $site]);
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with('sites/site_id/workflows/workflow_id', ['options' => ['method' => 'get',], 'query' => ['hydrate' => 'operations_with_logs']])
+            ->willReturn(['data' => ['baz' => '123']]);
+        $this->workflow->setRequest($this->request);
+        $this->workflow->fetchWithLogs();
+
+        $this->workflow = new Workflow((object)$data, ['user' => $user]);
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with('users/user_id/workflows/workflow_id', ['options' => ['method' => 'get',], 'query' => ['hydrate' => 'operations_with_logs']])
+            ->willReturn(['data' => ['baz' => '123']]);
+        $this->workflow->setRequest($this->request);
+        $this->workflow->fetchWithLogs();
+
+        $session = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $session->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->workflow = new Workflow((object)$data, ['organization' => $org]);
+        $this->request->expects($this->at(0))
+            ->method('request')
+            ->with('users/user_id/organizations/org_id/workflows/workflow_id', ['options' => ['method' => 'get',], 'query' => ['hydrate' => 'operations_with_logs']])
+            ->willReturn(['data' => ['baz' => '123']]);
+        $this->workflow->setSession($session);
+        $this->workflow->setRequest($this->request);
+        $this->workflow->fetchWithLogs();
+    }
+
+    // @TODO: Test the waiting and get message functions once they've been unwound into something testable.
+}

--- a/tests/unit_tests/new/Session/SessionTest.php
+++ b/tests/unit_tests/new/Session/SessionTest.php
@@ -5,15 +5,13 @@ namespace Pantheon\Terminus\UnitTests\Session;
 use League\Container\Container;
 use Pantheon\Terminus\Config;
 use Pantheon\Terminus\Session\Session;
-use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 use Terminus\Caches\FileCache;
-use Terminus\Exceptions\TerminusException;
-use Terminus\Models\User;
+use Pantheon\Terminus\Models\User;
 
 /**
  * Testing class for Pantheon\Terminus\Session\Session
  */
-class SessionTest extends CommandTestCase
+class SessionTest extends \PHPUnit_Framework_TestCase
 {
 
     protected $session;
@@ -46,9 +44,7 @@ class SessionTest extends CommandTestCase
 
         $this->assertEquals('bar', $this->session->get('foo'));
         $this->assertEquals(123, $this->session->get('abc'));
-        
-        $this->setExpectedException(TerminusException::class);
-        $this->session->get('invalid');
+        $this->assertEquals(null, $this->session->get('invalid'));
     }
 
 
@@ -78,12 +74,6 @@ class SessionTest extends CommandTestCase
    */
     public function testGetUser()
     {
-        $data = [
-        'foo' => 'bar',
-        'abc' => 123
-        ];
-
-
         $container = $this->getMockBuilder(Container::class)
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
This PR converts the user model and it's immediate model/collection dependencies to using DI for request/config/session. It stops at the first level so another PR will be needed for the next round of models/collections.
