### PR TITLE
(WIP) Replace ensureDirExists() with Symfony Filesystem component

### DIFF
--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Pantheon\Terminus\Commands;
+use Symfony\Component\Filesystem\Filesystem;
 
 class AliasesCommand extends TerminusCommand
 {

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -36,7 +36,7 @@ class AliasesCommand extends TerminusCommand
         }
         $config = $this->getConfig();
         $location = $config->fixDirectorySeparators(str_replace('~', $config->get('user_home'), $location));
-        $config->ensureDirExists(dirname($location));
+        $config->ensureDirExists(dirname($location), $location);
         if (file_put_contents($location, $aliases) !== false) {
             $this->log()->notice('Aliases file written to {location}.', ['location' => $location,]);
         }

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Pantheon\Terminus\Commands;
+
 use Symfony\Component\Filesystem\Filesystem;
 
 class AliasesCommand extends TerminusCommand

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -36,9 +36,14 @@ class AliasesCommand extends TerminusCommand
         }
         $config = $this->getConfig();
         $location = $config->fixDirectorySeparators(str_replace('~', $config->get('user_home'), $location));
-        $config->ensureDirExists(dirname($location), $location);
-        if (file_put_contents($location, $aliases) !== false) {
+
+        // @todo, should this dependency be injected somehow?
+        $filesystem = new Filesystem();
+        try {
+            $filesystem->dumpFile($location, $aliases);
             $this->log()->notice('Aliases file written to {location}.', ['location' => $location,]);
+        } catch (IOException $e) {
+            // @todo, not sure what the error reporting should be here.
         }
     }
 }

--- a/src/Config/TerminusConfig.php
+++ b/src/Config/TerminusConfig.php
@@ -196,26 +196,6 @@ class TerminusConfig extends \Robo\Config
     }
 
     /**
-     * Ensures a directory exists
-     *
-     * @param string $name  The name of the config var
-     * @param string $value The value of the named config var
-     * @return boolean|null
-     */
-    public function ensureDirExists($name, $value)
-    {
-        if ((strpos($name, 'TERMINUS_') !== false) && (strpos($name, '_DIR') !== false) && ($value != '~')) {
-            try {
-                $dir_exists = (is_dir($value) || (!file_exists($value) && @mkdir($value, 0777, true)));
-            } catch (\Exception $e) {
-                return false;
-            }
-            return $dir_exists;
-        }
-        return null;
-    }
-
-    /**
      * Ensures that directory paths work in any system
      *
      * @param string $path A path to set the directory separators for


### PR DESCRIPTION
I'm converting a CircleCI script to use the new Terminus and it is going well! https://github.com/pantheon-systems/search_api_pantheon/pull/60

 I ran into a bug with `terminus site aliases`


https://circleci.com/gh/pantheon-systems/search_api_pantheon/532
```
terminus aliases
PHP Warning:  Missing argument 2 for Pantheon\Terminus\Config\TerminusConfig::ensureDirExists(), called in /home/ubuntu/terminus/src/Commands/AliasesCommand.php on line 39 and defined in /home/ubuntu/terminus/src/Config/TerminusConfig.php on line 205

Warning: Missing argument 2 for Pantheon\Terminus\Config\TerminusConfig::ensureDirExists(), called in /home/ubuntu/terminus/src/Commands/AliasesCommand.php on line 39 and defined in /home/ubuntu/terminus/src/Config/TerminusConfig.php on line 205
PHP Warning:  file_put_contents(/home/ubuntu/.drush/pantheon.aliases.drushrc.php): failed to open stream: No such file or directory in /home/ubuntu/terminus/src/Commands/AliasesCommand.php on line 40

Warning: file_put_contents(/home/ubuntu/.drush/pantheon.aliases.drushrc.php): failed to open stream: No such file or directory in /home/ubuntu/terminus/src/Commands/AliasesCommand.php on line 40
+ echo '$options['\''strict'\''] = 0;'
./verify-solr.sh: line 8: /home/ubuntu/.drush/pantheon.aliases.drushrc.php: No such file or directory
```

Basically `AliasesCommand::aliases` is not passing enough arguments to `TerminusConfig::ensureDirExists()`. I thought this could just be fixed by added the second appropriate argument, but that still resulted in PHP warnings.

What I'm suggesting in this PR is removing `ensureDirExists` and instead using the Symfony Filesystem component. I'm looking for feedback on the best way to bring in the class. Should it be added as a service? Should `Pantheon\Terminus\DataStore\FileStore` rely on this Symfony component too?

 



