### PR TITLE
AL-747 Update Auth and Backup Commands' help text

### DIFF
--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -12,19 +12,20 @@ use Pantheon\Terminus\Exceptions\TerminusException;
 class LoginCommand extends TerminusCommand
 {
     /**
-     * Log a user into Pantheon
+     * Logs in a user to Pantheon.
      *
      * @command auth:login
      * @aliases login
      *
-     * @option machine-token A machine token to be saved for future logins
+     * @option machine-token Grants access for a user and is saved for future logins
+     * @option email Uses an existing machine token for this user
      *
      * @usage terminus auth:login --machine-token=<machine_token>
-     *   Logs in the user granted the machine token <machine_token>
+     *     Logs in a user granted the machine token <machine_token>.
      * @usage terminus auth:login
-     *   Logs in your user with a previously saved machine token
+     *     Logs in a user with a previously saved machine token.
      * @usage terminus auth:login --email=<email>
-     *   Logs in your user with a previously saved machine token belonging to <email>
+     *     Logs in a user with a previously saved machine token belonging to <email>.
      */
     public function logIn(array $options = ['machine-token' => null, 'email' => null,])
     {

--- a/src/Commands/Auth/LogoutCommand.php
+++ b/src/Commands/Auth/LogoutCommand.php
@@ -12,13 +12,13 @@ class LogoutCommand extends TerminusCommand
 {
 
     /**
-     * Log the currently logged-in user out of Pantheon
+     * Logs out the currently logged-in user.
      *
      * @command auth:logout
      * @aliases logout
      *
      * @usage terminus auth:logout
-     *   Logs you out of Pantheon by removing your saved session
+     *     Logs out of Pantheon and removes saved session.
      */
     public function logOut()
     {

--- a/src/Commands/Auth/WhoamiCommand.php
+++ b/src/Commands/Auth/WhoamiCommand.php
@@ -12,23 +12,23 @@ use Pantheon\Terminus\Commands\TerminusCommand;
 class WhoamiCommand extends TerminusCommand
 {
     /**
-     * Display information about the currently logged-in user
+     * Displays information about the currently logged-in user.
      *
      * @command auth:whoami
      * @aliases whoami
      *
      * @field-labels
-     *   firstname: First Name
-     *   lastname: Last Name
-     *   email: eMail
-     *   id: ID
+     *     firstname: First Name
+     *     lastname: Last Name
+     *     email: Email
+     *     id: ID
      * @default-string-field email
      * @return PropertyList
      *
      * @usage terminus auth:whoami
-     *   Responds with the email of the logged-in user
+     *     Displays the email of the logged-in user.
      * @usage terminus auth:whoami --format=table
-     *   Responds with the current session and user's data
+     *     Displays the current session and user's data.
      */
     public function whoAmI()
     {

--- a/src/Commands/Backup/Automatic/DisableCommand.php
+++ b/src/Commands/Backup/Automatic/DisableCommand.php
@@ -15,16 +15,16 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Disable a regular backup schedule
+     * Disables automatic backups.
      *
      * @authorize
      *
      * @command backup:automatic:disable
      *
-     * @param string $site_env Site & environment to disable the schedule of, in the format `site-name.env`.
+     * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage terminus backup:automatic:disable <site>.<env>
-     *    Disables the regular backup schedule for the <env> environment of <site>.
+     *    Disables the regular backup schedule for <site>'s <env> environment.
      */
     public function disableSchedule($site_env)
     {

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -15,19 +15,19 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Set up a week-long TTL backups to be made daily and a month-long TTL to be made weekly
+     * Enables automatic daily backups that are retained for one week and weekly backups retained for one month.
      *
      * @authorize
      *
      * @command backup:automatic:enable
      *
-     * @param string $site_env Site & environment to set the schedule of, in the format `site-name.env`.
+     * @param string $site_env Site & environment in the format `site-name.env`
      * @option string $day Day of the week to make the month-long backup in any format recognized by PHP strtotime
      *
      * @usage terminus backup:automatic:enable <site>.<env>
-     *     Sets backups to occur at a random hour, with month-long TTL backup made on a random day
+     *     Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups that are retained for one month.
      * @usage terminus backup:automatic:enable <site>.<env> --day=<day>
-     *     Sets backups to occur at a random hour, with month-long TTL backup made on <day>
+     *     Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups on <day> that are retained for one month.
      */
     public function enableSchedule($site_env, $options = ['day' => null,])
     {

--- a/src/Commands/Backup/Automatic/InfoCommand.php
+++ b/src/Commands/Backup/Automatic/InfoCommand.php
@@ -16,7 +16,8 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Retrieve the regular backup of your site's environment
+     * Displays the hour when daily backups are created and the day of the week when weekly backups are created.
+     *
      *
      * @authorize
      *
@@ -28,12 +29,12 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @default-string-field weekly_backup_day
      * @return PropertyList
      *
-     * @param string $site_env Site & environment to get the schedule of, in the format `site-name.env`.
+     * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage terminus backup:automatic:info <site>.<env>
-     *     Responds with the day of the week backups are scheduled for on the <env> environment of <site>
-     * * @usage terminus backup:automatic:info <site>.<env> --format=table
-     *     Responds with the day of the week and hour of the day backups are scheduled for on <site>.<env>
+     *     Displays the day when <site>'s <env> environment's weekly backup is created'.
+     * @usage terminus backup:automatic:info <site>.<env> --format=table
+     *     Displays the hour of <site>'s <env> environment's daily backups (retained for one week) and the day on which its weekly backups (retained for one month) are made.
      */
     public function getSchedule($site_env)
     {

--- a/src/Commands/Backup/CreateCommand.php
+++ b/src/Commands/Backup/CreateCommand.php
@@ -15,24 +15,24 @@ class CreateCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Create a backup of the specified environment
+     * Creates a backup of a specific site and environment.
      *
      * @authorize
      *
      * @command backup:create
      *
-     * @param string $site_env Site & environment to make a backup of, in the form `site-name.env`.
-     * @option string $element [code|files|database|db] Create a backup of just the code, files, or database
-     * @option integer $keep-for Set to retain the backup for a specific number of days
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @option string $element [code|files|database|db] Element to be backed up
+     * @option integer $keep-for Retention period, in days, to retain backup
      *
      * @usage terminus backup:create <site>.<env>
-     *    Creates a backup of the <env> environment of <site>
+     *    Creates a backup of <site>'s <env> environment.
      * @usage terminus backup:create <site>.<env> --element=<element>
-     *    Creates a backup of the <env> environment of <site>'s <element>
+     *    Creates a backup of <site>'s <env> environment's <element>.
      * @usage terminus backup:create <site>.<env> --keep-for=<days>
-     *    Creates a backup of the <env> environment of <site> and retains it for <days> days
+     *    Creates a backup of <site>'s <env> environment and retains it for <days> days.
      * @usage terminus backup:create <site>.<env> --element=<element> --keep-for=<days>
-     *    Creates a backup of awesome-site's live environment's <element> and retain it for <days> days
+     *    Creates a backup of <site>'s <env> environment's <element> and retains it for <days> days.
      */
     public function create($site_env, $options = ['element' => null, 'keep-for' => 365,])
     {

--- a/src/Commands/Backup/GetCommand.php
+++ b/src/Commands/Backup/GetCommand.php
@@ -16,23 +16,23 @@ class GetCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Fetch the download URL for a specific backup or latest backup
+     * Displays the download URL for a specific backup or latest backup.
      *
      * @authorize
      *
      * @command backup:get
      *
-     * @param string $site_env Site & environment to deploy to, in the form `site-name.env`.
-     * @option string $file [filename.tgz] Name of the backup archive file
-     * @option string $element [code|files|database|db] Specify an element to back up
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @option string $file [filename.tgz] Name of backup file
+     * @option string $element [code|files|database|db] Backup element to retrieve
      * @throws TerminusNotFoundException
      *
      * @usage terminus backup:get <site>.<env>
-     *     Returns the URL for the most recent backup of any type in the <env> environment of <site>
+     *     Displays the URL for the most recent backup of any type in <site>'s <env> environment.
      * @usage terminus backup:get awesome-site.dev --file=2016-08-18T23-16-20_UTC_code.tar.gz
-     *     Returns the URL for the backup with the specified archive file name in the <env> environment of <site>
+     *     Displays the URL for the backup with the specified file name in <site>'s <env> environment.
      * @usage terminus backup:get awesome-site.dev --element=code
-     *     Returns the URL for the most recent code backup in the <env> environment of <site>
+     *     Displays the URL for the most recent code backup in <site>'s <env> environment.
      */
     public function getBackup($site_env, array $options = ['file' => null, 'element' => null,])
     {

--- a/src/Commands/Backup/ListCommand.php
+++ b/src/Commands/Backup/ListCommand.php
@@ -16,7 +16,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * List the backups for a given site and environment
+     * Lists backups for a specific site and environment.
      *
      * @authorize
      *
@@ -24,19 +24,19 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases backups
      *
      * @field-labels
-     *   file: Filename
-     *   size: Size
-     *   date: Date
-     *   initiator: Initiator
+     *     file: Filename
+     *     size: Size
+     *     date: Date
+     *     initiator: Initiator
      * @return RowsOfFields
      *
-     * @param string $site_env Site & environment to deploy to, in the form `site-name.env`.
-     * @param string $element [code|files|database|db] Only show backups of a certain type
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param string $element [code|files|database|db] Backup element filter
      *
      * @usage terminus backup:list <site>.<env>
-     *     Lists all backups made of <site>'s <env> environment
+     *     Lists all backups made of <site>'s <env> environment.
      * @usage terminus backup:list <site>.<env> --element=<element>
-     *     Lists all <element> backups made of <site>'s <env> environment
+     *     Lists all <element> backups made of <site>'s <env> environment.
      */
     public function listBackups($site_env, $element = 'all')
     {

--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -17,23 +17,23 @@ class RestoreCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Restore a specific backup or the latest backup
+     * Restores a specific backup or the latest backup.
      *
      * @authorize
      *
      * @command backup:restore
      *
-     * @param string $site_env Site & environment to deploy to, in the form `site-name.env`.
-     * @option string $file [filename.tgz] Name of the backup archive file
-     * @option string $element [code|files|database|db] Backup type
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @option string $file [filename.tgz] Name of backup file
+     * @option string $element [code|files|database|db] Backup element
      * @throws TerminusException
      *
      * @usage terminus backup:restore <site>.<env>
-     *     Restores the most recent backup of any type to the <env> environment of <site>
+     *     Restores the most recent backup of any type to <site>'s <env> environment.
      * @usage terminus backup:restore <site>.<env> --file=<backup>
-     *     Restores backup with the specified archive file name, <backup>, to the <env> environment of <site>
+     *     Restores backup with the <backup> file name to <site>'s <env> environment.
      * @usage terminus backup:restore <site>.<env> --element=<element>
-     *     Restores the most recent <element> backup for the <env> environment of <site>
+     *     Restores the most recent <element> backup to <site>'s <env> environment.
      */
     public function restoreBackup($site_env, array $options = ['file' => null, 'element' => null,])
     {

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -77,7 +77,7 @@ Feature: Authorization command
     Given I am authenticated
     When I run "terminus auth:whoami --format=table --fields=email,id"
     Then I should get: "------- --------------------------------------"
-    And I should get: "eMail   [[username]]"
+    And I should get: "Email   [[username]]"
     And I should get: "ID      [[user_id]]"
     And I should get: "------- --------------------------------------"
 


### PR DESCRIPTION
First set of updates with @rachelwhitton to make internal help text consistent.

- Use "Displays..." for outputting data
- Put everything in the "[verb]s..." form (Simple Present)
- Command description should be a sentence with period
- Usage description should be a sentence with period
- Params/Options do not need to be a sentence
- Option doc: site_env Site & environment in the format `site-name.env`
- Use "specific xyz" instead of "given"
