### PR TITLE
Adds plugin loading for commands and hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.5.9",
+    "composer/semver": "1.4",
     "consolidation/robo": "^1.0.5",
     "guzzlehttp/guzzle": "^6.2",
     "psy/psysh": "^0.7",

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -25,6 +25,7 @@ TERMINUS_TIME_ZONE:     'UTC'
 
 # File Storage
 TERMINUS_CACHE_DIR:     '[[ TERMINUS_USER_HOME ]]/.terminus/cache'
+TERMINUS_PLUGINS_DIR:   '[[ TERMINUS_USER_HOME ]]/.terminus/plugins'
 TERMINUS_LOG_DIR:       '/tmp'
 TERMINUS_TOKENS_DIR:    '[[ TERMINUS_CACHE_DIR ]]/tokens'
 TERMINUS_ASSETS_DIR:    '[[ TERMINUS_ROOT ]]/assets'

--- a/src/Plugins/PluginDiscovery.php
+++ b/src/Plugins/PluginDiscovery.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Pantheon\Terminus\Plugins;
+
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Class PluginDiscovery
+ */
+class PluginDiscovery implements ContainerAwareInterface, LoggerAwareInterface
+{
+    use ContainerAwareTrait;
+    use LoggerAwareTrait;
+
+    /**
+     * @var string The path to the directory to search for plugins.
+     */
+    protected $directory_path;
+
+    /**
+     * PluginDiscovery constructor.
+     *
+     * @param $path
+     */
+    public function __construct($path)
+    {
+        $this->directory_path = $path;
+    }
+
+    /**
+     * Return a list of plugin
+     *
+     * @return PluginInfo[]
+     */
+    public function discover()
+    {
+        $out = [];
+        try {
+            $di = new \DirectoryIterator($this->directory_path);
+            foreach ($di as $dir) {
+                if ($dir->isDir() && !$dir->isDot() && $dir->isReadable()) {
+                    try {
+                        $out[] = $this->getContainer()->get(PluginInfo::class, [$dir->getPathname()]);
+                    } catch (TerminusException $e) {
+                        $this->logger->debug(
+                            'Plugin Discovery: Ignoring directory {dir} because: {msg}.',
+                            ['dir' => $dir->getPathName(), 'msg' => $e->getMessage()]
+                        );
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // Plugin directory probably didn't exist or wasn't writable. Do nothing.
+        }
+        return $out;
+    }
+}

--- a/src/Plugins/PluginInfo.php
+++ b/src/Plugins/PluginInfo.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Pantheon\Terminus\Plugins;
+
+use Composer\Semver\Semver;
+use Consolidation\AnnotatedCommand\CommandFileDiscovery;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+class PluginInfo
+{
+    const MAX_COMMAND_DEPTH = 4;
+
+    /**
+     * @var string
+     */
+    protected $plugin_dir;
+
+    /**
+     * @var null|array
+     */
+    protected $info = null;
+
+    /**
+     * PluginInfo constructor.
+     * @param $plugin_dir
+     */
+    public function __construct($plugin_dir)
+    {
+        $this->plugin_dir = $plugin_dir;
+        $this->info = $this->parsePluginInfo();
+    }
+
+    /**
+     * Get the info array for the plugin.
+     *
+     * @return array|null|string
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+
+    /**
+     * Get all of the commands and hooks in the plugin.
+     *
+     * @return array
+     */
+    public function getCommandsAndHooks()
+    {
+        $path = $this->getCommandFileDirectory();
+        $namespace = $this->getCommandNamespace();
+        $discovery = new CommandFileDiscovery();
+        $discovery->setSearchPattern('*Command.php')->setSearchLocations([])->setSearchDepth(self::MAX_COMMAND_DEPTH);
+        $command_files = $discovery->discover($path, $namespace);
+
+        // @TODO: Decide if we should require an autoloader for plugins or just include the command files here.
+        foreach ($command_files as $file => $class) {
+            include $file;
+        }
+
+        return $command_files;
+    }
+
+    /**
+     * Read and parse the info for the plugin.
+     *
+     * @return array|string
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    protected function parsePluginInfo()
+    {
+        // Each of these checks is broken out so that a plugin author can get specific error message if the plugin is malformed.
+        if (!$this->plugin_dir) {
+            throw new TerminusException('No plugin directory was specified');
+        }
+        if (!file_exists($this->plugin_dir)) {
+            throw new TerminusException('The directory "{dir}" is does not exist', ['dir' => $this->plugin_dir]);
+        }
+        if (!is_dir($this->plugin_dir)) {
+            throw new TerminusException('The file "{dir}" is not a directory', ['dir' => $this->plugin_dir]);
+        }
+        if (!is_readable($this->plugin_dir)) {
+            throw new TerminusException('The directory "{dir}" is not readable', ['dir' => $this->plugin_dir]);
+        }
+
+        $composer_json = $this->plugin_dir . '/composer.json';
+        if (!file_exists($composer_json)) {
+            throw new TerminusException('The file "{file}" is does not exist', ['file' => $composer_json]);
+        }
+        if (!is_readable($composer_json)) {
+            throw new TerminusException('The file "{file}" is not readable', ['file' => $composer_json]);
+        }
+
+        $info = json_decode(file_get_contents($composer_json), true);
+
+        if (!$info) {
+            throw new TerminusException('The file "{file}" is not a valid', ['file' => $composer_json]);
+        }
+
+        if (!$info['type'] || $info['type'] !== 'terminus-plugin') {
+            throw new TerminusException('The composer.json must contain a "type" attribute with the value "terminus-plugin"');
+        }
+
+        if (!isset($info['extra']['terminus'])) {
+            throw new TerminusException('The composer.json must contain a "terminus" section in "extras"');
+        }
+
+        if (!isset($info['extra']['terminus']['compatible-version'])) {
+            throw new TerminusException('The composer.json must contain a "compatible-version" field in "extras/terminus"');
+        }
+
+        return (array)$info;
+    }
+
+    /**
+     * Get the compatible Terminus version.
+     *
+     * @return string A version constraint string defining what versions of Terminus this plugin works with.
+     */
+    public function getCompatibleTerminusVersion()
+    {
+        return $this->getInfo()['extra']['terminus']['compatible-version'];
+    }
+
+    public function getName()
+    {
+        $info = $this->getInfo();
+        if (isset($info['name'])) {
+            return $info['name'];
+        }
+        return basename($this->plugin_dir);
+    }
+
+    /**
+     * Return the namespace for this plugin's commands and hooks.
+     *
+     * @return string
+     */
+    protected function getCommandNamespace()
+    {
+        $autoload = $this->getAutoloadInfo();
+        return $autoload['prefix'];
+    }
+
+    /**
+     * Return the directory where this plugin stores it's command files.
+     *
+     * @return string
+     */
+    private function getCommandFileDirectory()
+    {
+        $autoload = $this->getAutoloadInfo();
+        return $this->plugin_dir . '/' . $autoload['dir'];
+    }
+
+    /**
+     * Get the PSR-4 autoload info from the composer.json if any.
+     *
+     * @return array
+     */
+    protected function getAutoloadInfo()
+    {
+        $info = $this->getInfo();
+        if (isset($info['autoload']['psr-4'])) {
+            $keys = array_keys($info['autoload']['psr-4']);
+            return [
+                'prefix' => reset($keys),
+                'dir' => reset($info['autoload']['psr-4'])
+            ];
+        }
+        return ['prefix' => '', 'dir' => 'src'];
+    }
+}

--- a/tests/fixtures/plugins/invalid-no-composer-json/src/NullCommand.php
+++ b/tests/fixtures/plugins/invalid-no-composer-json/src/NullCommand.php
@@ -1,0 +1,16 @@
+<?php
+// @codingStandardsIgnoreStart
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}
+// @codingStandardsIgnoreEnd

--- a/tests/fixtures/plugins/invalid-wrong-composer-type/composer.json
+++ b/tests/fixtures/plugins/invalid-wrong-composer-type/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "orgnanme/wrong-type",
+    "description": "An test Terminus command",
+    "type": "foo",
+    "extra": {
+        "terminus": {
+            "compatible-version": "1.*"
+        }
+    }
+}

--- a/tests/fixtures/plugins/invalid-wrong-composer-type/src/Commands/Hello/NullCommand.php
+++ b/tests/fixtures/plugins/invalid-wrong-composer-type/src/Commands/Hello/NullCommand.php
@@ -1,0 +1,16 @@
+<?php
+// @codingStandardsIgnoreStart
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}
+// @codingStandardsIgnoreEnd

--- a/tests/fixtures/plugins/with-namespace/composer.json
+++ b/tests/fixtures/plugins/with-namespace/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "orgname/with-namespace",
+    "description": "A test Terminus command with namespacing",
+    "type": "terminus-plugin",
+    "extra": {
+        "terminus": {
+            "compatible-version": "1.*"
+        }
+    },
+    "license": "MIT",
+    "autoload": {
+        "psr-4": { "OrgName\\PluginName": "src" }
+    }
+}

--- a/tests/fixtures/plugins/with-namespace/src/Commands/NullCommand.php
+++ b/tests/fixtures/plugins/with-namespace/src/Commands/NullCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OrgName\PluginName\Commands;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}

--- a/tests/fixtures/plugins/with-namespace/src/Commands/OptionalCommandGroup/NullCommand.php
+++ b/tests/fixtures/plugins/with-namespace/src/Commands/OptionalCommandGroup/NullCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OrgName\PluginName\Commands\OptionalCommandGroup;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class GroupNullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:group:null
+     */
+    public function doNothing()
+    {
+    }
+}

--- a/tests/fixtures/plugins/without-namespace/composer.json
+++ b/tests/fixtures/plugins/without-namespace/composer.json
@@ -1,0 +1,9 @@
+{
+    "description": "An test Terminus command with no namespacing",
+    "type": "terminus-plugin",
+    "extra": {
+        "terminus": {
+            "compatible-version": "1.*"
+        }
+    }
+}

--- a/tests/fixtures/plugins/without-namespace/src/NullCommand.php
+++ b/tests/fixtures/plugins/without-namespace/src/NullCommand.php
@@ -1,0 +1,16 @@
+<?php
+// @codingStandardsIgnoreStart
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}
+// @codingStandardsIgnoreEnd

--- a/tests/unit_tests/Plugins/PluginDiscoveryTest.php
+++ b/tests/unit_tests/Plugins/PluginDiscoveryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Plugins;
+
+use League\Container\Container;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Plugins\PluginDiscovery;
+use Pantheon\Terminus\Plugins\PluginInfo;
+use Psr\Log\NullLogger;
+
+class PluginDiscoveryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDiscover()
+    {
+        $plugins_dir = __DIR__ . '/../../fixtures/plugins/';
+
+        $paths = [
+            $plugins_dir  . 'invalid-no-composer-json',
+            $plugins_dir  . 'invalid-wrong-composer-type',
+            $plugins_dir  . 'with-namespace',
+            $plugins_dir  . 'without-namespace'
+        ];
+
+        $logger = $this->getMockBuilder(NullLogger::class)
+            ->setMethods(array('debug'))
+            ->getMock();
+
+
+        $container = $this->getMockBuilder(Container::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $expected = [];
+        $log = 0;
+        foreach ($paths as $i => $path) {
+            if (strpos($path, 'invalid')) {
+                $msg = "Plugin $i is not valid";
+                $container->expects($this->at($i))
+                    ->method('get')
+                    ->with(PluginInfo::class, [$path])
+                    ->willThrowException(new TerminusException($msg));
+
+                $logger->expects($this->at($log++))
+                    ->method('debug')
+                    ->with('Plugin Discovery: Ignoring directory {dir} because: {msg}.', ['dir' => $path, 'msg' => $msg]);
+            } else {
+                $plugin = $this->getMockBuilder(PluginInfo::class)
+                    ->disableOriginalConstructor()
+                    ->getMock();
+                $container->expects($this->at($i))
+                    ->method('get')
+                    ->with(PluginInfo::class, [$path])
+                    ->willReturn($plugin);
+                $expected[] = $plugin;
+            }
+        }
+
+        $discovery = new PluginDiscovery($plugins_dir);
+        $discovery->setContainer($container);
+        $discovery->setLogger($logger);
+
+        $actual = $discovery->discover();
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/unit_tests/Plugins/PluginInfoTest.php
+++ b/tests/unit_tests/Plugins/PluginInfoTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Plugins;
+
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Plugins\PluginInfo;
+
+class PluginInfoTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->plugins_dir = __DIR__ . '/../../fixtures/plugins/';
+
+        $this->paths = [
+            $this->plugins_dir . 'invalid-no-composer-json',
+            $this->plugins_dir . 'invalid-wrong-composer-type',
+            $this->plugins_dir . 'with-namespace',
+            $this->plugins_dir . 'without-namespace'
+        ];
+    }
+
+    public function testCreatePluginInfo()
+    {
+        $plugin = new PluginInfo($this->paths[2]);
+
+        $info = $plugin->getInfo();
+        $this->assertEquals('orgname/with-namespace', $info['name']);
+        $this->assertEquals('A test Terminus command with namespacing', $info['description']);
+        $this->assertEquals('terminus-plugin', $info['type']);
+        $this->assertEquals('MIT', $info['license']);
+    }
+
+    public function testLoadCommands()
+    {
+        $plugin = new PluginInfo($this->paths[2]);
+
+        $expected = [
+            $this->plugins_dir . 'with-namespace/src/Commands/NullCommand.php' => 'OrgName\\PluginName\\Commands\\NullCommand',
+            $this->plugins_dir . 'with-namespace/src/Commands/OptionalCommandGroup/NullCommand.php' => 'OrgName\\PluginName\\Commands\\OptionalCommandGroup\\NullCommand',
+        ];
+        $actual = $plugin->getCommandsAndHooks();
+        $this->assertEquals($expected, $actual);
+
+
+        $plugin = new PluginInfo($this->paths[3]);
+
+        $expected = [
+            $this->plugins_dir . 'without-namespace/src/NullCommand.php' => 'NullCommand',
+        ];
+        $actual = $plugin->getCommandsAndHooks();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testFailNoComposer()
+    {
+        $this->setExpectedException(TerminusException::class);
+        new PluginInfo($this->paths[0]);
+    }
+
+    public function testFailInvalidType()
+    {
+        $this->setExpectedException(TerminusException::class);
+        new PluginInfo($this->paths[0]);
+    }
+
+    public function testGetName()
+    {
+        $plugin = new PluginInfo($this->paths[2]);
+        $this->assertEquals('orgname/with-namespace', $plugin->getName());
+
+        $plugin = new PluginInfo($this->paths[3]);
+        $this->assertEquals('without-namespace', $plugin->getName());
+    }
+
+    public function testGetTerminusVersion()
+    {
+        $plugin = new PluginInfo($this->paths[2]);
+        $this->assertEquals('1.*', $plugin->getCompatibleTerminusVersion());
+    }
+}


### PR DESCRIPTION
This implements an EXTREMELY rudimentary plugin loader. In it's current form it

1) Does not require plugins to have an autoloader or composer.json
2) Requires plugin classes to be in PSR-0 style directories
3) Uses a pretty ugly `include` statement to include the command class files.

This take is not terribly sophisticated but it works and it makes very few requirements on the plugin writers. The Symfony CommandFileDiscovery class seems to have basic support for psr-0 loading which allows this to operate with very little work for us or our plugin writers. The downsides of this are that psr-0 is deprecated and the plugins have to adhere to its awkward directory structure.

If we want a plugin manager that allows for PSR-4 directories (or some other arbitrary structure) we will need to do a bit of work to create our own command discovery class.

The plugin structure for this take would be:

```
plugin-directory/
    composer.json // Not actually used yet
    src/
        NameSpace/
            SubNameSpace/
                 Commands/
                     SomeGreatCommand.php

@TeslaDethray @greg-1-anderson 
What do you think of this compromise? Is it worth the extra effort to allow for a simpler directory structure for plugins? We can always add more sophisticated loaders later as long as we promise to still support whatever structure we specify at launch.



