### PR TITLE
Fixes a composition strict warning for OrganizationSiteMemberships

### DIFF
--- a/src/Collections/OrganizationSiteMemberships.php
+++ b/src/Collections/OrganizationSiteMemberships.php
@@ -8,10 +8,8 @@ use Pantheon\Terminus\Models\Organization;
 use Terminus\Exceptions\TerminusException;
 use Terminus\Exceptions\TerminusNotFoundException;
 
-class OrganizationSiteMemberships extends TerminusCollection implements ContainerAwareInterface
+class OrganizationSiteMemberships extends TerminusCollection
 {
-    use ContainerAwareTrait;
-
     /**
      * @var Organization
      */


### PR DESCRIPTION
OrganizationSiteMemberships was using the ContainerAwareTrait which was also being used by it’s parent. This caused a php-strict warning.