### PR TITLE
Return IDs with site list to make output formatters more functional

### DIFF
--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -29,7 +29,7 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
     /**
      * @var TerminusModel[]
      */
-    protected $models = [];
+    protected $models = null;
     /**
      * @var boolean
      */
@@ -85,7 +85,21 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
      */
     public function all()
     {
-        $models = array_values($this->getMembers());
+        $models = $this->getMembers();
+        return $models;
+    }
+
+    /**
+     * Retrieves all models serialized into arrays.
+     *
+     * @return array
+     */
+    public function serialize()
+    {
+        $models = [];
+        foreach ($this->getMembers() as $id => $model) {
+            $models[$id] = $model->serialize();
+        }
         return $models;
     }
 
@@ -136,7 +150,7 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
      */
     public function ids()
     {
-        $models = $this->getMembers();
+        $models = (array)$this->getMembers();
         $ids = array_keys($models);
         return $ids;
     }
@@ -152,12 +166,13 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
      */
     public function listing($key = 'id', $value = 'name')
     {
+        $models = $this->getMembers();
         $members = array_combine(
             array_map(
                 function ($member) use ($key) {
                     return $member->get($key);
                 },
-                $this->models
+                $models
             ),
             array_map(
                 function ($member) use ($value) {
@@ -170,7 +185,7 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
                     }
                     return $list;
                 },
-                $this->models
+                $models
             )
         );
         return $members;
@@ -262,7 +277,7 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
      */
     protected function getMembers()
     {
-        if (empty($this->models)) {
+        if ($this->models === null) {
             $this->fetch();
         }
         return $this->models;

--- a/src/Commands/Backup/ListCommand.php
+++ b/src/Commands/Backup/ListCommand.php
@@ -58,12 +58,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
 
         $data = [];
         foreach ($backups as $id => $backup) {
-            $data[] = [
-                'file'      => $backup->get('filename'),
-                'size'      => $backup->getSizeInMb(),
-                'date'      => $backup->getDate(),
-                'initiator' => $backup->getInitiator(),
-            ];
+            $data[] = $backup->serialize();
         }
 
         // Return the output data.

--- a/src/Commands/Branch/ListCommand.php
+++ b/src/Commands/Branch/ListCommand.php
@@ -35,13 +35,6 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function listBranches($site_id)
     {
-        $site = $this->getSite($site_id);
-        $branches = array_map(
-            function ($branch) {
-                return $branch->serialize();
-            },
-            $site->getBranches()->all()
-        );
-        return new RowsOfFields($branches);
+        return new RowsOfFields($this->getSite($site_id)->getBranches()->serialize());
     }
 }

--- a/src/Commands/Domain/ListCommand.php
+++ b/src/Commands/Domain/ListCommand.php
@@ -38,12 +38,6 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     public function listDomains($site_env)
     {
         list(, $env) = $this->getSiteEnv($site_env);
-        $domains = array_map(
-            function ($domain) {
-                return $domain->serialize();
-            },
-            $env->getDomains()->all()
-        );
-        return new RowsOfFields($domains);
+        return new RowsOfFields($env->getDomains()->serialize());
     }
 }

--- a/src/Commands/Domain/LookupCommand.php
+++ b/src/Commands/Domain/LookupCommand.php
@@ -40,7 +40,7 @@ class LookupCommand extends TerminusCommand implements SiteAwareInterface
     public function lookup($domain)
     {
         $this->log()->notice('This operation may take a long time to run.');
-        $sites = $this->sites()->fetch()->all();
+        $sites = $this->sites()->all();
         $environments = ['dev', 'test', 'live',];
         foreach ($sites as $site_id => $site) {
             foreach ($environments as $env_name) {

--- a/src/Commands/Env/CodeLogCommand.php
+++ b/src/Commands/Env/CodeLogCommand.php
@@ -23,7 +23,7 @@ class CodeLogCommand extends TerminusCommand implements SiteAwareInterface
      * @command env:code-log
      *
      * @field-labels
-     *     time: Timestamp
+     *     datetime: Timestamp
      *     author: Author
      *     labels: Labels
      *     hash: Commit ID
@@ -38,23 +38,6 @@ class CodeLogCommand extends TerminusCommand implements SiteAwareInterface
     public function codeLog($site_env)
     {
         list(, $env) = $this->getSiteEnv($site_env, 'dev');
-        $logs = $env->getCommits()->all();
-        $data = [];
-        foreach ($logs as $log) {
-            $data[] = [
-                'time'    => $log->get('datetime'),
-                'author'  => $log->get('author'),
-                'labels'  => implode(', ', $log->get('labels')),
-                'hash'    => $log->get('hash'),
-                'message' => trim(
-                    str_replace(
-                        "\n",
-                        '',
-                        str_replace("\t", '', substr($log->get('message'), 0, 50))
-                    )
-                ),
-            ];
-        }
-        return new RowsOfFields($data);
+        return new RowsOfFields($env->getCommits()->serialize());
     }
 }

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -39,11 +39,6 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function listEnvs($site_id)
     {
-        $site = $this->getSite($site_id);
-        $data = [];
-        foreach ($site->getEnvironments()->all() as $env) {
-            $data[] = $env->serialize();
-        }
-        return new RowsOfFields($data);
+        return new RowsOfFields($this->getSite($site_id)->getEnvironments()->serialize());
     }
 }

--- a/src/Commands/MachineToken/ListCommand.php
+++ b/src/Commands/MachineToken/ListCommand.php
@@ -29,20 +29,10 @@ class ListCommand extends TerminusCommand
      */
     public function listTokens()
     {
-        $machine_tokens = $this->session()->getUser()->getMachineTokens()->all();
-        $data = array();
-        foreach ($machine_tokens as $id => $machine_token) {
-            $data[] = array(
-                'id' => $machine_token->id,
-                'device_name' => $machine_token->get('device_name'),
-            );
-        }
-
+        $data = $this->session()->getUser()->getMachineTokens()->serialize();
         if (count($data) == 0) {
             $this->log()->warning('You have no machine tokens.');
         }
-
-        // Return the output data.
         return new RowsOfFields($data);
     }
 }

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -48,12 +48,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
         if (!is_null($tag = $options['tag'])) {
             $this->sites->filterByTag($tag);
         }
-        $sites = array_map(
-            function ($site) {
-                return $site->serialize();
-            },
-            $this->sites->all()
-        );
+        $sites = $this->sites->serialize();
 
         if (empty($sites)) {
             $this->log()->notice('This organization has no sites.');

--- a/src/Commands/Org/Team/ListCommand.php
+++ b/src/Commands/Org/Team/ListCommand.php
@@ -35,12 +35,7 @@ class ListCommand extends TerminusCommand
     public function listTeam($organization)
     {
         $org = $this->session()->getUser()->getOrgMemberships()->get($organization)->getOrganization();
-        $members = array_map(
-            function ($member) {
-                return $member->serialize();
-            },
-            $org->getUserMemberships()->fetch()->all()
-        );
+        $members = $org->getUserMemberships()->serialize();
         if (empty($members)) {
             $this->log()->notice('{org} has no team members.', ['org' => $org->get('profile')->name,]);
         }

--- a/src/Commands/PaymentMethod/ListCommand.php
+++ b/src/Commands/PaymentMethod/ListCommand.php
@@ -29,12 +29,7 @@ class ListCommand extends TerminusCommand
      */
     public function listPaymentMethods()
     {
-        $methods = array_map(
-            function ($method) {
-                return $method->serialize();
-            },
-            $this->session()->getUser()->getPaymentMethods()->fetch()->all()
-        );
+        $methods = $this->session()->getUser()->getPaymentMethods()->serialize();
         if (empty($methods)) {
             $this->log()->notice('There are no payment methods attached to this account.');
         }

--- a/src/Commands/SSHKey/ListCommand.php
+++ b/src/Commands/SSHKey/ListCommand.php
@@ -31,16 +31,7 @@ class ListCommand extends TerminusCommand
      */
     public function listSSHKeys()
     {
-        $ssh_keys = $this->session()->getUser()->getSSHKeys()->all();
-
-        $data = [];
-        foreach ($ssh_keys as $id => $ssh_key) {
-            $data[] = array(
-                'id' => $ssh_key->id,
-                'hex' => $ssh_key->getHex(),
-                'comment' => $ssh_key->getComment(),
-            );
-        }
+        $data = $this->session()->getUser()->getSSHKeys()->serialize();
         if (count($data) == 0) {
             $this->log()->warning('You have no ssh keys.');
         }

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -70,12 +70,7 @@ class ListCommand extends SiteCommand
             $this->sites->filterByOwner($owner);
         }
 
-        $sites = array_map(
-            function ($site) {
-                return $site->serialize();
-            },
-            $this->sites->all()
-        );
+        $sites = $this->sites->serialize();
 
         if (empty($sites)) {
             $this->log()->notice('You have no sites.');

--- a/src/Commands/Site/LookupCommand.php
+++ b/src/Commands/Site/LookupCommand.php
@@ -32,6 +32,6 @@ class LookupCommand extends SiteCommand
      */
     public function lookup($site_name)
     {
-        return new PropertyList((array)$this->sites()->findUuidByName($site_name));
+        return new PropertyList($this->sites()->get($site_name)->serialize());
     }
 }

--- a/src/Commands/Site/Org/ListCommand.php
+++ b/src/Commands/Site/Org/ListCommand.php
@@ -35,12 +35,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function listOrgs($site_id)
     {
-        $orgs = array_map(
-            function ($site) {
-                return $site->serialize();
-            },
-            $this->getSite($site_id)->getOrganizationMemberships()->all()
-        );
+        $orgs = $this->getSite($site_id)->getOrganizationMemberships()->serialize();
 
         if (empty($orgs)) {
             $this->log()->notice('This site has no supporting organizations.');

--- a/src/Commands/Site/Team/ListCommand.php
+++ b/src/Commands/Site/Team/ListCommand.php
@@ -24,11 +24,11 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases site:team
      *
      * @field-labels
-     *   first: First name
-     *   last: Last name
+     *   firstname: First name
+     *   lastname: Last name
      *   email: Email
      *   role: Role
-     *   uuid: User ID
+     *   id: User ID
      * @return RowsOfFields
      *
      * @param string $site_id Site name to list team members for.
@@ -39,18 +39,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     public function teamList($site_id)
     {
         $site = $this->getSite($site_id);
-        $user_memberships = $site->getUserMemberships()->all();
-        $data = [];
-        foreach ($user_memberships as $user_membership) {
-            $user = $user_membership->get('user');
-            $data[] = array(
-                'first' => $user->profile->firstname,
-                'last'  => $user->profile->lastname,
-                'email' => $user->email,
-                'role'  => $user_membership->get('role'),
-                'uuid'  => $user->id,
-            );
-        }
-        return new RowsOfFields($data);
+        $user_memberships = $site->getUserMemberships()->serialize();
+        return new RowsOfFields($user_memberships);
     }
 }

--- a/src/Commands/Upstream/ListCommand.php
+++ b/src/Commands/Upstream/ListCommand.php
@@ -30,12 +30,6 @@ class ListCommand extends TerminusCommand
      */
     public function listUpstreams()
     {
-        $upstreams = array_map(
-            function ($upstream) {
-                return $upstream->serialize();
-            },
-            $this->session()->getUser()->getUpstreams()->all()
-        );
-        return new RowsOfFields($upstreams);
+        return new RowsOfFields($this->session()->getUser()->getUpstreams()->serialize());
     }
 }

--- a/src/Commands/Workflow/ListCommand.php
+++ b/src/Commands/Workflow/ListCommand.php
@@ -42,23 +42,14 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     public function wfList($site_id)
     {
         $site = $this->getSite($site_id);
-        $site->getWorkflows()->fetch(['paged' => false]);
-        $workflows = $site->getWorkflows()->all();
+        $workflows = $site->getWorkflows()->fetch(['paged' => false])->serialize();
 
-        $data = [];
-        foreach ($workflows as $workflow) {
-            foreach ($workflows as $workflow) {
-                $workflow_data = $workflow->serialize();
-                unset($workflow_data['operations']);
-                $data[] = $workflow_data;
-            }
-            if (count($data) == 0) {
-                $this->log()->warning(
-                    'No workflows have been run on {site}.',
-                    ['site' => $site->get('name')]
-                );
-            }
-            return new RowsOfFields($data);
+        if (count($workflows) == 0) {
+            $this->log()->warning(
+                'No workflows have been run on {site}.',
+                ['site' => $site->get('name')]
+            );
         }
+        return new RowsOfFields($workflows);
     }
 }

--- a/src/Models/Backup.php
+++ b/src/Models/Backup.php
@@ -158,6 +158,21 @@ class Backup extends TerminusModel implements ConfigAwareInterface
     }
 
     /**
+     * Formats the object into an associative array for output
+     *
+     * @return array Associative array of data for output
+     */
+    public function serialize()
+    {
+        return [
+            'file'      => $this->get('filename'),
+            'size'      => $this->getSizeInMb(),
+            'date'      => $this->getDate(),
+            'initiator' => $this->getInitiator(),
+        ];
+    }
+
+    /**
      * @inheritdoc
      */
     protected function parseAttributes($data)

--- a/src/Models/Commit.php
+++ b/src/Models/Commit.php
@@ -8,4 +8,15 @@ namespace Pantheon\Terminus\Models;
  */
 class Commit extends TerminusModel
 {
+
+    public function serialize()
+    {
+        return [
+            'datetime' => $this->get('datetime'),
+            'author' => $this->get('author'),
+            'labels' => implode(', ', $this->get('labels')),
+            'hash' => $this->get('hash'),
+            'message' => substr(strtr(trim($this->get('message')), ["\n" => ' ', "\t" => ' ']), 0, 50),
+        ];
+    }
 }

--- a/src/Models/SSHKey.php
+++ b/src/Models/SSHKey.php
@@ -65,4 +65,18 @@ class SSHKey extends TerminusModel
         $hex = implode(':', str_split($this->id, 2));
         return $hex;
     }
+
+    /**
+     * Formats the object into an associative array for output
+     *
+     * @return array Associative array of data for output
+     */
+    public function serialize()
+    {
+        return array(
+            'id' => $this->id,
+            'hex' => $this->getHex(),
+            'comment' => $this->getComment(),
+        );
+    }
 }

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -259,7 +259,7 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
                 . '.' . substr($data['php_version'], 1, 1);
         }
         if (isset($this->tags)) {
-            $data['tags'] = implode(',', $this->tags->ids());
+            $data['tags'] = implode(',', (array)$this->tags->ids());
         }
         if (isset($this->memberships)) {
             $data['memberships'] = implode(',', $this->memberships);

--- a/src/Models/SiteOrganizationMembership.php
+++ b/src/Models/SiteOrganizationMembership.php
@@ -58,7 +58,7 @@ class SiteOrganizationMembership extends TerminusModel implements ContainerAware
      */
     public function serialize()
     {
-        $organization = $this->getOrganizatio();
+        $organization = $this->getOrganization();
         $data = [
             'org_id' => $organization->id,
             'org_name' => $organization->get('profile')->name,

--- a/src/Models/SiteUserMembership.php
+++ b/src/Models/SiteUserMembership.php
@@ -91,4 +91,12 @@ class SiteUserMembership extends TerminusModel implements ContainerAwareInterfac
     {
         return $this->site;
     }
+
+    public function serialize()
+    {
+        $user = $this->getUser()->serialize();
+        return $user + [
+            'role'  => $this->get('role'),
+        ];
+    }
 }

--- a/src/Models/TerminusModel.php
+++ b/src/Models/TerminusModel.php
@@ -127,4 +127,14 @@ abstract class TerminusModel implements RequestAwareInterface
     {
         return $this->url;
     }
+
+    /**
+     * Formats the object into an associative array for output
+     *
+     * @return array Associative array of data for output
+     */
+    public function serialize()
+    {
+        return (array)$this->attributes;
+    }
 }

--- a/tests/features/site-lookup.feature
+++ b/tests/features/site-lookup.feature
@@ -15,4 +15,4 @@ Feature: Looking up a site
   @vcr site-lookup-dne.yml
   Scenario: Site look-up fails because site DNE
     When I run "terminus site:lookup invalid"
-    Then I should get: "A site named invalid was not found."
+    Then I should get: "Could not locate a site your user may access identified by invalid."

--- a/tests/unit_tests/Collections/SSHKeysTest.php
+++ b/tests/unit_tests/Collections/SSHKeysTest.php
@@ -64,7 +64,7 @@ class SSHKeysTest extends UserOwnedCollectionTest
         foreach ($data as $id => $key) {
             $options['id'] = $id;
             $model_data = (object)['id' => $id, 'key' => $key];
-            $model = $models[$i] = new SSHKey($model_data, $options);
+            $model = $models[$id] = new SSHKey($model_data, $options);
             $this->container->expects($this->at($i++))
                 ->method('get')
                 ->with(SSHKey::class, [$model_data, $options])

--- a/tests/unit_tests/Collections/TerminusCollectionTest.php
+++ b/tests/unit_tests/Collections/TerminusCollectionTest.php
@@ -43,6 +43,7 @@ class TerminusCollectionTest extends CollectionTestCase
             'b' => (object)['id' => 'b', 'foo' => '456', 'category' => 'a'],
             'c' => (object)['id' => 'c', 'foo' => '678', 'category' => 'b']
         ];
+
         $this->request->expects($this->once())
             ->method('request')
             ->with('TESTURL', ['options' => ['method' => 'get']])
@@ -66,6 +67,7 @@ class TerminusCollectionTest extends CollectionTestCase
                 ->method('get')
                 ->with(TerminusModel::class, [$model_data, $options])
                 ->willReturn($models[$key]);
+            $models[$model_data->id]->method('serialize')->willReturn((array)$model_data);
         }
 
         $collection->setRequest($this->request);
@@ -74,10 +76,15 @@ class TerminusCollectionTest extends CollectionTestCase
         $collection->fetch();
 
         $this->assertEquals(array_keys($models), $collection->ids());
-        $this->assertEquals(array_values($models), $collection->all());
+        $this->assertEquals($models, $collection->all());
         foreach ($models as $id => $model) {
             $this->assertEquals($model, $collection->get($id));
         }
+
+        $expected = array_map(function ($d) {
+            return (array)$d;
+        }, $data);
+        $this->assertEquals($expected, $collection->serialize());
 
         $listing = [
             'a' => '123',

--- a/tests/unit_tests/Commands/Branch/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Branch/ListCommandTest.php
@@ -20,27 +20,16 @@ class ListCommandTest extends CommandTestCase
     public function testListBranches()
     {
         $branches_info = [
-            ['id' => 'master', 'sha' => 'xxx'],
-            ['id' => 'another', 'sha' => 'yyy'],
+            'master' => ['id' => 'master', 'sha' => 'xxx'],
+            'another' => ['id' => 'another', 'sha' => 'yyy'],
         ];
-
-        $branches = [];
-        foreach ($branches_info as $branch_info) {
-            $branch = $this->getMockBuilder(Branch::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $branch->expects($this->once())
-                ->method('serialize')
-                ->willReturn($branch_info);
-            $branches[] = $branch;
-        }
-
+        
         $branches_collection = $this->getMockBuilder(Branches::class)
             ->disableOriginalConstructor()
             ->getMock();
         $branches_collection->expects($this->once())
-            ->method('all')
-            ->willReturn($branches);
+            ->method('serialize')
+            ->willReturn($branches_info);
 
         $this->site->expects($this->once())
             ->method('getBranches')

--- a/tests/unit_tests/Commands/CommandTestCase.php
+++ b/tests/unit_tests/Commands/CommandTestCase.php
@@ -53,6 +53,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
      * @var Environments
      */
     protected $environments;
+    protected $site2;
 
     /**
      * @return Config
@@ -129,6 +130,15 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
             ->willReturn($this->environment);
 
         $this->site->method('getEnvironments')->willReturn($this->environments);
+        $this->site->id = 'abc';
+
+        $this->site2 = $this->getMockBuilder(Site::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->site2->id = 'def';
+
+
+
 
         $this->sites = $this->getMockBuilder(Sites::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/Commands/Domain/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Domain/ListCommandTest.php
@@ -29,20 +29,17 @@ class ListCommandTest extends DomainTest
      */
     public function testList()
     {
-        $dummy_info = ['domain' => 'domain', 'zone' => 'zone',];
+        $dummy_info = ['123' => ['domain' => 'domain', 'zone' => 'zone']];
 
         $this->domains->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->with()
-            ->willReturn([$this->domain, $this->domain,]);
+            ->willReturn($dummy_info);
         $this->logger->expects($this->never())
             ->method('log');
-        $this->domain->expects($this->any())
-            ->method('serialize')
-            ->willReturn($dummy_info);
 
         $out = $this->command->listDomains('site_name.env_id');
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals($dummy_info, $out->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/Domain/LookupCommandTest.php
+++ b/tests/unit_tests/Commands/Domain/LookupCommandTest.php
@@ -32,10 +32,6 @@ class LookupCommandTest extends DomainTest
         $this->site_name = 'site_name';
 
         $this->sites->expects($this->once())
-            ->method('fetch')
-            ->with()
-            ->willReturn($this->sites);
-        $this->sites->expects($this->once())
             ->method('all')
             ->with()
             ->willReturn([$this->site,]);

--- a/tests/unit_tests/Commands/Env/CodeLogCommandTest.php
+++ b/tests/unit_tests/Commands/Env/CodeLogCommandTest.php
@@ -51,23 +51,21 @@ class CodeLogCommandTest extends EnvCommandTest
      */
     public function testLog()
     {
+        $data = ['1' => [
+            'datetime' => '2016-09-21T12:21:18',
+            'author' => 'Daisy Duck',
+            'labels' => ['test', 'dev'],
+            'hash' => 'c65e638f03cabc7b97e686bb9de843b7173e329a',
+            'message' => 'Add some new code',
+        ]];
         $this->environment->id = 'dev';
-        $this->commits->method('all')
-            ->willReturn([
-                $this->commit_1,
-                $this->commit_2,
-            ]);
+        $this->commits->method('serialize')
+            ->willReturn($data);
 
         $out = $this->command->codeLog('mysite.dev');
 
         $this->assertInstanceOf('Consolidation\OutputFormatters\StructuredData\RowsOfFields', $out);
-        $this->assertEquals(count($out), 2);
-        $out_1 = $out->getArrayCopy()[0];
-        $this->assertEquals($this->commit_1_attribs['datetime'], $out_1['time']);
-        $this->assertEquals($this->commit_1_attribs['author'], $out_1['author']);
-        $this->assertEquals($this->commit_1_attribs['hash'], $out_1['hash']);
-        $this->assertEquals($this->commit_1_attribs['message'], $out_1['message']);
-        $this->assertEquals('test, dev', $out_1['labels']);
+        $this->assertEquals($data, $out->getArrayCopy());
     }
 
     /**
@@ -76,7 +74,7 @@ class CodeLogCommandTest extends EnvCommandTest
     public function testDeployNoCode()
     {
         $this->environment->id = 'dev';
-        $this->commits->method('all')
+        $this->commits->method('serialize')
             ->willReturn([]);
 
         $out = $this->command->codeLog('mysite.dev');

--- a/tests/unit_tests/Commands/Env/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Env/ListCommandTest.php
@@ -25,20 +25,9 @@ class ListCommandTest extends EnvCommandTest
             ['foo' => 'abc', 'baz' => 'def'],
         ];
 
-        $envs = [];
-        foreach ($data as $env) {
-            $mock = $this->getMockBuilder(Environment::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-
-            $mock->expects($this->once())
-                ->method('serialize')
-                ->willReturn($env);
-            $envs[] = $mock;
-        }
         $this->environments->expects($this->once())
-            ->method('all')
-            ->willReturn($envs);
+            ->method('serialize')
+            ->willReturn($data);
 
         $this->command = new ListCommand();
         $this->command->setSites($this->sites);

--- a/tests/unit_tests/Commands/MachineToken/MachineTokenCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokenCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pantheon\Terminus\UnitTests\Commands\Auth;
+namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Session\Session;

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Pantheon\Terminus\UnitTests\Commands\Auth;
+namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Commands\MachineToken\DeleteCommand;
 use Robo\Config;

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensListCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensListCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pantheon\Terminus\UnitTests\Commands\Auth;
+namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Commands\MachineToken\ListCommand;
 use Robo\Config;
@@ -31,7 +31,7 @@ class MachineTokensListCommandTest extends MachineTokenCommandTest
      */
     public function testMachineTokenListEmpty()
     {
-        $this->machine_tokens->method('all')
+        $this->machine_tokens->method('serialize')
             ->willReturn([]);
 
         $this->logger->expects($this->once())
@@ -49,15 +49,11 @@ class MachineTokensListCommandTest extends MachineTokenCommandTest
     public function testMachineTokenListNotEmpty()
     {
         $tokens = [
-            ['id' => '1', 'device_name' => 'Foo'],
-            ['id' => '2', 'device_name' => 'Bar']
+            '1' => ['id' => '1', 'device_name' => 'Foo'],
+            '2' => ['id' => '2', 'device_name' => 'Bar']
         ];
-        $collection = new MachineTokens(['user' => $this->user]);
-        $this->machine_tokens->method('all')
-            ->willReturn([
-                new MachineToken((object)$tokens[0], ['collection' => $collection]),
-                new MachineToken((object)$tokens[1], ['collection' => $collection])
-            ]);
+        $this->machine_tokens->method('serialize')
+            ->willReturn($tokens);
 
         $this->logger->expects($this->never())
             ->method($this->anything());

--- a/tests/unit_tests/Commands/Org/Site/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Org/Site/ListCommandTest.php
@@ -34,11 +34,9 @@ class ListCommandTest extends OrgSiteCommandTest
     public function testOrgSiteListEmpty()
     {
         $this->sites->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->with()
             ->willReturn([]);
-        $this->site->expects($this->never())
-          ->method('serialize');
 
         $this->logger->expects($this->once())
             ->method('log')
@@ -60,18 +58,15 @@ class ListCommandTest extends OrgSiteCommandTest
         ];
 
         $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site,]);
-        $this->site->expects($this->any())
             ->method('serialize')
-            ->willReturn($data);
+            ->with()
+            ->willReturn(['site_id' => $data]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->listSites($this->organization->id);
         $this->assertInstanceOf('Consolidation\OutputFormatters\StructuredData\RowsOfFields', $out);
-        $this->assertEquals([$data,], $out->getArrayCopy());
+        $this->assertEquals(['site_id' => $data], $out->getArrayCopy());
     }
 
     /**
@@ -79,21 +74,17 @@ class ListCommandTest extends OrgSiteCommandTest
      */
     public function testOrgSiteListByTag()
     {
-        $data = [
+        $data = ['site_id' => [
           'id' => 'site_id',
           'name' => 'Site Name',
-        ];
+        ]];
         $tag = 'tag';
 
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site,]);
         $this->sites->expects($this->once())
             ->method('filterByTag')
             ->with($this->equalTo($tag))
             ->willReturn($this->sites);
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->willReturn($data);
         $this->logger->expects($this->never())
@@ -101,6 +92,6 @@ class ListCommandTest extends OrgSiteCommandTest
 
         $out = $this->command->listSites($this->organization->id, compact('tag'));
         $this->assertInstanceOf('Consolidation\OutputFormatters\StructuredData\RowsOfFields', $out);
-        $this->assertEquals([$data,], $out->getArrayCopy());
+        $this->assertEquals($data, $out->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/Org/Team/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Org/Team/ListCommandTest.php
@@ -30,11 +30,9 @@ class ListCommandTest extends OrgTeamCommandTest
     {
         $org_name = 'org_name';
         $this->org_user_memberships->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->with()
             ->willReturn([]);
-        $this->org_user_membership->expects($this->never())
-            ->method('serialize');
         $this->organization->expects($this->once())
             ->method('get')
             ->with($this->equalTo('profile'))
@@ -59,25 +57,24 @@ class ListCommandTest extends OrgTeamCommandTest
     public function testOrgTeamListNotEmpty()
     {
         $data = [
-            'id' => 'user_id',
-            'first_name' => 'Dev',
-            'last_name' => 'User',
-            'email' => 'devuser@pantheon.io',
-            'role' => 'team_role',
+            'user_id' => [
+                'id' => 'user_id',
+                'first_name' => 'Dev',
+                'last_name' => 'User',
+                'email' => 'devuser@pantheon.io',
+                'role' => 'team_role',
+            ]
         ];
 
         $this->org_user_memberships->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->org_user_membership,]);
-        $this->org_user_membership->expects($this->any())
             ->method('serialize')
+            ->with()
             ->willReturn($data);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->listTeam($this->organization->id);
         $this->assertInstanceOf('Consolidation\OutputFormatters\StructuredData\RowsOfFields', $out);
-        $this->assertEquals([$data,], $out->getArrayCopy());
+        $this->assertEquals($data, $out->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/PaymentMethod/ListCommandTest.php
+++ b/tests/unit_tests/Commands/PaymentMethod/ListCommandTest.php
@@ -55,10 +55,6 @@ class ListCommandTest extends CommandTestCase
             ->method('getPaymentMethods')
             ->with()
             ->willReturn($this->payment_methods);
-        $this->payment_methods->expects($this->once())
-            ->method('fetch')
-            ->with()
-            ->willReturn($this->payment_methods);
 
         $this->command = new ListCommand($this->getConfig());
         $this->command->setSession($this->session);
@@ -70,27 +66,20 @@ class ListCommandTest extends CommandTestCase
      */
     public function testListPaymentMethods()
     {
-        $data = ['id' => 'payment_method_id', 'label' => 'Card - 1111',];
+        $data = ['payment_method_id' => ['id' => 'payment_method_id', 'label' => 'Card - 1111']];
 
-        $payment_method = $this->getMockBuilder(PaymentMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $payment_method->expects($this->once())
+        $this->payment_methods->expects($this->once())
             ->method('serialize')
             ->with()
             ->willReturn($data);
 
-        $this->payment_methods->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$payment_method,]);
         $this->logger->expects($this->never())
             ->method('log');
 
 
         $out = $this->command->listPaymentMethods();
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$data,], $out->getArrayCopy());
+        $this->assertEquals($data, $out->getArrayCopy());
     }
 
 
@@ -100,7 +89,7 @@ class ListCommandTest extends CommandTestCase
     public function testListPaymentMethodsEmpty()
     {
         $this->payment_methods->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->with()
             ->willReturn([]);
         $this->logger->expects($this->once())

--- a/tests/unit_tests/Commands/SSHKey/ListCommandTest.php
+++ b/tests/unit_tests/Commands/SSHKey/ListCommandTest.php
@@ -31,7 +31,7 @@ class ListCommandTest extends SSHKeyCommandTest
      */
     public function testSSHKeyListEmpty()
     {
-        $this->ssh_keys->method('all')
+        $this->ssh_keys->method('serialize')
             ->willReturn([]);
 
         $this->logger->expects($this->once())
@@ -48,34 +48,20 @@ class ListCommandTest extends SSHKeyCommandTest
      */
     public function testSSHKeysList()
     {
-        $keys = [
-            [
-                'id' => '79e7e210bdf335bb8651a46b9a8417ab',
-                'key' => 'ssh-rsa xxxxxxx dev@foo.bar',
-            ],
-            [
-                'id' => '27a7a11ab9d2acbf91063410546ef980',
-                'key' => 'ssh-rsa yyyyyyy dev@baz.bar',
-            ]
-        ];
         $output = [
-            [
+            '79e7e210bdf335bb8651a46b9a8417ab' => [
                 'id' => '79e7e210bdf335bb8651a46b9a8417ab',
                 'hex' => '79:e7:e2:10:bd:f3:35:bb:86:51:a4:6b:9a:84:17:ab',
                 'comment' => 'dev@foo.bar'
             ],
-            [
+            '27a7a11ab9d2acbf91063410546ef980' => [
                 'id' => '27a7a11ab9d2acbf91063410546ef980',
                 'hex' => '27:a7:a1:1a:b9:d2:ac:bf:91:06:34:10:54:6e:f9:80',
                 'comment' => 'dev@baz.bar'
             ]
         ];
-        $collection = new SSHKeys(['user' => $this->user]);
-        $this->ssh_keys->method('all')
-            ->willReturn([
-                new SSHKey((object)$keys[0], ['collection' => $collection]),
-                new SSHKey((object)$keys[1], ['collection' => $collection])
-            ]);
+        $this->ssh_keys->method('serialize')
+            ->willReturn($output);
 
         $this->logger->expects($this->never())
             ->method($this->anything());

--- a/tests/unit_tests/Commands/Site/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Site/ListCommandTest.php
@@ -61,20 +61,16 @@ class ListCommandTest extends CommandTestCase
             ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['abc' => $dummy_info, 'def' => $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index();
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['abc' => $dummy_info, 'def' => $dummy_info,], $out->getArrayCopy());
     }
 
     /**
@@ -92,7 +88,6 @@ class ListCommandTest extends CommandTestCase
             'memberships' => 'user_id: Team',
         ];
 
-        $this->site->memberships = ['user_id: Team'];
         $this->sites->expects($this->once())
             ->method('fetch')
             ->with($this->equalTo(['org_id' => null, 'team_only' => true,]))
@@ -103,20 +98,16 @@ class ListCommandTest extends CommandTestCase
             ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['a' => $dummy_info, 'b' =>  $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index(['team' => true, 'owner' => null, 'org' => null, 'name' => null,]);
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['a' => $dummy_info, 'b' =>  $dummy_info,], $out->getArrayCopy());
     }
 
     /**
@@ -134,7 +125,6 @@ class ListCommandTest extends CommandTestCase
             'memberships' => 'org_id: org_url',
         ];
 
-        $this->site->memberships = ['org_id: org_url'];
         $this->sites->expects($this->once())
             ->method('fetch')
             ->with($this->equalTo(['org_id' => 'org_id', 'team_only' => false,]))
@@ -145,20 +135,16 @@ class ListCommandTest extends CommandTestCase
             ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['a' => $dummy_info, 'b' =>  $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index(['team' => false, 'owner' => null, 'org' => 'org_id', 'name' => null,]);
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['a' => $dummy_info, 'b' =>  $dummy_info,], $out->getArrayCopy());
     }
 
     /**
@@ -177,7 +163,6 @@ class ListCommandTest extends CommandTestCase
         ];
         $regex = '(.*)';
 
-        $this->site->memberships = ['org_id: org_url'];
         $this->sites->expects($this->once())
             ->method('fetch')
             ->with($this->equalTo(['org_id' => null, 'team_only' => false,]))
@@ -190,20 +175,16 @@ class ListCommandTest extends CommandTestCase
             ->method('getUser');
         $this->sites->expects($this->never())
             ->method('filterByOwner');
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['a' => $dummy_info, 'b' =>  $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index(['team' => false, 'owner' => null, 'org' => null, 'name' => $regex,]);
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['a' => $dummy_info, 'b' =>  $dummy_info,], $out->getArrayCopy());
     }
 
     /**
@@ -235,20 +216,16 @@ class ListCommandTest extends CommandTestCase
             ->method('filterByOwner')
             ->with($this->equalTo($user_id))
             ->willReturn($this->sites);
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['a' => $dummy_info, 'b' =>  $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index(['team' => false, 'owner' => $user_id, 'org' => null, 'name' => null,]);
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['a' => $dummy_info, 'b' =>  $dummy_info,], $out->getArrayCopy());
     }
 
     /**
@@ -271,7 +248,6 @@ class ListCommandTest extends CommandTestCase
             ->getMock();
         $user->id = $user_id;
 
-        $this->site->memberships = ['org_id: org_url'];
         $this->sites->expects($this->once())
             ->method('fetch')
             ->with($this->equalTo(['org_id' => null, 'team_only' => false,]))
@@ -286,19 +262,15 @@ class ListCommandTest extends CommandTestCase
             ->method('filterByOwner')
             ->with($this->equalTo($user_id))
             ->willReturn($this->sites);
-        $this->site->expects($this->any())
+        $this->sites->expects($this->once())
             ->method('serialize')
             ->with()
-            ->willReturn($dummy_info);
-        $this->sites->expects($this->once())
-            ->method('all')
-            ->with()
-            ->willReturn([$this->site, $this->site,]);
+            ->willReturn(['a' => $dummy_info, 'b' =>  $dummy_info,]);
         $this->logger->expects($this->never())
             ->method('log');
 
         $out = $this->command->index(['team' => false, 'owner' => 'me', 'org' => null, 'name' => null,]);
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$dummy_info, $dummy_info,], $out->getArrayCopy());
+        $this->assertEquals(['a' => $dummy_info, 'b' =>  $dummy_info,], $out->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/Site/LookupCommandTest.php
+++ b/tests/unit_tests/Commands/Site/LookupCommandTest.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\UnitTests\Commands\Site;
 
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Pantheon\Terminus\Commands\Site\LookupCommand;
+use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
 /**
@@ -31,30 +32,14 @@ class LookupCommandTest extends CommandTestCase
     {
         $site_name = 'my-site';
 
-        $this->sites->method('findUuidByName')
-            ->with($this->equalTo($site_name))
-            ->willReturn(['name' => $site_name, 'id' => 'site_id',]);
+        $this->site->expects($this->once())
+            ->method('serialize')
+            ->willReturn(['name' => $site_name, 'id' => 'site_id']);
 
         $out = $this->command->lookup($site_name);
         $this->assertInstanceOf(PropertyList::class, $out);
-    }
 
-    /**
-     * Exercises site:lookup where the result is that the site exists but you do not have access to it
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage You are not authorized for this site.
-     */
-    public function testSiteLookupExistsButNotAuthorized()
-    {
-        $site_name = 'my-site';
-
-        $this->sites->method('findUuidByName')
-            ->with($this->equalTo($site_name))
-            ->will($this->throwException(new \Exception('You are not authorized for this site.')));
-
-        $out = $this->command->lookup($site_name);
-        $this->assertInstanceOf(PropertyList::class, $out);
+        $this->assertEquals(['name' => $site_name, 'id' => 'site_id'], $out->getArrayCopy());
     }
 
     /**
@@ -67,7 +52,7 @@ class LookupCommandTest extends CommandTestCase
     {
         $site_name = 'my-site';
 
-        $this->sites->method('findUuidByName')
+        $this->sites->method('get')
             ->with($this->equalTo($site_name))
             ->will($this->throwException(new \Exception("A site named $site_name was not found.")));
 

--- a/tests/unit_tests/Commands/Site/Org/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Site/Org/ListCommandTest.php
@@ -40,23 +40,13 @@ class ListCommandTest extends CommandTestCase
     public function testListOrgs()
     {
         $data = [
-            ['org_name' => 'abc', 'org_id' => '000'],
-            ['org_name' => 'def', 'org_id' => '111'],
+            '000' => ['org_name' => 'abc', 'org_id' => '000'],
+            '111' => ['org_name' => 'def', 'org_id' => '111'],
         ];
-        $memberships = [];
-        foreach ($data as $item) {
-            $mock = $this->getMockBuilder(SiteOrganizationMembership::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $mock->expects($this->once())
-                ->method('serialize')
-                ->willReturn($item);
-            $memberships[] = $mock;
-        }
 
         $this->org_memberships->expects($this->once())
-            ->method('all')
-            ->willReturn($memberships);
+            ->method('serialize')
+            ->willReturn($data);
 
         $out = $this->command->listOrgs('my-site');
         $this->assertInstanceOf(RowsOfFields::class, $out);
@@ -69,7 +59,7 @@ class ListCommandTest extends CommandTestCase
     public function testListOrgsNone()
     {
         $this->org_memberships->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->willReturn([]);
 
         $this->logger->expects($this->at(0))

--- a/tests/unit_tests/Commands/Site/Team/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Site/Team/ListCommandTest.php
@@ -27,28 +27,28 @@ class ListCommandTest extends TeamCommandTest
      */
     public function testListCommand()
     {
-        $user = (object)[];
-        $user->id = 'abcdef';
-        $user->profile = (object)[];
-        $user->profile->firstname = 'Daisy';
-        $user->profile->lastname = 'Duck';
-        $user->email = 'daisy@duck.com';
-
-        $this->user_membership->expects($this->any())
-            ->method('get')
-            ->will($this->onConsecutiveCalls($user, 'team_member', $user, 'team_member'));
+        $expected = [
+            'abc' => [
+                'firstname' => 'Daisy',
+                'lastname' => 'Duck',
+                'email' => 'daisy@duck.com',
+                'user_id' => 'abc',
+                'role' => 'team_member',
+            ],
+            'def' => [
+                'firstname' => 'Mickey',
+                'lastname' => 'Mouse',
+                'email' => 'mickey@mouse.com',
+                'user_id' => 'def',
+                'role' => 'team_member',
+            ]
+        ];
 
         $this->user_memberships->expects($this->once())
-            ->method('all')
-            ->willReturn([$this->user_membership, $this->user_membership]);
+            ->method('serialize')
+            ->willReturn($expected);
 
-        $out = $this->command->teamList('mysite');
-        foreach ($out as $u) {
-            $this->assertEquals($u['first'], $user->profile->firstname);
-            $this->assertEquals($u['last'], $user->profile->lastname);
-            $this->assertEquals($u['email'], $user->email);
-            $this->assertEquals($u['role'], 'team_member');
-            $this->assertEquals($u['uuid'], $user->id);
-        }
+        $actual = $this->command->teamList('mysite');
+        $this->assertEquals($expected, $actual->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/Upstream/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/ListCommandTest.php
@@ -29,12 +29,12 @@ class ListCommandTest extends UpstreamCommandTest
     public function testListUpstreams()
     {
         $this->upstreams->expects($this->once())
-            ->method('all')
+            ->method('serialize')
             ->with()
-            ->willReturn([$this->upstream,]);
+            ->willReturn([$this->data['id'] => $this->data]);
 
         $out = $this->command->listUpstreams();
         $this->assertInstanceOf(RowsOfFields::class, $out);
-        $this->assertEquals([$this->data,], $out->getArrayCopy());
+        $this->assertEquals([$this->data['id'] => $this->data], $out->getArrayCopy());
     }
 }

--- a/tests/unit_tests/Commands/Workflow/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Workflow/ListCommandTest.php
@@ -29,15 +29,12 @@ class ListCommandTest extends WorkflowCommandTest
     {
         $this->workflows->expects($this->once())
             ->method('fetch')
-            ->willReturn(null);
+            ->willReturn($this->workflows);
 
         $this->workflows->expects($this->once())
-            ->method('all')
-            ->willReturn([$this->workflow]);
-
-        $this->workflow->expects($this->once())
             ->method('serialize')
-            ->willReturn(['id' => '12345', 'details' => 'test']);
+            ->willReturn(['12345' => ['id' => '12345', 'details' => 'test']]);
+
 
         $out = $this->command->wfList('mysite');
         foreach ($out as $w) {

--- a/tests/unit_tests/Models/BackupTest.php
+++ b/tests/unit_tests/Models/BackupTest.php
@@ -204,4 +204,24 @@ class BackupTest extends ModelTestCase
         $this->setExpectedException(TerminusException::class, 'This backup has no archive to restore.');
         $this->assertNull($backup->restore());
     }
+
+    public function testSerialize()
+    {
+        $this->configSet(['date_format' => 'Y-m-d']);
+        $backup = $this->_getBackup([
+            'size' => 4508876,
+            'finish_time' => 1479742685,
+            'folder' => 'xyz_automated',
+            'filename' => 'test.tar.gz',
+        ]);
+
+        $expected = [
+            'file' => 'test.tar.gz',
+            'size' => '4.3MB',
+            'date' => '2016-11-21',
+            'initiator' => 'automated',
+        ];
+        $actual = $backup->serialize();
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/unit_tests/Models/CommitTest.php
+++ b/tests/unit_tests/Models/CommitTest.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Pantheon\Terminus\UnitTests\Models;
+
+use Pantheon\Terminus\Models\Commit;
+
+class CommitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSerialize()
+    {
+        $data = [
+            'datetime' => '2016-09-21T12:21:18',
+            'author' => 'Daisy Duck',
+            'labels' => ['test', 'dev'],
+            'hash' => 'c65e638f03cabc7b97e686bb9de843b7173e329a',
+            'message' => str_pad(" Add some new code\nAnother Line Here\tTab", 100, '-'),
+        ];
+        $commit = new Commit((object)$data);
+        $actual = $commit->serialize();
+        $expected = [
+            'datetime' => '2016-09-21T12:21:18',
+            'author' => 'Daisy Duck',
+            'labels' => 'test, dev',
+            'hash' => 'c65e638f03cabc7b97e686bb9de843b7173e329a',
+            'message' => str_pad('Add some new code Another Line Here Tab', 50, '-'),
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/unit_tests/Models/SSHKeyTest.php
+++ b/tests/unit_tests/Models/SSHKeyTest.php
@@ -74,4 +74,41 @@ class SSHKeyTest extends ModelTestCase
         $this->assertEquals('12:34:56:78:90:ab:cd:ef', $sshkey->getHex());
         $this->assertEquals('dev@example.com', $sshkey->getComment());
     }
+
+    public function testSerialize()
+    {
+        $keys = [
+            '79e7e210bdf335bb8651a46b9a8417ab' => [
+                'id' => '79e7e210bdf335bb8651a46b9a8417ab',
+                'key' => 'ssh-rsa xxxxxxx dev@foo.bar',
+            ],
+            '27a7a11ab9d2acbf91063410546ef980' => [
+                'id' => '27a7a11ab9d2acbf91063410546ef980',
+                'key' => 'ssh-rsa yyyyyyy dev@baz.bar',
+            ]
+        ];
+        $excpected = [
+            '79e7e210bdf335bb8651a46b9a8417ab' => [
+                'id' => '79e7e210bdf335bb8651a46b9a8417ab',
+                'hex' => '79:e7:e2:10:bd:f3:35:bb:86:51:a4:6b:9a:84:17:ab',
+                'comment' => 'dev@foo.bar'
+            ],
+            '27a7a11ab9d2acbf91063410546ef980' => [
+                'id' => '27a7a11ab9d2acbf91063410546ef980',
+                'hex' => '27:a7:a1:1a:b9:d2:ac:bf:91:06:34:10:54:6e:f9:80',
+                'comment' => 'dev@baz.bar'
+            ]
+        ];
+        $collection = $this->getMockBuilder(SSHKeys::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        foreach ($keys as $i => $key_data) {
+            $sshkey = new SSHKey(
+                (object)$key_data,
+                ['collection' => $collection]
+            );
+            $this->assertEquals($excpected[$i], $sshkey->serialize());
+        }
+    }
 }


### PR DESCRIPTION
The output formatters expect lists of rows to be indexed by their id. Or at least doing so gives you more options. By stripping the IDs from the index we lose that function. By adding it back we can do:

`terminus site:list --format=list` and get a list if site ids rather than a meaningless list of numbers.