### PR TITLE
Fix a few problems with plugin info parsing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f562d7b2415b4228e4362b9a0907a821",
+    "hash": "27df489e02b27313204fb63a25601df6",
     "content-hash": "ec5a4ce94be5c9e46dd671edae12ed6e",
     "packages": [
         {
@@ -71,16 +71,16 @@
         },
         {
             "name": "consolidation/annotated-command",
-            "version": "2.2.0",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "2066be99905d4001b516e41feab52718614e00c1"
+                "reference": "1f1d92807f72901e049e9df048b412c3bc3652c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/2066be99905d4001b516e41feab52718614e00c1",
-                "reference": "2066be99905d4001b516e41feab52718614e00c1",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/1f1d92807f72901e049e9df048b412c3bc3652c9",
+                "reference": "1f1d92807f72901e049e9df048b412c3bc3652c9",
                 "shasum": ""
             },
             "require": {
@@ -119,7 +119,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-11-24 00:36:49"
+            "time": "2016-12-16 01:23:33"
         },
         {
             "name": "consolidation/log",
@@ -1044,16 +1044,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.14",
+            "version": "v2.8.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e"
+                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a871ba00e0f604dceac64c56c27f99fbeaf4854e",
-                "reference": "a871ba00e0f604dceac64c56c27f99fbeaf4854e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d5643cd095e5e37d31e004bb2606b5dd7e96602f",
+                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f",
                 "shasum": ""
             },
             "require": {
@@ -1101,7 +1101,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15 23:02:12"
+            "time": "2016-12-06 11:59:35"
         },
         {
             "name": "symfony/debug",
@@ -1162,7 +1162,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -1222,7 +1222,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1271,16 +1271,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4263e35a1e342a0f195c9349c0dee38148f8a14f"
+                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4263e35a1e342a0f195c9349c0dee38148f8a14f",
-                "reference": "4263e35a1e342a0f195c9349c0dee38148f8a14f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
+                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
                 "shasum": ""
             },
             "require": {
@@ -1316,7 +1316,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:11:03"
+            "time": "2016-12-13 09:39:43"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1379,7 +1379,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -1428,16 +1428,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "86f4e8aeb07bd5fb467f6bdd599a30298d19fa5f"
+                "reference": "f722532b0966e9b6fc631e682143c07b2cf583a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/86f4e8aeb07bd5fb467f6bdd599a30298d19fa5f",
-                "reference": "86f4e8aeb07bd5fb467f6bdd599a30298d19fa5f",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f722532b0966e9b6fc631e682143c07b2cf583a0",
+                "reference": "f722532b0966e9b6fc631e682143c07b2cf583a0",
                 "shasum": ""
             },
             "require": {
@@ -1487,20 +1487,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-11-29 10:33:09"
+            "time": "2016-12-11 14:34:22"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f2300ba8fbb002c028710b92e1906e7457410693"
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f2300ba8fbb002c028710b92e1906e7457410693",
-                "reference": "f2300ba8fbb002c028710b92e1906e7457410693",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
                 "shasum": ""
             },
             "require": {
@@ -1542,7 +1542,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 21:17:59"
+            "time": "2016-12-10 10:07:06"
         },
         {
             "name": "victorjonsson/markdowndocs",
@@ -3207,7 +3207,7 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
@@ -3263,16 +3263,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4a68f8953180bf77ea65f585020f4db0b18600b4"
+                "reference": "b4ec9f099599cfc5b7f4d07bb2e910781a2be5e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4a68f8953180bf77ea65f585020f4db0b18600b4",
-                "reference": "4a68f8953180bf77ea65f585020f4db0b18600b4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b4ec9f099599cfc5b7f4d07bb2e910781a2be5e4",
+                "reference": "b4ec9f099599cfc5b7f4d07bb2e910781a2be5e4",
                 "shasum": ""
             },
             "require": {
@@ -3315,20 +3315,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-29 11:12:32"
+            "time": "2016-12-09 07:45:17"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f5419adad083c90e0dfd8588ef83683d7dbcc20d"
+                "reference": "037054501c41007c93b6de1b5c7a7acb83523593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f5419adad083c90e0dfd8588ef83683d7dbcc20d",
-                "reference": "f5419adad083c90e0dfd8588ef83683d7dbcc20d",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/037054501c41007c93b6de1b5c7a7acb83523593",
+                "reference": "037054501c41007c93b6de1b5c7a7acb83523593",
                 "shasum": ""
             },
             "require": {
@@ -3378,11 +3378,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-25 12:32:42"
+            "time": "2016-12-08 15:27:33"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -3431,16 +3431,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "64ab6fc0b42e5386631f408e6adcaaff8eee5ba1"
+                "reference": "5fd18eca88f4d187807a1eba083bc99feaa8635b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/64ab6fc0b42e5386631f408e6adcaaff8eee5ba1",
-                "reference": "64ab6fc0b42e5386631f408e6adcaaff8eee5ba1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/5fd18eca88f4d187807a1eba083bc99feaa8635b",
+                "reference": "5fd18eca88f4d187807a1eba083bc99feaa8635b",
                 "shasum": ""
             },
             "require": {
@@ -3491,7 +3491,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 21:17:59"
+            "time": "2016-11-30 14:40:17"
         },
         {
             "name": "theseer/fdomdocument",

--- a/src/Plugins/PluginDiscovery.php
+++ b/src/Plugins/PluginDiscovery.php
@@ -46,7 +46,7 @@ class PluginDiscovery implements ContainerAwareInterface, LoggerAwareInterface
                     try {
                         $out[] = $this->getContainer()->get(PluginInfo::class, [$dir->getPathname()]);
                     } catch (TerminusException $e) {
-                        $this->logger->debug(
+                        $this->logger->warning(
                             'Plugin Discovery: Ignoring directory {dir} because: {msg}.',
                             ['dir' => $dir->getPathName(), 'msg' => $e->getMessage()]
                         );

--- a/src/Plugins/PluginInfo.php
+++ b/src/Plugins/PluginInfo.php
@@ -94,10 +94,10 @@ class PluginInfo
         $info = json_decode(file_get_contents($composer_json), true);
 
         if (!$info) {
-            throw new TerminusException('The file "{file}" is not a valid', ['file' => $composer_json]);
+            throw new TerminusException('The file "{file}" does not contain valid JSON', ['file' => $composer_json]);
         }
 
-        if (!$info['type'] || $info['type'] !== 'terminus-plugin') {
+        if (!isset($info['type']) || $info['type'] !== 'terminus-plugin') {
             throw new TerminusException('The composer.json must contain a "type" attribute with the value "terminus-plugin"');
         }
 
@@ -107,6 +107,15 @@ class PluginInfo
 
         if (!isset($info['extra']['terminus']['compatible-version'])) {
             throw new TerminusException('The composer.json must contain a "compatible-version" field in "extras/terminus"');
+        }
+
+        if (isset($info['autoload']) && isset($info['autoload']['psr-4'])) {
+            foreach ($info['autoload']['psr-4'] as $namespace => $path) {
+                if (substr($namespace, -1) != '\\') {
+                    $correctNamespace = $namespace . '\\';
+                    throw new TerminusException('The namespace "{namespace}" in the composer.json autoload psr-4 section must end with a namespace separator. Should be "{correct}"', ['namespace' => addslashes($namespace), 'correct' => addslashes($correctNamespace)]);
+                }
+            }
         }
 
         return (array)$info;

--- a/tests/fixtures/plugins/with-namespace/composer.json
+++ b/tests/fixtures/plugins/with-namespace/composer.json
@@ -9,6 +9,6 @@
     },
     "license": "MIT",
     "autoload": {
-        "psr-4": { "OrgName\\PluginName": "src" }
+        "psr-4": { "OrgName\\PluginName\\": "src" }
     }
 }

--- a/tests/unit_tests/Plugins/PluginDiscoveryTest.php
+++ b/tests/unit_tests/Plugins/PluginDiscoveryTest.php
@@ -22,7 +22,7 @@ class PluginDiscoveryTest extends \PHPUnit_Framework_TestCase
         ];
 
         $logger = $this->getMockBuilder(NullLogger::class)
-            ->setMethods(array('debug'))
+            ->setMethods(array('warning'))
             ->getMock();
 
 
@@ -41,7 +41,7 @@ class PluginDiscoveryTest extends \PHPUnit_Framework_TestCase
                     ->willThrowException(new TerminusException($msg));
 
                 $logger->expects($this->at($log++))
-                    ->method('debug')
+                    ->method('warning')
                     ->with('Plugin Discovery: Ignoring directory {dir} because: {msg}.', ['dir' => $path, 'msg' => $msg]);
             } else {
                 $plugin = $this->getMockBuilder(PluginInfo::class)


### PR DESCRIPTION
- Fix crash when a plugin's composer.json file is missing the 'type' attribute.
- Ensure that the warning message produced by invalid plugins is displayed.
- Fix incomplete sentence in the 'invalid json' test.

Note that by switching the plugin message from `debug` to `warning`, the error message printed when an invalid plugin is present is displayed on every run of Terminus. The apparent intention of the existing code was to only display such messages when Terminus is run in debug mode (e.g. with `-vvv`). Unfortunately, the commandline options are not parsed until after the Terminus plugins are loaded, so `$this->logger->debug(...)` will never produce any output at this stage of execution. To fix this problem, Terminus would need to implement its own Symfony Console Application class.  If this is done, then `Application::doRun()` could be overridden, and plugins could be loaded at that time, just prior to calling `parent::doRun()`. At this point in the execution of the program, the commandline options have been parsed and the output stream's verbosity level has been set, but the current command hasn't been searched for yet -- all necessary requirements for loading plugins and using `debug`-level log messages.