### PR TITLE
Adds base class for site/org owned collections

### DIFF
--- a/src/Collections/Bindings.php
+++ b/src/Collections/Bindings.php
@@ -5,44 +5,38 @@ namespace Pantheon\Terminus\Collections;
 use Pantheon\Terminus\Models\Binding;
 use Pantheon\Terminus\Models\Environment;
 
-class Bindings extends TerminusCollection
+class Bindings extends EnvironmentOwnedCollection
 {
-  /**
-   * @var Environment
-   */
+    /**
+     * @var Environment
+     */
     public $environment;
-  /**
-   * @var string
-   */
+
+    /**
+     * @var string
+     */
     protected $collected_class = 'Pantheon\Terminus\Models\Binding';
 
-  /**
-   * Object constructor
-   *
-   * @param array $options Options to set as $this->key
-   */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->environment = $options['environment'];
-        $this->url = "sites/{$this->environment->site->id}/bindings";
-    }
+    /**
+     * @var string
+     */
+    protected $url = 'sites/{site_id}/bindings';
 
-  /**
-   * Get bindings by type
-   *
-   * @param string $type e.g. "appserver", "db server", etc
-   * @return Binding[]
-   */
+    /**
+     * Get bindings by type
+     *
+     * @param string $type e.g. "appserver", "db server", etc
+     * @return Binding[]
+     */
     public function getByType($type)
     {
         $models = array_filter(
             $this->all(),
             function (Binding $binding) use ($type) {
                 $is_valid = (
-                $binding->get('type') == $type
-                && !$binding->get('failover')
-                && !$binding->get('slave_of')
+                    $binding->get('type') == $type
+                    && !$binding->get('failover')
+                    && !$binding->get('slave_of')
                 );
                 return $is_valid;
             }

--- a/src/Collections/Branches.php
+++ b/src/Collections/Branches.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus\Collections;
 
-class Branches extends TerminusCollection
+class Branches extends SiteOwnedCollection
 {
     /**
      * @var Site
@@ -14,14 +14,9 @@ class Branches extends TerminusCollection
     protected $collected_class = 'Pantheon\Terminus\Models\Branch';
 
     /**
-     * @inheritdoc
+     * @var string
      */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->site = $options['site'];
-        $this->url = "sites/{$this->site->id}/code-tips";
-    }
+    protected $url = 'sites/{site_id}/code-tips';
 
     /**
      * @inheritdoc

--- a/src/Collections/Commits.php
+++ b/src/Collections/Commits.php
@@ -2,32 +2,16 @@
 
 namespace Pantheon\Terminus\Collections;
 
-use Pantheon\Terminus\Models\Environment;
-
-class Commits extends TerminusCollection
+class Commits extends EnvironmentOwnedCollection
 {
-  /**
-   * @var Environment
-   */
-    public $environment;
-  /**
-   * @var string
-   */
+
+    /**
+     * @var string
+     */
     protected $collected_class = 'Pantheon\Terminus\Models\Commit';
 
-  /**
-   * Object constructor
-   *
-   * @param array $options Options to set as $this->key
-   */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->environment = $options['environment'];
-        $this->url = sprintf(
-            'sites/%s/environments/%s/code-log',
-            $this->environment->site->id,
-            $this->environment->id
-        );
-    }
+    /**
+     * @var string
+     */
+    protected $url = 'sites/{site_id}/environments/{environment_id}/code-log';
 }

--- a/src/Collections/EnvironmentOwnedCollection.php
+++ b/src/Collections/EnvironmentOwnedCollection.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Pantheon\Terminus\Models\Environment;
+
+class EnvironmentOwnedCollection extends TerminusCollection
+{
+    /**
+     * @var Environment
+     */
+    protected $environment;
+
+    /**
+     * Object constructor
+     *
+     * @param array $options Options to set as $this->key
+     */
+    public function __construct($options = [])
+    {
+        parent::__construct($options);
+        $this->setEnvironment($options['environment']);
+    }
+
+    /**
+     * @return Environment
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @param Environment $environment
+     */
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUrl()
+    {
+        return $this->replaceUrlTokens(parent::getUrl());
+    }
+
+    /**
+     * @param $url
+     * @return string
+     */
+    protected function replaceUrlTokens($url) {
+        $tr = [
+            '{environment_id}' => $this->getEnvironment()->id,
+            '{site_id}' => $this->getEnvironment()->site->id
+        ];
+        return strtr($url, $tr);
+    }
+}

--- a/src/Collections/Environments.php
+++ b/src/Collections/Environments.php
@@ -4,28 +4,19 @@ namespace Pantheon\Terminus\Collections;
 
 use Pantheon\Terminus\Models\Environment;
 
-class Environments extends TerminusCollection
+class Environments extends SiteOwnedCollection
 {
-    /**
-     * @var Site
-     */
-    public $site;
+
     /**
      * @var string
      */
     protected $collected_class = 'Pantheon\Terminus\Models\Environment';
 
     /**
-     * Object constructor
-     *
-     * @param array $options Options to set as $this->key
+     * @var string
      */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->site = $options['site'];
-        $this->url = "sites/{$this->site->id}/environments";
-    }
+    protected $url = 'users/{site_id}/environments';
+
 
     /**
      * Creates a multidev environment
@@ -36,7 +27,7 @@ class Environments extends TerminusCollection
      */
     public function create($to_env_id, Environment $from_env)
     {
-        $workflow = $this->site->getWorkflows()->create(
+        $workflow = $this->getSite()->getWorkflows()->create(
             'create_cloud_development_environment',
             [
                 'params' => [

--- a/src/Collections/Hostnames.php
+++ b/src/Collections/Hostnames.php
@@ -5,29 +5,22 @@ namespace Pantheon\Terminus\Collections;
 use Pantheon\Terminus\Models\Environment;
 use Terminus\Exceptions\TerminusNotFoundException;
 
-class Hostnames extends TerminusCollection
+class Hostnames extends EnvironmentOwnedCollection
 {
-    /**
-     * @var Environment
-     */
-    public $environment;
     /**
      * @var string
      */
     protected $collected_class = 'Pantheon\Terminus\Models\Hostname';
+
+    /**
+     * @var string
+     */
+    protected $url = 'sites/{site_id}/environments/{environment_id}/hostnames';
+
     /**
      * @var mixed Use to hydrate the data with additional information
      */
     protected $hydrate = false;
-
-    /**
-     * @inheritdoc
-     */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->environment = $options['environment'];
-    }
 
     /**
      * Adds a hostname to the environment
@@ -37,12 +30,8 @@ class Hostnames extends TerminusCollection
      */
     public function create($hostname)
     {
-        $url = sprintf(
-            'sites/%s/environments/%s/hostnames/%s',
-            $this->environment->site->id,
-            $this->environment->id,
-            rawurlencode($hostname)
-        );
+        $url = $this->replaceUrlTokens('sites/{site_id}/environments/{environment_id}/hostnames/');
+        $url .= rawurlencode($hostname);
         $this->request->request($url, ['method' => 'put',]);
     }
 
@@ -60,12 +49,7 @@ class Hostnames extends TerminusCollection
 
     public function getUrl()
     {
-        return sprintf(
-            'sites/%s/environments/%s/hostnames?hydrate=%s',
-            $this->environment->site->id,
-            $this->environment->id,
-            $this->hydrate
-        );
+        return parent::getUrl() . '?hydrate=' . $this->hydrate;
     }
 
     /**

--- a/src/Collections/SiteOrganizationMemberships.php
+++ b/src/Collections/SiteOrganizationMemberships.php
@@ -7,32 +7,22 @@ use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\SiteOrganizationMembership;
 use Pantheon\Terminus\Models\Workflow;
 
-class SiteOrganizationMemberships extends TerminusCollection
+class SiteOrganizationMemberships extends SiteOwnedCollection
 {
-    /**
-     * @var Site
-     */
-    public $site;
     /**
      * @var string
      */
     protected $collected_class = 'Pantheon\Terminus\Models\SiteOrganizationMembership';
+
+    /**
+     * @var string
+     */
+    protected $url = 'sites/{site_id}/memberships/organizations';
+
     /**
      * @var boolean
      */
     protected $paged = true;
-
-    /**
-     * Object constructor
-     *
-     * @param array $options Options to set as $this->key
-     */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->site = $options['site'];
-        $this->url = "sites/{$this->site->id}/memberships/organizations";
-    }
 
     /**
      * Adds this org as a member to the site
@@ -43,7 +33,7 @@ class SiteOrganizationMemberships extends TerminusCollection
      **/
     public function create($name, $role)
     {
-        $workflow = $this->site->getWorkflows()->create(
+        $workflow = $this->getSite()->getWorkflows()->create(
             'add_site_organization_membership',
             ['params' => ['organization_name' => $name, 'role' => $role,],]
         );

--- a/src/Collections/SiteOwnedCollection.php
+++ b/src/Collections/SiteOwnedCollection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pantheon\Terminus\Collections;
+
+use Pantheon\Terminus\Models\Site;
+
+class SiteOwnedCollection extends TerminusCollection
+{
+    /**
+     * @var Site
+     */
+    protected $site;
+
+    /**
+     * Object constructor
+     *
+     * @param array $options Options to set as $this->key
+     */
+    public function __construct($options = [])
+    {
+        parent::__construct($options);
+        $this->setSite($options['site']);
+    }
+
+    /**
+     * @return Site
+     */
+    public function getSite()
+    {
+        return $this->site;
+    }
+
+    /**
+     * @param Site $site
+     */
+    public function setSite($site)
+    {
+        $this->site = $site;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUrl()
+    {
+        return str_replace('{site_id}', $this->getSite()->id, parent::getUrl());
+    }
+}

--- a/src/Collections/SiteUserMemberships.php
+++ b/src/Collections/SiteUserMemberships.php
@@ -4,32 +4,22 @@ namespace Pantheon\Terminus\Collections;
 
 use Terminus\Exceptions\TerminusNotFoundException;
 
-class SiteUserMemberships extends TerminusCollection
+class SiteUserMemberships extends SiteOwnedCollection
 {
-    /**
-     * @var Site
-     */
-    public $site;
     /**
      * @var string
      */
     protected $collected_class = 'Pantheon\Terminus\Models\SiteUserMembership';
+
+    /**
+     * @var string
+     */
+    protected $url = 'users/{site_id}/memberships/users';
+
     /**
      * @var boolean
      */
     protected $paged = true;
-
-    /**
-     * Object constructor
-     *
-     * @param array $options Options to set as $this->key
-     */
-    public function __construct($options = [])
-    {
-        parent::__construct($options);
-        $this->site = $options['site'];
-        $this->url = "sites/{$this->site->id}/memberships/users";
-    }
 
     /**
      * Adds this user as a member to the site


### PR DESCRIPTION
This creates base classes for collections owned by sites and by environment. It simplifies the collection classes somewhat by abstracting away some of the mechanics of injecting the collection owner and generating the URL for the collection.

This method could also be used to simplify many of the models and some of the unit tests.
