### PR TITLE
Link to raw version of terminus-completion.bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are planning to run WP-CLI or Drush commands through Terminus, please [up
 
 Tab completion
 --------------
-Terminus also comes with a tab completion script for Bash. Just download [terminus-completion.bash](https://github.com/pantheon-systems/terminus/blob/master/utils/terminus-completion.bash) and source it from `~/.bash_profile`:
+Terminus also comes with a tab completion script for Bash. Just download [terminus-completion.bash](https://raw.githubusercontent.com/pantheon-systems/terminus/master/utils/terminus-completion.bash) and source it from `~/.bash_profile`:
 
 ```bash
 source /FULL/PATH/TO/terminus-completion.bash


### PR DESCRIPTION
This makes the link `wget`table. I `wget`ted the one with all the HTML gubbins which obviously didn't work.
