### PR TITLE
AL-747 Update helptext for `payment` commands

### DIFF
--- a/src/Commands/PaymentMethod/AddCommand.php
+++ b/src/Commands/PaymentMethod/AddCommand.php
@@ -15,18 +15,18 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Apply a payment method attached to your account to the given site
+     * Associates an existing payment method with a site.
      *
      * @authorize
      *
      * @command payment-method:add
      * @aliases pm:add
      *
-     * @param string $site_name The name or UUID of the site to attach a payment method to
-     * @param string $payment_method The label or UUID of the payment method to apply to the site
+     * @param string $site_name Site name
+     * @param string $payment_method Payment method label or UUID
      *
-     * @usage terminus payment-method:add <site> <method>
-     *   Attaches the <method> payment method ot the <site> site
+     * @usage terminus payment-method:add <site> <payment_method>
+     *     Associates <payment_method> with <site>.
      */
     public function add($site_name, $payment_method)
     {

--- a/src/Commands/PaymentMethod/ListCommand.php
+++ b/src/Commands/PaymentMethod/ListCommand.php
@@ -12,7 +12,7 @@ use Pantheon\Terminus\Commands\TerminusCommand;
 class ListCommand extends TerminusCommand
 {
     /**
-     * Lists the payment methods attached to the logged-in account
+     * Displays the list of payment methods for the currently logged-in user.
      *
      * @authorize
      *
@@ -20,12 +20,12 @@ class ListCommand extends TerminusCommand
      * @aliases payment-methods pm:list pms
      *
      * @field-labels
-     *   label: Label
-     *   id: ID
+     *     label: Label
+     *     id: ID
      * @return RowsOfFields
      *
      * @usage terminus payment-method:list
-     *   Display a list of payment methods which the logged-in user has attached to their account
+     *     Displays the list of payment methods for the currently logged-in user.
      */
     public function listPaymentMethods()
     {

--- a/src/Commands/PaymentMethod/RemoveCommand.php
+++ b/src/Commands/PaymentMethod/RemoveCommand.php
@@ -15,17 +15,17 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
 
     /**
-     * Remove the applied paynment method to the given site
+     * Disassociates the active payment method from a site.
      *
      * @authorize
      *
      * @command payment-method:remove
      * @aliases pm:remove pm:rm
      *
-     * @param string $site_name The name or UUID of the site to remove the payment method from
+     * @param string $site_name Site name
      *
      * @usage terminus payment-method:remove <site>
-     *   Removes the set payment method from the <site> site, if one exists.
+     *     Disassociates the active payment method from <site>.
      */
     public function remove($site_name)
     {


### PR DESCRIPTION
I didn't like the phrase `payment method` because method makes me think that would be credit card vs contract. when this is really just about choosing among your credit cards. The dashboard calls this an "payment instrument" but that's also probs nonsensy from a customer point of view. 