### PR TITLE
Add new DataStore to replace FileCache

### DIFF
--- a/src/DataStore/DataStoreAwareInterface.php
+++ b/src/DataStore/DataStoreAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+interface DataStoreAwareInterface
+{
+    /***
+     * Inject a data store object.
+     *
+     * @param DataStoreInterface $data_store
+     */
+    public function setDataStore(DataStoreInterface $data_store);
+
+    /**
+     * Get the data store object.
+     *
+     * @return DataStoreInterface
+     */
+    public function getDataStore();
+}

--- a/src/DataStore/DataStoreAwareTrait.php
+++ b/src/DataStore/DataStoreAwareTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+trait DataStoreAwareTrait
+{
+    /**
+     * @var DataStoreInterface
+     */
+    protected $data_store;
+
+    /**
+     * @return mixed
+     */
+    public function getDataStore()
+    {
+        return $this->data_store;
+    }
+
+    /**
+     * @param DataStoreInterface $data_store
+     */
+    public function setDataStore(DataStoreInterface $data_store)
+    {
+        $this->data_store = $data_store;
+    }
+}

--- a/src/DataStore/DataStoreInterface.php
+++ b/src/DataStore/DataStoreInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+/**
+ * Interface DataStoreInterface
+ */
+interface DataStoreInterface
+{
+    /**
+     * Reads retrieves data from the store
+     *
+     * @param string $key A key
+     * @return mixed The value fpr the given key or null.
+     */
+    public function get($key);
+
+    /**
+     * Saves a value with the given key
+     *
+     * @param string $key A key
+     * @param mixed $data Data to save to the store
+     */
+    public function set($key, $data);
+
+    /**
+     * Checks if a key is in the store
+     *
+     * @param string $key A key
+     * @return bool Whether a value exists with the given key
+     */
+    public function has($key);
+
+    /**
+     * Remove value from the store
+     *
+     * @param string $key A key
+     */
+    public function remove($key);
+
+    /**
+     * Return a list of all keys in the store.
+     * @return array A list of keys
+     */
+    public function keys();
+}

--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Pantheon\Terminus\DataStore;
+
+use Terminus\Exceptions\TerminusException;
+
+class FileStore implements DataStoreInterface
+{
+    /**
+     * @var string The directory to store the data files in.
+     */
+    protected $directory;
+
+    public function __construct($directory)
+    {
+        $this->directory = $directory;
+    }
+
+    /**
+     * Reads retrieves data from the store
+     *
+     * @param string $key A key
+     * @return mixed The value fpr the given key or null.
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function get($key)
+    {
+        $out = null;
+        // Read the json encoded value from disk if it exists.
+        $path = $this->getFileName($key);
+        if (file_exists($path)) {
+            $out = file_get_contents($path);
+            $out = json_decode($out);
+        }
+        return $out;
+    }
+
+    /**
+     * Saves a value with the given key
+     *
+     * @param string $key A key
+     * @param mixed $data Data to save to the store
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function set($key, $data)
+    {
+        $path = $this->getFileName($key);
+        file_put_contents($path, json_encode($data));
+    }
+
+    /**
+     * Checks if a key is in the store
+     *
+     * @param string $key A key
+     * @return bool Whether a value exists with the given key
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function has($key)
+    {
+        $path = $this->getFileName($key);
+        return file_exists($path);
+    }
+
+    /**
+     * Remove value from the store
+     *
+     * @param string $key A key
+     * @throws \Terminus\Exceptions\TerminusException
+     */
+    public function remove($key)
+    {
+        $path = $this->getFileName($key);
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    /**
+     * Return a list of all keys in the store.
+     * @return array A list of keys
+     */
+    public function keys()
+    {
+        $root = $this->directory;
+        return array_diff(scandir($root), array('..', '.'));
+    }
+
+    /**
+     * Get a valid file name for the given key.
+     * @param string $key The data key to be written or read
+     * @return string A file path
+     * @throws TerminusException
+     */
+    protected function getFileName($key)
+    {
+        $key = $this->cleanKey($key);
+
+        // Reality check to prevent stomping on the local filesystem if there is something wrong with the config.
+        if (!$this->directory) {
+            throw new TerminusException('Could not save data to a file because the path setting is mis-configured.');
+        }
+        if (!$key) {
+            throw new TerminusException('Could not save data to a file because it is missing an ID');
+        }
+
+        return $this->directory . '/' . $key;
+    }
+
+    /**
+     * Make the file path safe by whitelisting characters.
+     * This is a very naive approach to hashing but in practice this doesn't matter since this is only used for a
+     * few already safe keys.
+     *
+     * @param $key
+     * @return mixed
+     */
+    protected function cleanKey($key)
+    {
+        return preg_replace('/[^a-zA-Z0-9\-\_\@\.]/', '-', $key);
+    }
+}

--- a/tests/new_unit_tests/DataStore/FileStoreTest.php
+++ b/tests/new_unit_tests/DataStore/FileStoreTest.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\DataStore;
+
+class FileStoreTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testSet()
+    {
+    }
+
+    public function testGet()
+    {
+    }
+
+    public function testKeys()
+    {
+    }
+
+    public function testHas()
+    {
+    }
+}

--- a/tests/unit_tests/new/Session/SessionTest.php
+++ b/tests/unit_tests/new/Session/SessionTest.php
@@ -4,8 +4,8 @@ namespace Pantheon\Terminus\UnitTests\Session;
 
 use League\Container\Container;
 use Pantheon\Terminus\Config;
+use Pantheon\Terminus\DataStore\FileStore;
 use Pantheon\Terminus\Session\Session;
-use Terminus\Caches\FileCache;
 use Pantheon\Terminus\Models\User;
 
 /**
@@ -19,16 +19,16 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->filecache = $this->getMockBuilder(FileCache::class)
-        ->disableOriginalConstructor()
-        ->getMock();
+        $this->filecache = $this->getMockBuilder(FileStore::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->session = new Session($this->filecache);
     }
 
-  /**
-   * Test getting and setting data
-   */
+    /**
+     * Test getting and setting data
+     */
     public function testSetGet()
     {
         $data = [
@@ -36,7 +36,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             'abc' => 123
         ];
         $this->filecache->expects($this->once())
-            ->method('getData')
+            ->method('get')
             ->with('session')
             ->willReturn($data);
 
@@ -48,19 +48,19 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     }
 
 
-  /**
-   * Test getting and setting data
-   */
+    /**
+     * Test getting and setting data
+     */
     public function testSetData()
     {
         $data = [
-        'foo' => 'bar',
-        'abc' => 123
+            'foo' => 'bar',
+            'abc' => 123
         ];
 
         $this->filecache->expects($this->once())
-        ->method('putData')
-        ->with('session', $data);
+            ->method('set')
+            ->with('session', $data);
 
         $this->session->setData($data);
 
@@ -69,9 +69,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-  /**
-   * Test getting and setting data
-   */
+    /**
+     * Test getting and setting data
+     */
     public function testGetUser()
     {
         $container = $this->getMockBuilder(Container::class)
@@ -83,11 +83,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with(User::class, [(object)array('id' => '123')])
             ->willReturn($user);
-        
+
         $this->filecache->expects($this->once())
-        ->method('getData')
-        ->with('session')
-        ->willReturn(['user_id' => '123']);
+            ->method('get')
+            ->with('session')
+            ->willReturn(['user_id' => '123']);
 
         $this->session = new Session($this->filecache);
         $this->session->setContainer($container);
@@ -96,14 +96,14 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($user, $out);
     }
 
-  /**
-   * Test destroying the session
-   */
+    /**
+     * Test destroying the session
+     */
     public function testDestroy()
     {
         $this->filecache->expects($this->once())
-        ->method('remove')
-        ->with('session');
+            ->method('remove')
+            ->with('session');
 
         $this->session->destroy();
     }
@@ -119,7 +119,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             'expires_at' => time() + 100
         ];
         $this->filecache->expects($this->any())
-            ->method('getData')
+            ->method('get')
             ->with('session')
             ->willReturn($data);
 
@@ -139,11 +139,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             'expires_at' => time() - 100
         ];
         $this->filecache->expects($this->once())
-            ->method('getData')
+            ->method('get')
             ->with('session')
             ->willReturn($data);
 
-        $config =  $this->getMockBuilder(Config::class)
+        $config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $config->expects($this->once())
@@ -166,11 +166,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             'expires_at' => time() - 100
         ];
         $this->filecache->expects($this->once())
-            ->method('getData')
+            ->method('get')
             ->with('session')
             ->willReturn($data);
 
-        $config =  $this->getMockBuilder(Config::class)
+        $config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $config->expects($this->once())


### PR DESCRIPTION
I resurrected this from a previous PR that didn't get merged. 

This removes the over-complex and difficult to test FileCache and adds the simpler and more abstracted FileStore. It also moves the 'where to store' logic for sessions and tokens into the Runner so that those classes no longer have any knowledge of the mechanism of storage.