### PR TITLE
Convert and test orgs and org memberships

### DIFF
--- a/src/Collections/OrganizationSiteMemberships.php
+++ b/src/Collections/OrganizationSiteMemberships.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Terminus\Exceptions\TerminusException;
+
+class OrganizationSiteMemberships extends TerminusCollection
+{
+    /**
+     * @var Organization
+     */
+    public $organization;
+    /**
+     * @var string
+     */
+    protected $collected_class = 'Pantheon\Terminus\Models\OrganizationSiteMembership';
+    /**
+     * @var boolean
+     */
+    protected $paged = true;
+
+    /**
+     * Instantiates the collection
+     *
+     * @param array $options To be set
+     * @return OrganizationSiteMemberships
+     */
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+        $this->organization = $options['organization'];
+        $this->url = "organizations/{$this->organization->id}/memberships/sites";
+    }
+
+    /**
+     * Adds a site to this organization
+     *
+     * @param Site $site Site object of site to add to this organization
+     * @return Workflow
+     */
+    public function create($site)
+    {
+        $workflow = $this->organization->getWorkflows()->create(
+            'add_organization_site_membership',
+            ['params' => ['site_id' => $site->id, 'role' => 'team_member',],]
+        );
+        return $workflow;
+    }
+
+    /**
+     * Retrieves the model with site of the given UUID or name
+     *
+     * @param string $id UUID or name of desired site membership instance
+     * @return OrganizationSiteMembership
+     */
+    public function get($id)
+    {
+        $models = $this->getMembers();
+        if (isset($models[$id])) {
+            return $models[$id];
+        } else {
+            foreach ($models as $key => $membership) {
+                if (in_array($id, [$membership->site->id, $membership->site->get('name')])) {
+                    return $membership;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the matching site from model members
+     *
+     * @param string $site_id ID or name of desired site
+     * @return Site $membership->site
+     * @throws TerminusException
+     */
+    public function getSite($site_id)
+    {
+        if (is_null($membership = $this->get($site_id))) {
+            throw new TerminusException(
+                'This user is not a member of an organization identified by {id}.',
+                ['id' => $site_id,]
+            );
+        }
+        return $membership->site;
+    }
+
+    /**
+     * Determines whether a site is a member of this collection
+     *
+     * @param Site $site Site to determine membership of
+     * @return bool
+     */
+    public function siteIsMember($site)
+    {
+        $is_member = !is_null($this->get($site));
+        return $is_member;
+    }
+}

--- a/src/Collections/OrganizationUserMemberships.php
+++ b/src/Collections/OrganizationUserMemberships.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Terminus\Exceptions\TerminusException;
+
+class OrganizationUserMemberships extends TerminusCollection
+{
+  /**
+   * @var Organization
+   */
+    public $organization;
+  /**
+   * @var string
+   */
+    protected $collected_class = 'Pantheon\Terminus\Models\OrganizationUserMembership';
+   /**
+    * @var boolean
+    */
+    protected $paged = true;
+
+  /**
+   * Instantiates the collection, sets param members as properties
+   *
+   * @param array $options To be set to $this->key
+   */
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+        $this->organization = $options['organization'];
+        $this->url = "organizations/{$this->organization->id}/memberships/users";
+    }
+
+  /**
+   * Adds a user to this organization
+   *
+   * @param string $uuid UUID of user user to add to this organization
+   * @param string $role Role to assign to the new member
+   * @return Workflow $workflow
+   */
+    public function create($uuid, $role)
+    {
+        $workflow = $this->organization->getWorkflows()->create(
+            'add_organization_user_membership',
+            ['params' => ['user_email' => $uuid, 'role' => $role,]]
+        );
+        return $workflow;
+    }
+
+  /**
+   * Retrieves models by either user ID, email address, or full name
+   *
+   * @param string $id Either a user ID, email address, or full name
+   * @return OrganizationUserMembership
+   * @throws TerminusException
+   */
+    public function get($id)
+    {
+        $models = $this->getMembers();
+        if (isset($models[$id])) {
+            return $models[$id];
+        }
+        foreach ($models as $model) {
+            $user_data = $model->get('user');
+            if (in_array($id, [$user_data->get('email'), $user_data->get('profile')->full_name])) {
+                return $model;
+            }
+        }
+        throw new TerminusException(
+            'An organization member identified by "{id}" could not be found.',
+            compact('id'),
+            1
+        );
+    }
+}

--- a/src/Models/Organization.php
+++ b/src/Models/Organization.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Collections\OrganizationSiteMemberships;
+use Pantheon\Terminus\Collections\OrganizationUserMemberships;
+use Pantheon\Terminus\Collections\UserSiteMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+
+class Organization extends TerminusModel implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * @var OrganizationSiteMemberships
+     */
+    public $site_memberships;
+    /**
+     * @var OrganizationUserMemberships
+     */
+    public $user_memberships;
+    /**
+     * @var Workflows
+     */
+    public $workflows;
+    /**
+     * @var array
+     */
+    private $features;
+
+    /**
+     * Returns a specific organization feature value
+     *
+     * @param string $feature Feature to check
+     * @return mixed|null Feature value, or null if not found
+     */
+    public function getFeature($feature)
+    {
+        if (!isset($this->features)) {
+            $response = $this->request->request(
+                sprintf('organizations/%s/features', $this->id)
+            );
+            $this->features = (array)$response['data'];
+        }
+        if (isset($this->features[$feature])) {
+            return $this->features[$feature];
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves organization sites
+     *
+     * @return Site[]
+     */
+    public function getSites()
+    {
+        $site_memberships = $this->getSiteMemberships()->all();
+        $sites = array_combine(
+            array_map(
+                function ($membership) {
+                    return $membership->site->id;
+                },
+                $site_memberships
+            ),
+            array_map(
+                function ($membership) {
+                    return $membership->site;
+                },
+                $site_memberships
+            )
+        );
+        return $sites;
+    }
+
+    /**
+     * Retrieves organization users
+     *
+     * @return User[]
+     */
+    public function getUsers()
+    {
+        $user_memberships = $this->getUserMemberships()->all();
+        $users = array_combine(
+            array_map(
+                function ($membership) {
+                    return $membership->user->id;
+                },
+                $user_memberships
+            ),
+            array_map(
+                function ($membership) {
+                    return $membership->user;
+                },
+                $user_memberships
+            )
+        );
+        return $users;
+    }
+
+    /**
+     * Formats the Organization object into an associative array for output
+     *
+     * @return array Associative array of data for output
+     *         string id   The UUID of the organization
+     *         string name The name of the organization
+     */
+    public function serialize()
+    {
+        return ['id' => $this->id, 'name' => $this->get('profile')->name,];
+    }
+
+    /**
+     * @return OrganizationSiteMemberships
+     */
+    public function getSiteMemberships()
+    {
+        if (!$this->site_memberships) {
+            $this->site_memberships = $this->getContainer()
+                ->get(OrganizationSiteMemberships::class, [['organization' => $this]]);
+        }
+        return $this->site_memberships;
+    }
+
+    /**
+     * @return Workflows
+     */
+    public function getWorkflows()
+    {
+        if (empty($this->workflows)) {
+            $this->workflows = $this->getContainer()
+                ->get(Workflows::class, [['organization' => $this]]);
+        }
+        return $this->workflows;
+    }
+
+    /**
+     * @return OrganizationUserMemberships
+     */
+    public function getUserMemberships()
+    {
+        if (empty($this->user_memberships)) {
+            $this->user_memberships = $this->getContainer()
+                ->get(OrganizationUserMemberships::class, [['organization' => $this]]);
+        }
+        return $this->user_memberships;
+    }
+}

--- a/src/Models/OrganizationSiteMembership.php
+++ b/src/Models/OrganizationSiteMembership.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use Terminus\Collections\Tags;
+use Terminus\Models\Site;
+
+class OrganizationSiteMembership extends TerminusModel
+{
+    /**
+     * @var Organization
+     */
+    public $organization;
+    /**
+     * @var Site
+     */
+    public $site;
+    /**
+     * @var Tags
+     */
+    public $tags;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->organization = $options['collection']->organization;
+        // @TODO: Convert Site and use the container to instantiate.
+        $this->site = new Site($attributes->site);
+        $this->site->memberships = [$this,];
+        $this->tags = new Tags(['data' => (array)$attributes->tags, 'org_site_membership' => $this,]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        return "{$this->organization->id}: {$this->organization->get('profile')->name}";
+    }
+
+    /**
+     * Removes a site from this organization
+     *
+     * @return Workflow
+     */
+    public function delete()
+    {
+        $workflow = $this->organization->workflows->create(
+            'remove_organization_site_membership',
+            ['params' => ['site_id' => $this->site->id,],]
+        );
+        return $workflow;
+    }
+}

--- a/src/Models/OrganizationUserMembership.php
+++ b/src/Models/OrganizationUserMembership.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+
+class OrganizationUserMembership extends TerminusModel implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+    /**
+     * @var Organization
+     */
+    public $organization;
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * @var \stdClass
+     */
+    protected $user_data;
+
+    /**
+     * Object constructor
+     *
+     * @param object $attributes Attributes of this model
+     * @param array $options Options with which to configure this model
+     */
+    public function __construct($attributes = null, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        $this->user_data = $attributes->user;
+        $this->organization = $options['collection']->organization;
+    }
+
+    /**
+     * Removes a user from this organization
+     *
+     * @return Workflow
+     */
+    public function delete()
+    {
+        $workflow = $this->organization->workflows->create(
+            'remove_organization_user_membership',
+            ['params' => ['user_id' => $this->getUser()->id,],]
+        );
+        return $workflow;
+    }
+
+    /**
+     * Sets the user's role within this organization
+     *
+     * @param string $role Role for this user to take in the organization
+     * @return Workflow
+     */
+    public function setRole($role)
+    {
+        $workflow = $this->organization->workflows->create(
+            'update_organization_user_membership',
+            ['params' => ['user_id' => $this->getUser()->id, 'role' => $role,],]
+        );
+        return $workflow;
+    }
+
+    /**
+     * Get the user for this membership
+     *
+     * @return User
+     */
+    public function getUser()
+    {
+        if (empty($this->user)) {
+            $this->user = $this->getContainer()->get(User::class, [$this->user_data]);
+            $this->user->memberships = [$this,];
+        }
+        return $this->user;
+    }
+}

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -68,13 +68,13 @@ class User extends TerminusModel implements ContainerAwareInterface
         $organizations = array_combine(
             array_map(
                 function ($membership) {
-                    return $membership->organization->id;
+                    return $membership->getOrganization()->id;
                 },
                 $org_memberships
             ),
             array_map(
                 function ($membership) {
-                    return $membership->organization;
+                    return $membership->getOrganization();
                 },
                 $org_memberships
             )

--- a/src/Models/UserOrganizationMembership.php
+++ b/src/Models/UserOrganizationMembership.php
@@ -2,10 +2,12 @@
 
 namespace Pantheon\Terminus\Models;
 
-use Terminus\Models\Organization;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
 
-class UserOrganizationMembership extends TerminusModel
+class UserOrganizationMembership extends TerminusModel implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
     /**
      * @var Organization
      */
@@ -25,8 +27,17 @@ class UserOrganizationMembership extends TerminusModel
     {
         parent::__construct($attributes, $options);
         $this->user = $options['collection']->getUser();
-        // @TODO: Follow this dependency chain and invert it.
-        $this->organization = new Organization($attributes->organization);
-        $this->organization->memberships = [$this,];
+    }
+
+    /**
+     * @return Organization
+     */
+    public function getOrganization()
+    {
+        if (empty($this->organization)) {
+            $this->organization = $this->getContainer()->get(Organization::class, [$this->get('organization')]);
+            $this->organization->memberships = [$this,];
+        }
+        return $this->organization;
     }
 }

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -7,6 +7,8 @@ use League\Container\Container;
 use League\Container\ContainerInterface;
 use Pantheon\Terminus\Collections\Instruments;
 use Pantheon\Terminus\Collections\MachineTokens;
+use Pantheon\Terminus\Collections\OrganizationSiteMemberships;
+use Pantheon\Terminus\Collections\OrganizationUserMemberships;
 use Pantheon\Terminus\Collections\SavedTokens;
 use Pantheon\Terminus\Collections\SshKeys;
 use Pantheon\Terminus\Collections\UserOrganizationMemberships;
@@ -14,6 +16,9 @@ use Pantheon\Terminus\Collections\UserSiteMemberships;
 use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Models\Instrument;
 use Pantheon\Terminus\Models\MachineToken;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\OrganizationSiteMembership;
+use Pantheon\Terminus\Models\OrganizationUserMembership;
 use Pantheon\Terminus\Models\SavedToken;
 use Pantheon\Terminus\Models\SshKey;
 use Pantheon\Terminus\Models\UserOrganizationMembership;
@@ -133,6 +138,11 @@ class Runner
         $container->add(UserSiteMembership::class);
         $container->add(UserOrganizationMemberships::class);
         $container->add(UserOrganizationMembership::class);
+        $container->add(OrganizationSiteMemberships::class);
+        $container->add(OrganizationSiteMembership::class);
+        $container->add(OrganizationUserMemberships::class);
+        $container->add(OrganizationUserMembership::class);
+        $container->add(Organization::class);
 
         $container->share('sites', Sites::class);
         $container->inflector(SiteAwareInterface::class)

--- a/tests/unit_tests/new/Collections/OrganizationSiteMembershipsTest.php
+++ b/tests/unit_tests/new/Collections/OrganizationSiteMembershipsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collections;
+
+use Pantheon\Terminus\Collections\OrganizationSiteMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Organization;
+use Terminus\Exceptions\TerminusException;
+use Terminus\Models\Site;
+
+class OrganizationSiteMembershipsTest extends CollectionTestCase
+{
+    public function testCreate()
+    {
+        $workflows = $this->getMockBuilder(Workflows::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $organization = $this->getMockBuilder(Organization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $organization->expects($this->once())
+            ->method('getWorkflows')
+            ->willReturn($workflows);
+
+        $site = (object)['id' => '123'];
+
+        $workflows->expects($this->once())
+            ->method('create')
+            ->with('add_organization_site_membership', ['params' => ['site_id' => '123', 'role' => 'team_member']]);
+
+        $org_site_membership = new OrganizationSiteMemberships(['organization' => $organization]);
+        $org_site_membership->create($site);
+    }
+
+    public function testGet()
+    {
+        $model_data = [
+            'a' => (object)[
+                'site' => new Site((object)['id' => 'abc', 'name' => 'Site A']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+            'b' => (object)[
+                'site' => new Site((object)['id' => 'bcd', 'name' => 'Site B']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+            'c' => (object)[
+                'site' => new Site((object)['id' => 'cde', 'name' => 'Site C']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+        ];
+
+        $org_site_membership = $this->getMockBuilder(OrganizationSiteMemberships::class)
+            ->setMethods(['getMembers'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org_site_membership->expects($this->any())
+            ->method('getMembers')
+            ->willReturn($model_data);
+
+        $this->assertEquals($model_data['a'], $org_site_membership->get('a'));
+        $this->assertEquals($model_data['b'], $org_site_membership->get('b'));
+        $this->assertEquals($model_data['c'], $org_site_membership->get('c'));
+        $this->assertEquals($model_data['a'], $org_site_membership->get('Site A'));
+        $this->assertEquals($model_data['b'], $org_site_membership->get('Site B'));
+        $this->assertEquals($model_data['a'], $org_site_membership->get('abc'));
+        $this->assertEquals($model_data['c'], $org_site_membership->get('cde'));
+        $this->assertEquals(null, $org_site_membership->get('invalid'));
+
+
+        $this->assertEquals($model_data['a']->site, $org_site_membership->getSite('a'));
+        $this->assertEquals($model_data['a']->site, $org_site_membership->getSite('Site A'));
+        $this->assertEquals($model_data['a']->site, $org_site_membership->getSite('abc'));
+        $this->setExpectedException(TerminusException::class);
+        $this->assertEquals(null, $org_site_membership->getSite('invalid'));
+
+        $this->assertTrue($org_site_membership->siteIsMember('abc'));
+        $this->assertTrue($org_site_membership->siteIsMember('Site B'));
+        $this->assertFalse($org_site_membership->siteIsMember('invalid'));
+    }
+}

--- a/tests/unit_tests/new/Collections/OrganizationUserMembershipsTest.php
+++ b/tests/unit_tests/new/Collections/OrganizationUserMembershipsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Collections;
+
+use Pantheon\Terminus\Collections\OrganizationUserMemberships;
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\User;
+use Terminus\Models\OrganizationUserMembership;
+
+class OrganizationUserMembershipsTest extends CollectionTestCase
+{
+    public function testCreate()
+    {
+        $workflows = $this->getMockBuilder(Workflows::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $organization = $this->getMockBuilder(Organization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $organization->expects($this->once())
+            ->method('getWorkflows')
+            ->willReturn($workflows);
+
+        $organization->id = '123';
+
+        $workflows->expects($this->once())
+            ->method('create')
+            ->with(
+                'add_organization_user_membership',
+                ['params' => ['user_email' => 'dev@example.com', 'role' => 'team_member']]
+            );
+
+        $org_site_membership = new OrganizationUserMemberships(['organization' => $organization]);
+        $org_site_membership->create('dev@example.com', 'team_member');
+    }
+
+    public function testGet()
+    {
+        $user_data = [
+            'a' => ['id' => 'abc', 'email' => 'a@example.com', 'profile' => (object)['full_name' => 'User A']],
+            'b' => ['id' => 'bcd', 'email' => 'b@example.com', 'profile' => (object)['full_name' => 'User B']],
+            'c' => ['id' => 'cde', 'email' => 'c@example.com', 'profile' => (object)['full_name' => 'User C']],
+        ];
+
+        foreach ($user_data as $i => $user) {
+            $model_data[$i] = $this->getMockBuilder(OrganizationUserMembership::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $model_data[$i]->expects($this->any())
+                ->method('get')
+                ->with('user')
+                ->willReturn(new User((object)$user));
+        }
+
+        $org_user_membership = $this->getMockBuilder(OrganizationUserMemberships::class)
+            ->setMethods(['getMembers'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org_user_membership->expects($this->any())
+            ->method('getMembers')
+            ->willReturn($model_data);
+
+        $this->assertEquals($model_data['a'], $org_user_membership->get('a'));
+        $this->assertEquals($model_data['b'], $org_user_membership->get('b'));
+        $this->assertEquals($model_data['c'], $org_user_membership->get('c'));
+        $this->assertEquals($model_data['a'], $org_user_membership->get('User A'));
+        $this->assertEquals($model_data['b'], $org_user_membership->get('User B'));
+        $this->assertEquals($model_data['a'], $org_user_membership->get('a@example.com'));
+        $this->assertEquals($model_data['c'], $org_user_membership->get('c@example.com'));
+    }
+}

--- a/tests/unit_tests/new/Models/OrganizationSiteMembershipTest.php
+++ b/tests/unit_tests/new/Models/OrganizationSiteMembershipTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Models;
+
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\OrganizationSiteMembership;
+use Pantheon\Terminus\Models\Workflow;
+
+class OrganizationSiteMembershipTest extends ModelTestCase
+{
+    public function testToString()
+    {
+        $org = new Organization((object)['id' => '123', 'profile' => (object)['name' => 'My Org']]);
+        $org_site = new OrganizationSiteMembership(
+            (object)['site' => (object)[], 'tags' => (object)[]],
+            ['collection' => (object)['organization' => $org]]
+        );
+        $this->assertEquals('123: My Org', (string)$org_site);
+    }
+    
+    public function testDelete()
+    {
+        $org = new Organization((object)['id' => '123', 'profile' => (object)['name' => 'My Org']]);
+        $org->workflows = $this->getMockBuilder(Workflows::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $wf = $this->getMockBuilder(Workflow::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org->workflows->expects($this->once())
+            ->method('create')
+            ->with(
+                'remove_organization_site_membership',
+                ['params' => ['site_id' => '123']]
+            )
+            ->willReturn($wf);
+
+        $org_site = new OrganizationSiteMembership(
+            (object)['site' => (object)['id' => '123'], 'tags' => (object)[]],
+            ['collection' => (object)['organization' => $org]]
+        );
+        $out = $org_site->delete();
+        $this->assertEquals($wf, $out);
+    }
+}

--- a/tests/unit_tests/new/Models/OrganizationTest.php
+++ b/tests/unit_tests/new/Models/OrganizationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Models;
+
+use League\Container\Container;
+use Pantheon\Terminus\Collections\OrganizationSiteMemberships;
+use Pantheon\Terminus\Collections\OrganizationUserMemberships;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\User;
+use Terminus\Models\Site;
+
+class OrganizationTest extends ModelTestCase
+{
+    public function testGetFeature()
+    {
+        $data = [
+            "change_management" => true,
+            "multidev" => false,
+        ];
+
+        $this->request->expects($this->once())
+            ->method('request')
+            ->with(
+                'organizations/123/features',
+                []
+            )
+            ->willReturn(['data' => $data]);
+
+        $organization = new Organization((object)['id' => '123']);
+        $organization->setRequest($this->request);
+
+        $this->assertTrue($organization->getFeature('change_management'));
+        $this->assertFalse($organization->getFeature('multidev'));
+        $this->assertNull($organization->getFeature('invalid'));
+    }
+
+    public function testGetSites()
+    {
+        $organization = new Organization((object)['id' => '123']);
+
+        $model_data = [
+            'a' => (object)[
+                'site' => new Site((object)['id' => 'abc', 'name' => 'Site A']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+            'b' => (object)[
+                'site' => new Site((object)['id' => 'bcd', 'name' => 'Site B']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+            'c' => (object)[
+                'site' => new Site((object)['id' => 'cde', 'name' => 'Site C']),
+                'organization_id' => '123',
+                "role" => "team_member",
+            ],
+        ];
+        $sites = [];
+        foreach ($model_data as $model) {
+            $sites[$model->site->id] = $model->site;
+        }
+        $org_site_membership = $this->getMockBuilder(OrganizationSiteMemberships::class)
+            ->setMethods(['getMembers'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org_site_membership->expects($this->any())
+            ->method('getMembers')
+            ->willReturn($model_data);
+
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('get')
+            ->with(OrganizationSiteMemberships::class, [['organization' => $organization]])
+            ->willReturn($org_site_membership);
+
+        $organization->setContainer($container);
+
+        $this->assertEquals($org_site_membership, $organization->getSiteMemberships());
+        $this->assertEquals($sites, $organization->getSites());
+    }
+
+    public function testGetUsers()
+    {
+        $organization = new Organization((object)['id' => '123']);
+
+        $user_data = [
+            'a' => ['id' => 'abc', 'email' => 'a@example.com', 'profile' => (object)['full_name' => 'User A']],
+            'b' => ['id' => 'bcd', 'email' => 'b@example.com', 'profile' => (object)['full_name' => 'User B']],
+            'c' => ['id' => 'cde', 'email' => 'c@example.com', 'profile' => (object)['full_name' => 'User C']],
+        ];
+        $users = [];
+        foreach ($user_data as $i => $user) {
+            $model_data[$i] = $this->getMockBuilder(OrganizationUserMembership::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $model_data[$i]->user = $users[$user['id']] = new User((object)$user);
+        }
+
+        $org_user_membership = $this->getMockBuilder(OrganizationUserMemberships::class)
+            ->setMethods(['getMembers'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org_user_membership->expects($this->any())
+            ->method('getMembers')
+            ->willReturn($model_data);
+
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container->expects($this->once())
+            ->method('get')
+            ->with(OrganizationUserMemberships::class, [['organization' => $organization]])
+            ->willReturn($org_user_membership);
+
+        $organization->setContainer($container);
+
+        $this->assertEquals($org_user_membership, $organization->getUserMemberships());
+        $this->assertEquals($users, $organization->getUsers());
+    }
+}

--- a/tests/unit_tests/new/Models/OrganizationUserMembershipTest.php
+++ b/tests/unit_tests/new/Models/OrganizationUserMembershipTest.php
@@ -1,0 +1,88 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Models;
+
+use League\Container\Container;
+use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\OrganizationUserMembership;
+use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Models\Workflow;
+
+class OrganizationUserMembershipTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDelete()
+    {
+        $user_data = (object)['id' => '234'];
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with(User::class, [$user_data])
+            ->willReturn(new User($user_data));
+
+        $wf = $this->getMockBuilder(Workflow::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org = new Organization((object)['id' => '123', 'profile' => (object)['name' => 'My Org']]);
+        $org->workflows = $this->getMockBuilder(Workflows::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org->workflows->expects($this->once())
+            ->method('create')
+            ->with(
+                'remove_organization_user_membership',
+                ['params' => ['user_id' => '234']]
+            )
+            ->willReturn($wf);
+
+        $org_site = new OrganizationUserMembership(
+            (object)['user' => $user_data],
+            ['collection' => (object)['organization' => $org]]
+        );
+        $org_site->setContainer($container);
+        $out = $org_site->delete();
+        $this->assertEquals($wf, $out);
+    }
+
+    public function testSetRole()
+    {
+        $user_data = (object)['id' => '234'];
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with(User::class, [$user_data])
+            ->willReturn(new User($user_data));
+
+        $wf = $this->getMockBuilder(Workflow::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org = new Organization((object)['id' => '123', 'profile' => (object)['name' => 'My Org']]);
+        $org->workflows = $this->getMockBuilder(Workflows::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $org->workflows->expects($this->once())
+            ->method('create')
+            ->with(
+                'update_organization_user_membership',
+                ['params' => ['user_id' => '234', 'role' => 'testrole']]
+            )
+            ->willReturn($wf);
+
+        $org_site = new OrganizationUserMembership(
+            (object)['user' => $user_data],
+            ['collection' => (object)['organization' => $org]]
+        );
+        $org_site->setContainer($container);
+        $out = $org_site->setRole('testrole');
+        $this->assertEquals($wf, $out);
+    }
+}

--- a/tests/unit_tests/new/Models/UserTest.php
+++ b/tests/unit_tests/new/Models/UserTest.php
@@ -10,7 +10,9 @@ use Pantheon\Terminus\Collections\SshKeys;
 use Pantheon\Terminus\Collections\UserOrganizationMemberships;
 use Pantheon\Terminus\Collections\UserSiteMemberships;
 use Pantheon\Terminus\Collections\Workflows;
+use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Models\UserOrganizationMembership;
 use Robo\Collection\Collection;
 
 class UserTest extends ModelTestCase
@@ -142,19 +144,28 @@ class UserTest extends ModelTestCase
         $memberships = [
             (object)[
                 'id' => '1',
-                'organization' => (object)[
+                'organization' => new Organization((object)[
                     'id' => 'org1',
                     'other' => 'abc'
-                ]
+                ])
             ],
             (object)[
                 'id' => '2',
-                'organization' => (object)[
+                'organization' => new Organization((object)[
                     'id' => 'org2',
                     'other' => 'cdf'
-                ]
+                ])
             ]
         ];
+        $membs = [];
+        foreach ($memberships as $i => $membership) {
+            $membs[$i] = $this->getMockBuilder(UserOrganizationMembership::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $membs[$i]->expects($this->any())
+                ->method('getOrganization')
+                ->willReturn($membership->organization);
+        }
         $orgs = [
             'org1' => $memberships[0]->organization,
             'org2' => $memberships[1]->organization
@@ -166,7 +177,7 @@ class UserTest extends ModelTestCase
 
         $orgmemberships ->expects($this->once())
             ->method('all')
-            ->willReturn($memberships);
+            ->willReturn($membs);
 
         $container = $this->getMockBuilder(Container::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
One more step down the dependency chain. This PR ports over org membership models/collections and adds unit tests
