### PR TITLE
AL-543 Adds https:delete command

### DIFF
--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -722,6 +722,34 @@ class Environment extends TerminusModel
         return $workflow;
     }
 
+    /**
+     * Remove a HTTPS certificate from the environment
+     *
+     * @return array $workflow
+     *
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function disableHttpsCertificate()
+    {
+        if (!$this->settings('ssl_enabled')) {
+            throw new TerminusException('The {env} environment does not have https enabled.', ['env' => $this->id]);
+        }
+        $response = $this->request->request(
+            "sites/{$this->site->id}/environments/{$this->id}/settings",
+            [
+                'method' => 'put',
+                'form_params' => [
+                    'ssl_enabled' => false,
+                    'dedicated_ip' => false,
+                ],
+            ]
+        );
+        if ($response['status_code'] !== 200) {
+            throw new TerminusException('There was an problem disabling https for this environment.');
+        }
+        return $this->convergeBindings();
+    }
+
   /**
    * Gives SFTP connection info for this environment
    *

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -745,8 +745,7 @@ class Environment extends TerminusModel
                     ],
                 ]
             );
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             throw new TerminusException('There was an problem disabling https for this environment.');
         }
     }

--- a/php/Terminus/Models/Environment.php
+++ b/php/Terminus/Models/Environment.php
@@ -734,20 +734,21 @@ class Environment extends TerminusModel
         if (!$this->settings('ssl_enabled')) {
             throw new TerminusException('The {env} environment does not have https enabled.', ['env' => $this->id]);
         }
-        $response = $this->request->request(
-            "sites/{$this->site->id}/environments/{$this->id}/settings",
-            [
-                'method' => 'put',
-                'form_params' => [
-                    'ssl_enabled' => false,
-                    'dedicated_ip' => false,
-                ],
-            ]
-        );
-        if ($response['status_code'] !== 200) {
+        try {
+            $this->request->request(
+                "sites/{$this->site->id}/environments/{$this->id}/settings",
+                [
+                    'method' => 'put',
+                    'form_params' => [
+                        'ssl_enabled' => false,
+                        'dedicated_ip' => false,
+                    ],
+                ]
+            );
+        }
+        catch (\Exception $e) {
             throw new TerminusException('There was an problem disabling https for this environment.');
         }
-        return $this->convergeBindings();
     }
 
   /**

--- a/src/Commands/Https/DeleteCommand.php
+++ b/src/Commands/Https/DeleteCommand.php
@@ -24,7 +24,13 @@ class DeleteCommand extends TerminusCommand implements SiteAwareInterface
     public function delete($site_env)
     {
         list(, $env) = $this->getSiteEnv($site_env, 'dev');
-        $workflow = $env->disableHttpsCertificate();
+        // Push the settings change
+        $env->disableHttpsCertificate();
+        // Converge the environment bindings to get the settings to take effect.
+        $workflow = $env->convergeBindings();
+        $this->log()->notice("HTTPS has been disabled and the environment's bindings will now be converged.");
+
+        // Wait for the workflow to complete.
         while (!$workflow->checkProgress()) {
             // @TODO: Add Symfony progress bar to indicate that something is happening.
         }

--- a/src/Commands/Https/DeleteCommand.php
+++ b/src/Commands/Https/DeleteCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Https;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+
+class DeleteCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+
+    /**
+     * Delete or disable https for a site.
+     *
+     * @authorized
+     *
+     * @command https:delete
+     *
+     * @param string $site_env Site and environment in the form `site-name.env`.
+     *
+     * @usage terminus https:delete <site_name>.<env_name>
+     */
+    public function delete($site_env)
+    {
+        list(, $env) = $this->getSiteEnv($site_env, 'dev');
+        $workflow = $env->disableHttpsCertificate();
+        while (!$workflow->checkProgress()) {
+            // @TODO: Add Symfony progress bar to indicate that something is happening.
+        }
+        $this->log()->notice($workflow->getMessage());
+    }
+}

--- a/tests/active_features/https.feature
+++ b/tests/active_features/https.feature
@@ -1,0 +1,25 @@
+Feature: Set HTTPS Certificate
+  In order to enable HTTPS to secure my website
+  As a user
+  I need to be able to be able update my environment's HTTPS certificate
+
+  Background: I am authenticated and I have a site named [[test_site_name]]
+    Given I am authenticated
+    And a site named "[[test_site_name]]"
+
+  @vcr https_delete.yml
+  Scenario: Delete an HTTPS Certificate
+    When I run "terminus https:delete [[test_site_name]].dev"
+    Then I should get:
+    """
+    Converged containers on "dev"
+    """
+
+  @vcr https_delete-nocert.yml
+  Scenario: Delete a non-existant HTTPS Certificate
+    When I run "terminus https:delete [[test_site_name]].dev"
+    Then I should get:
+    """
+    The dev environment does not have https enabled
+    """
+

--- a/tests/fixtures/https_delete-nocert.yml
+++ b/tests/fixtures/https_delete-nocert.yml
@@ -1,0 +1,177 @@
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.13.3 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            verify: '1'
+            method: post
+            absolute_url: ''
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"111111111111111111111111111111111111111111111","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 16 Aug 2016 22:51:26 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: f535ebd0-6403-11e6-9844-1524ed28772c
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"session": "11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq","expires_at":1473807086,"user_id":"11111111-1111-1111-1111-111111111111"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/site-names/behat-tests'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:26 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c256d820-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"id": "11111111-1111-1111-1111-111111111111", "name": "behat-tests"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111?site_state=true'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Content-Length: '3159'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c3ced220-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"created": 1477079090, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "framework": "wordpress", "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "holder_type": "organization", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}, "name": "behat-tests", "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "owner": "11111111-1111-1111-1111-111111111111", "php_version": "55", "preferred_zone": "onebox", "purchased_at": 1477079293, "service_level": "pro", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "label": "behat-tests", "id": "11111111-1111-1111-1111-111111111111", "holder": {"instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "maxdevsites": "10", "name": "Another Test Org", "id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "key": "7249b1ca-0897-4e3b-bc16-f081fed63821", "service_level": "enterprise", "org_logo_height": 85, "machine_name": "another-test-org", "org_logo_width": 85, "has_multidev": false, "support_plan": "regular_support", "show_org_name_header": "yes", "base_domain": null, "requires_onboarding": false, "has_change_management": false, "profile": {"machine_name": "another-test-org", "change_service_url": null, "name": "Another Test Org", "email_domain": null, "org_logo_width": 85, "org_logo_height": 85, "base_domain": null, "billing_url": null, "terms_of_service": null, "org_logo": null}, "use_org_instrument": true, "settings": {"service_level": "enterprise", "use_org_instrument": true, "show_org_name_header": "yes", "base_domain": null, "discoverable": false, "email_domain": null}}, "settings": {"allow_domains": true, "max_num_cdes": 10, "stunnel": false, "replica_verification_strategy": "pt-heartbeat", "owner": "11111111-1111-1111-1111-111111111111", "secure_runtime_access": false, "pingdom": 0, "allow_indexserver": false, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "failover_appserver": 0, "cacheserver": 1, "support_plan": "regular_support", "appserver": 1, "on_server_development": false, "drush_version": 5, "label": "behat-tests", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "allow_read_slaves": false, "indexserver": 1, "php_version": "55", "php_channel": "stable", "allow_cacheserver": false, "ssl_enabled": null, "min_backups": 0, "service_level": "pro", "dedicated_ip": null, "dbserver": 1, "purchased_at": 1477079293, "framework": "wordpress", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "guilty_of_abuse": null, "preferred_zone": "onebox", "pingdom_chance": 0, "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "name": "behat-tests", "created": 1477079090, "max_backups": 7, "holder_type": "organization", "number_allow_domains": 200, "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "pingdom_manually_enabled": false, "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}}, "base_domain": null, "attributes": {"label": "behat-tests"}, "add_ons": []}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c3fb3950-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"live": {"environment_created": 1477079091, "dns_zone": "onebox.pantheonsite.io", "randseed": "BKU19TUGTDL10IW26T8R3BQYXEDM1ICI", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}, "test": {"environment_created": 1477079091, "dns_zone": "onebox.pantheon.io", "randseed": "U7U2PSWWR5OP63RJK5W52L7K4UZ0WO1I", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}, "dev": {"watchers": 1, "dedicated_ip": false, "diffstat": {}, "on_server_development": true, "environment_created": 1477079090, "dns_zone": "onebox.pantheonsite.io", "randseed": "9MFCV3O8UKEZ8O07D6C1GW8HL053QRV8", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "fa0dd988c2a337b5b544bef9fe75d22239a6133a", "ssl_enabled": false, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments/dev/settings'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Content-Length: '2244'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c42ef380-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"target_ref": "refs/heads/master", "diffstat": {}, "allow_domains": true, "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "site": "11111111-1111-1111-1111-111111111111", "stunnel": false, "replica_verification_strategy": "pt-heartbeat", "mysql": {"query_cache_size": 64, "innodb_buffer_pool_size": 512, "innodb_log_file_size": 50331648, "BlockIOWeight": 500, "MemoryLimit": 1024, "CPUShares": 750}, "owner": "11111111-1111-1111-1111-111111111111", "secure_runtime_access": false, "pingdom": 0, "allow_indexserver": false, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "failover_appserver": 0, "cacheserver": 1, "support_plan": "regular_support", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "on_server_development": true, "environment_created": 1477079090, "drush_version": 5, "redis": {"MemoryLimit": 256, "maxmemory": 241172480, "CPUShares": 32, "BlockIOWeight": 100}, "label": "behat-tests", "environment": "dev", "appserver": 1, "allow_read_slaves": false, "preferred_zone": "onebox", "php_version": "55", "php_channel": "stable", "allow_cacheserver": false, "ssl_enabled": false, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io", "min_backups": 0, "service_level": "pro", "dedicated_ip": false, "dbserver": 1, "purchased_at": 1477079293, "framework": "wordpress", "watchers": 1, "max_num_cdes": 10, "guilty_of_abuse": null, "indexserver": 1, "dns_zone": "onebox.pantheonsite.io", "pingdom_chance": 0, "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "name": "behat-tests", "created": 1477079090, "max_backups": 7, "php-fpm": {"fpm_max_children": 8, "opcache_revalidate_freq": 0, "BlockIOWeight": 300, "MemoryLimit": 768, "apc_shm_size": 256, "php_memory_limit": 256, "CPUShares": 750}, "randseed": "9MFCV3O8UKEZ8O07D6C1GW8HL053QRV8", "holder_type": "organization", "number_allow_domains": 200, "target_commit": "fa0dd988c2a337b5b544bef9fe75d22239a6133a", "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "pingdom_manually_enabled": false, "nginx": {"sendfile": "off", "aio": "off", "worker_processes": 4, "directio": "off"}, "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}}'

--- a/tests/fixtures/https_delete.yml
+++ b/tests/fixtures/https_delete.yml
@@ -1,0 +1,288 @@
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/authorize/machine-token'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.13.3 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            verify: '1'
+            method: post
+            absolute_url: ''
+            json: terminus
+            Accept: null
+        body: '{"machine_token":"111111111111111111111111111111111111111111111","client":"terminus"}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Tue, 16 Aug 2016 22:51:26 GMT'
+            Content-Type: 'application/json; charset=utf-8'
+            Content-Length: '182'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: f535ebd0-6403-11e6-9844-1524ed28772c
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"session": "11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq","expires_at":1473807086,"user_id":"11111111-1111-1111-1111-111111111111"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/site-names/behat-tests'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:26 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c256d820-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"id": "11111111-1111-1111-1111-111111111111", "name": "behat-tests"}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111?site_state=true'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Content-Length: '3159'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c3ced220-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"created": 1477079090, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "framework": "wordpress", "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "holder_type": "organization", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}, "name": "behat-tests", "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "owner": "11111111-1111-1111-1111-111111111111", "php_version": "55", "preferred_zone": "onebox", "purchased_at": 1477079293, "service_level": "pro", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "label": "behat-tests", "id": "11111111-1111-1111-1111-111111111111", "holder": {"instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "maxdevsites": "10", "name": "Another Test Org", "id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "key": "7249b1ca-0897-4e3b-bc16-f081fed63821", "service_level": "enterprise", "org_logo_height": 85, "machine_name": "another-test-org", "org_logo_width": 85, "has_multidev": false, "support_plan": "regular_support", "show_org_name_header": "yes", "base_domain": null, "requires_onboarding": false, "has_change_management": false, "profile": {"machine_name": "another-test-org", "change_service_url": null, "name": "Another Test Org", "email_domain": null, "org_logo_width": 85, "org_logo_height": 85, "base_domain": null, "billing_url": null, "terms_of_service": null, "org_logo": null}, "use_org_instrument": true, "settings": {"service_level": "enterprise", "use_org_instrument": true, "show_org_name_header": "yes", "base_domain": null, "discoverable": false, "email_domain": null}}, "settings": {"allow_domains": true, "max_num_cdes": 10, "stunnel": false, "replica_verification_strategy": "pt-heartbeat", "owner": "11111111-1111-1111-1111-111111111111", "secure_runtime_access": false, "pingdom": 0, "allow_indexserver": false, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "failover_appserver": 0, "cacheserver": 1, "support_plan": "regular_support", "appserver": 1, "on_server_development": false, "drush_version": 5, "label": "behat-tests", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "allow_read_slaves": false, "indexserver": 1, "php_version": "55", "php_channel": "stable", "allow_cacheserver": false, "ssl_enabled": true, "min_backups": 0, "service_level": "pro", "dedicated_ip": true`, "dbserver": 1, "purchased_at": 1477079293, "framework": "wordpress", "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "guilty_of_abuse": null, "preferred_zone": "onebox", "pingdom_chance": 0, "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "name": "behat-tests", "created": 1477079090, "max_backups": 7, "holder_type": "organization", "number_allow_domains": 200, "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "pingdom_manually_enabled": false, "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}}, "base_domain": null, "attributes": {"label": "behat-tests"}, "add_ons": []}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c3fb3950-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"live": {"environment_created": 1477079091, "dns_zone": "onebox.pantheonsite.io", "randseed": "BKU19TUGTDL10IW26T8R3BQYXEDM1ICI", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}, "test": {"environment_created": 1477079091, "dns_zone": "onebox.pantheon.io", "randseed": "U7U2PSWWR5OP63RJK5W52L7K4UZ0WO1I", "lock": {"username": null, "password": null, "locked": false}, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}, "dev": {"watchers": 1, "dedicated_ip": true, "diffstat": {}, "on_server_development": true, "environment_created": 1477079090, "dns_zone": "onebox.pantheonsite.io", "randseed": "9MFCV3O8UKEZ8O07D6C1GW8HL053QRV8", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "fa0dd988c2a337b5b544bef9fe75d22239a6133a", "ssl_enabled": true, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io"}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments/dev/settings'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:34:29 GMT'
+            Content-Type: application/json
+            Content-Length: '2244'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: c42ef380-97cd-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"target_ref": "refs/heads/master", "diffstat": {}, "allow_domains": true, "upstream": {"url": "https://github.com/pantheon-systems/WordPress", "product_id": "4ccdd52d-330f-4e48-b01d-79f71397de15", "branch": "master"}, "site": "11111111-1111-1111-1111-111111111111", "stunnel": false, "replica_verification_strategy": "pt-heartbeat", "mysql": {"query_cache_size": 64, "innodb_buffer_pool_size": 512, "innodb_log_file_size": 50331648, "BlockIOWeight": 500, "MemoryLimit": 1024, "CPUShares": 750}, "owner": "11111111-1111-1111-1111-111111111111", "secure_runtime_access": false, "pingdom": 0, "allow_indexserver": false, "created_by_user_id": "11111111-1111-1111-1111-111111111111", "failover_appserver": 0, "cacheserver": 1, "support_plan": "regular_support", "instrument": "42396ca2-e932-47c1-99be-a60f48c22502", "on_server_development": true, "environment_created": 1477079090, "drush_version": 5, "redis": {"MemoryLimit": 256, "maxmemory": 241172480, "CPUShares": 32, "BlockIOWeight": 100}, "label": "behat-tests", "environment": "dev", "appserver": 1, "allow_read_slaves": false, "preferred_zone": "onebox", "php_version": "55", "php_channel": "stable", "allow_cacheserver": false, "ssl_enabled": true, "styx_cluster": "styx-devuser-onebox6.onebox.pantheon.io", "min_backups": 0, "service_level": "pro", "dedicated_ip": true, "dbserver": 1, "purchased_at": 1477079293, "framework": "wordpress", "watchers": 1, "max_num_cdes": 10, "guilty_of_abuse": null, "indexserver": 1, "dns_zone": "onebox.pantheonsite.io", "pingdom_chance": 0, "holder_id": "7249b1ca-0897-4e3b-bc16-f081fed63821", "name": "behat-tests", "created": 1477079090, "max_backups": 7, "php-fpm": {"fpm_max_children": 8, "opcache_revalidate_freq": 0, "BlockIOWeight": 300, "MemoryLimit": 768, "apc_shm_size": 256, "php_memory_limit": 256, "CPUShares": 750}, "randseed": "9MFCV3O8UKEZ8O07D6C1GW8HL053QRV8", "holder_type": "organization", "number_allow_domains": 200, "target_commit": "fa0dd988c2a337b5b544bef9fe75d22239a6133a", "organization": "7249b1ca-0897-4e3b-bc16-f081fed63821", "pingdom_manually_enabled": false, "nginx": {"sendfile": "off", "aio": "off", "worker_processes": 4, "directio": "off"}, "last_code_push": {"timestamp": "2016-10-21T19:45:04", "user_uuid": null}}'
+-
+    request:
+        method: PUT
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments/dev/settings'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: put
+            absolute_url: ''
+            json: ''
+            Accept: null
+        body: '{"ssl_enabled":false,"dedicated_ip":false}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:38:15 GMT'
+            Content-Type: application/json
+            Content-Length: '4'
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 4afde830-97ce-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: 'true'
+-
+    request:
+        method: POST
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/environments/dev/workflows'
+        headers:
+            Host: onebox
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: post
+            absolute_url: ''
+            json: ''
+            Accept: null
+        body: '{"type":"converge_environment","params":{}}'
+    response:
+        status:
+            http_version: '1.1'
+            code: '202'
+            message: Accepted
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:38:17 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 4b2e1ff0-97ce-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+        body: '{"environment_id": "dev", "user_id": "11111111-1111-1111-1111-111111111111", "site_id": "11111111-1111-1111-1111-111111111111", "trace_id": "4b2e1ff0-97ce-11e6-ba93-85eff07488d9", "params": {}, "task_ids": ["4b423792-97ce-11e6-8169-bc764e10cbc8", "4b44e49c-97ce-11e6-8169-bc764e10cbc8", "4b453550-97ce-11e6-8169-bc764e10cbc8", "4b454842-97ce-11e6-8169-bc764e10cbc8", "4b455bd4-97ce-11e6-8169-bc764e10cbc8"], "role": "owner", "type": "converge_environment", "id": "4b34b0e0-97ce-11e6-8169-bc764e10cbc8", "key": "1477080000", "waiting_for_task_id": "4b423792-97ce-11e6-8169-bc764e10cbc8", "keep_forever": false, "phase": "created", "queued_time": null, "run_time": null, "created_at": 1477082296.218032, "reason": "", "environment": "dev", "final_task_id": null, "result": null, "total_time": null, "active_description": "Converge \"dev\"", "description": "Converge \"dev\"", "step": 1, "has_operation_log_output": false, "number_of_tasks": 5, "trace_log_url": "https://app.logz.io/#/dashboard/kibana?kibanaRoute=discover%3F_a%3D(query:(query_string:(analyze_wildcard:!t,query:%27trace_id:4b2e1ff0-97ce-11e6-ba93-85eff07488d9%27)))%26_g%3D(refreshInterval:(display:Off,pause:!f,value:0),time:(from:%272016-10-21T20:33:16.218032Z%27,mode:quick,to:%27now%27))", "user": {"user_id": "11111111-1111-1111-1111-111111111111", "created_at": 1464729556, "destination_organization_id": null, "is_registered": true, "created_organization_id": null, "password": "SCRUBBED", "email": "devuser@getpantheon.com"}, "user_email": "devuser@getpantheon.com", "waiting_for_task": {"allow_concurrent": true, "environment": "dev", "fn_name": "queue_jenkins_task", "params": {"host": "localhost", "task_type": "converge_hostname", "job_id": "4b423792-97ce-11e6-8169-bc764e10cbc8", "hostname_id": "dev-behat-tests.onebox.pantheonsite.io"}, "site_id": "11111111-1111-1111-1111-111111111111", "trace_id": "4b2e1ff0-97ce-11e6-ba93-85eff07488d9", "workflow_id": "4b34b0e0-97ce-11e6-8169-bc764e10cbc8", "id": "4b423792-97ce-11e6-8169-bc764e10cbc8", "key": "1477080000", "responses": [], "queued_time": null, "host": "localhost", "result": null, "phase": "created", "created_at": 1477082296.306677, "run_time": null, "total_time": null, "reason": "", "error_details": "", "internal_reason": "", "trace_log_url": "https://app.logz.io/#/dashboard/kibana?kibanaRoute=discover%3F_a%3D(query:(query_string:(analyze_wildcard:!t,query:%27trace_id:4b2e1ff0-97ce-11e6-ba93-85eff07488d9%27)))%26_g%3D(refreshInterval:(display:Off,pause:!f,value:0),time:(from:%272016-10-21T20:33:16.306677Z%27,mode:quick,to:%27now%27))", "type": "converge_hostname", "build_url": null, "messages": {}}}'
+-
+    request:
+        method: GET
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/workflows/4b34b0e0-97ce-11e6-8169-bc764e10cbc8'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/1.0.0-alpha (php_version=5.5.26&script=bin/terminus)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:e0509b4c-97bc-11e6-af3a-bc764e10cbc8:IyAxuHjFsRMelKv1InUVq'
+            verify: ''
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 21 Oct 2016 20:38:18 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 4c8831b0-97ce-11e6-ba93-85eff07488d9
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"environment_id": "dev", "final_task_id": "34a7d090-97c5-11e6-b252-bc764e10cbc8", "finished_at": 1477078402.824557, "params": {}, "reason": "", "result": "succeeded", "role": "owner", "site_id": "11111111-1111-1111-1111-111111111111", "started_at": 1477078393.025379, "task_ids": ["34a4cc6a-97c5-11e6-b252-bc764e10cbc8", "34a755b6-97c5-11e6-b252-bc764e10cbc8", "34a7a854-97c5-11e6-b252-bc764e10cbc8", "34a7bbf0-97c5-11e6-b252-bc764e10cbc8", "34a7d090-97c5-11e6-b252-bc764e10cbc8"], "trace_id": "349091a0-97c5-11e6-ba93-85eff07488d9", "type": "converge_environment", "user_id": "11111111-1111-1111-1111-111111111111", "waiting_for_task_id": null, "id": "3497443c-97c5-11e6-b252-bc764e10cbc8", "key": "5bfa50d3-830a-464e-ae0b-afd983b62d51", "keep_forever": false, "phase": "finished", "queued_time": null, "run_time": 9.799178123474121, "created_at": 1477078392.805894, "environment": "dev", "total_time": 10.018663167953491, "active_description": "Converged containers on \"dev\"", "description": "Converge \"dev\"", "step": 5, "has_operation_log_output": false, "number_of_tasks": 5, "trace_log_url": "https://app.logz.io/#/dashboard/kibana?kibanaRoute=discover%3F_a%3D(query:(query_string:(analyze_wildcard:!t,query:%27trace_id:349091a0-97c5-11e6-ba93-85eff07488d9%27)))%26_g%3D(refreshInterval:(display:Off,pause:!f,value:0),time:(from:%272016-10-21T19:28:12.805894Z%27,mode:quick,to:%272016-10-21T19:38:22.824557Z%27))", "user": {"user_id": "11111111-1111-1111-1111-111111111111", "created_at": 1464729556, "destination_organization_id": null, "is_registered": true, "created_organization_id": null, "password": "SCRUBBED", "email": "devuser@pantheon.io"}, "user_email": "devuser@pantheon.io", "final_task": {"allow_concurrent": true, "build": {"url": "job/chef_solo_bindings/79811/", "number": 79811, "phase": "STARTED", "estimated_duration": 5930, "duration": 0, "full_url": "https://104.130.220.48:8090/jenkins/job/chef_solo_bindings/79811/"}, "environment": "dev", "finished_at": 1477078400.909902, "fn_name": "queue_jenkins_task", "has_error": false, "params": {"host": "104.130.220.48", "task_type": "converge_dbserver_binding", "job_id": "34a7d090-97c5-11e6-b252-bc764e10cbc8", "binding_id": "d78a1bc046414daeafe40b60c7c54b40"}, "queued_at": 1477078393.117489, "responses": [{"code": 201, "body": "Successfully queued converge_dbserver_binding", "error_details": "", "internal_reason": ""}], "result": "succeeded", "site_id": "11111111-1111-1111-1111-111111111111", "started_at": 1477078394.993618, "trace_id": "349091a0-97c5-11e6-ba93-85eff07488d9", "user_id": "pantheon", "workflow_id": "3497443c-97c5-11e6-b252-bc764e10cbc8", "id": "34a7d090-97c5-11e6-b252-bc764e10cbc8", "key": "1477076400", "queued_time": 1.876128911972046, "host": "104.130.220.48", "phase": "finished", "created_at": 1477078392.914344, "run_time": 5.916284084320068, "total_time": 7.995558023452759, "reason": "", "error_details": "", "internal_reason": "", "trace_log_url": "https://app.logz.io/#/dashboard/kibana?kibanaRoute=discover%3F_a%3D(query:(query_string:(analyze_wildcard:!t,query:%27trace_id:349091a0-97c5-11e6-ba93-85eff07488d9%27)))%26_g%3D(refreshInterval:(display:Off,pause:!f,value:0),time:(from:%272016-10-21T19:28:12.914344Z%27,mode:quick,to:%272016-10-21T19:38:20.909902Z%27))", "type": "converge_dbserver_binding", "build_url": "https://104.130.220.48:8090/jenkins/job/chef_solo_bindings/79811/", "messages": {"2016-10-21T19:34:15.054961": {"message": "Successfully queued converge_dbserver_binding", "level": "INFO"}}}}'

--- a/tests/unit_tests/new/Commands/Https/DeleteCommandTest.php
+++ b/tests/unit_tests/new/Commands/Https/DeleteCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Https;
+
+use Pantheon\Terminus\Commands\Https\DeleteCommand;
+use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+use Terminus\Exceptions\TerminusException;
+
+class DeleteCommandTest extends CommandTestCase
+{
+    public function testDelete()
+    {
+        $workflow = $this->getMockBuilder(Workflow::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        // workflow succeeded
+        $workflow->expects($this->once())->method('checkProgress')->willReturn(true);
+        $workflow->expects($this->once())->method('getMessage')->willReturn('successful workflow');
+
+        $this->environment->expects($this->once())
+            ->method('disableHttpsCertificate')
+            ->willReturn($workflow);
+
+
+        // should display a notice about the mode switch
+        $this->logger->expects($this->once())
+            ->method('log')->with(
+                $this->equalTo('notice'),
+                $this->equalTo('successful workflow')
+            );
+
+        $command = new DeleteCommand();
+        $command->setSites($this->sites);
+        $command->setLogger($this->logger);
+        $command->delete('mysite.dev');
+    }
+
+    public function testDeleteFailed()
+    {
+        $this->environment->expects($this->once())
+            ->method('disableHttpsCertificate')
+            ->will($this->throwException(new TerminusException('Could not delete')));
+
+        $command = new DeleteCommand();
+        $command->setSites($this->sites);
+
+        $this->setExpectedException(TerminusException::class);
+        $command->delete('mysite.dev');
+    }
+}

--- a/tests/unit_tests/new/Commands/Https/DeleteCommandTest.php
+++ b/tests/unit_tests/new/Commands/Https/DeleteCommandTest.php
@@ -20,16 +20,24 @@ class DeleteCommandTest extends CommandTestCase
         $workflow->expects($this->once())->method('getMessage')->willReturn('successful workflow');
 
         $this->environment->expects($this->once())
-            ->method('disableHttpsCertificate')
+            ->method('disableHttpsCertificate');
+        $this->environment->expects($this->once())
+            ->method('convergeBindings')
             ->willReturn($workflow);
 
 
         // should display a notice about the mode switch
-        $this->logger->expects($this->once())
+        $this->logger->expects($this->at(0))
+            ->method('log')->with(
+                $this->equalTo('notice'),
+                $this->equalTo('HTTPS has been disabled and the environment\'s bindings will now be converged.')
+            );
+        $this->logger->expects($this->at(1))
             ->method('log')->with(
                 $this->equalTo('notice'),
                 $this->equalTo('successful workflow')
             );
+
 
         $command = new DeleteCommand();
         $command->setSites($this->sites);


### PR DESCRIPTION
This command attempts to replicate the logic that the dashboard uses to disable a cert:

https://github.com/pantheon-systems/dashboard/blob/479ac550619c77871a2dd6a5647b6fee73f5a808/app/workshops/site/views/tools/domains/ssl_view.coffee#L120

One critical gap that this PR leaves in testing coverage is unit test of `Environment::disableHttpsCertificate`. Since the `Environment` model is not yet converted over to the new framework, I think we should leave that testing until it is ported.
