### PR TITLE
Added stop-gap confirmation for deletes.

### DIFF
--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -53,6 +53,11 @@ class RestoreCommand extends TerminusCommand implements SiteAwareInterface
             $backup = array_shift($backups);
         }
 
+        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
+        if (!$this->confirm('Are you sure you want to restore to {env} on {site}?', $tr)) {
+            return;
+        }
+
         $workflow = $backup->restore();
         $workflow->wait();
 

--- a/src/Commands/Env/CloneContentCommand.php
+++ b/src/Commands/Env/CloneContentCommand.php
@@ -46,6 +46,12 @@ class CloneContentCommand extends TerminusCommand implements SiteAwareInterface
         list($site, $env) = $this->getSiteEnv($site_env);
         $from_name = $env->getName();
         $target = $site->getEnvironments()->get($target_env);
+        $to_name = $target->getName();
+
+        $tr = ['from' => $from_name, 'to' => $to_name, 'env' => $site->getName()];
+        if (!$this->confirm('Are you sure you want to clone content from {from} to {to} on {site}?', $tr)) {
+            return;
+        }
 
         if (empty($options['db-only'])) {
             $workflow = $target->cloneFiles($from_name);

--- a/src/Commands/Env/WipeCommand.php
+++ b/src/Commands/Env/WipeCommand.php
@@ -31,6 +31,12 @@ class WipeCommand extends TerminusCommand implements SiteAwareInterface
     public function wipe($site_env)
     {
         list($site, $env) = $this->getSiteEnv($site_env);
+
+        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
+        if (!$this->confirm('Are you sure you want to wipe {env} on {site}?', $tr)) {
+            return;
+        }
+
         $workflow = $env->wipe();
         $this->log()->notice(
             'Wiping the "{env}" environment of "{site}"',

--- a/src/Commands/Import/DatabaseCommand.php
+++ b/src/Commands/Import/DatabaseCommand.php
@@ -27,6 +27,12 @@ class DatabaseCommand extends TerminusCommand implements SiteAwareInterface
     public function import($site_env, $url)
     {
         list($site, $env) = $this->getSiteEnv($site_env);
+
+        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
+        if (!$this->confirm('Are you sure you overwrite the database for {env} on {site}?', $tr)) {
+            return;
+        }
+
         $workflow = $env->importDatabase($url);
         while (!$workflow->checkProgress()) {
             // @TODO: Add Symfony progress bar to indicate that something is happening.

--- a/src/Commands/Import/FilesCommand.php
+++ b/src/Commands/Import/FilesCommand.php
@@ -30,6 +30,12 @@ class FilesCommand extends TerminusCommand implements SiteAwareInterface
     public function import($site_env, $url)
     {
         list($site, $env) = $this->getSiteEnv($site_env);
+
+        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
+        if (!$this->confirm('Are you sure you overwrite the files for {env} on {site}?', $tr)) {
+            return;
+        }
+
         $workflow = $env->importFiles($url);
         while (!$workflow->checkProgress()) {
             // @TODO: Add Symfony progress bar to indicate that something is happening.

--- a/src/Commands/Import/SiteCommand.php
+++ b/src/Commands/Import/SiteCommand.php
@@ -32,7 +32,13 @@ class SiteCommand extends TerminusCommand implements SiteAwareInterface
     public function import($sitename, $url)
     {
         $site = $sitename;
-        list(, $env) = $this->getSiteEnv($site, 'dev');
+        list($site, $env) = $this->getSiteEnv($site, 'dev');
+
+        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
+        if (!$this->confirm('Are you sure you overwrite the code, database and files for {env} on {site}?', $tr)) {
+            return;
+        }
+
         $workflow = $env->import($url);
         try {
             $workflow->wait();

--- a/src/Commands/MachineToken/DeleteCommand.php
+++ b/src/Commands/MachineToken/DeleteCommand.php
@@ -25,6 +25,10 @@ class DeleteCommand extends TerminusCommand
         $machine_token = $this->session()->getUser()->getMachineTokens()->get($machine_token_id);
         $name = $machine_token->get('device_name');
 
+        if (!$this->confirm('Are you sure you want to delete this machine token?')) {
+            return;
+        }
+
         $this->log()->notice('Deleting {token} ...', ['token' => $name]);
         $machine_token->delete();
         $this->log()->notice('Deleted {token}!', ['token' => $name]);

--- a/src/Commands/Multidev/DeleteCommand.php
+++ b/src/Commands/Multidev/DeleteCommand.php
@@ -34,6 +34,11 @@ class DeleteCommand extends TerminusCommand implements SiteAwareInterface
     public function deleteMultidev($site_env, $options = ['delete-branch' => false,])
     {
         list(, $env) = $this->getSiteEnv($site_env);
+
+        if (!$this->confirm('Are you sure you want to delete {env}?', ['env' => $env->getName()])) {
+            return;
+        }
+
         $workflow = $env->delete(['delete_branch' => $options['delete-branch'],]);
         $workflow->wait();
         if ($workflow->isSuccessful()) {

--- a/src/Commands/Site/DeleteCommand.php
+++ b/src/Commands/Site/DeleteCommand.php
@@ -23,6 +23,11 @@ class DeleteCommand extends SiteCommand
     public function delete($site_name)
     {
         $site = $this->getSite($site_name);
+
+        if (!$this->confirm('Are you sure you want to delete {site}?', ['site' => $site->getName()])) {
+            return;
+        }
+
         $site->delete();
         $this->log()->notice('Deleted {site} from Pantheon', ['site' => $site_name,]);
     }

--- a/src/Commands/TerminusCommand.php
+++ b/src/Commands/TerminusCommand.php
@@ -57,4 +57,27 @@ abstract class TerminusCommand implements
         }
         return $this->io;
     }
+
+    /**
+     * Confirm that the user wants to continue with the command.
+     *
+     * @deprecated 1.0.0 This is not the correct way to do this and will be removed in the future. Use with caution.
+     *
+     * @param $confirm_text
+     * @param array $replacements
+     * @return bool|string
+     */
+    protected function confirm($confirm_text, $replacements = [])
+    {
+        if ($this->input()->hasOption('yes') && $this->input()->getOption('yes')) {
+            return true;
+        }
+
+        $tr = [];
+        foreach ($replacements as $key => $val) {
+            $tr['{' . $key . '}'] = $val;
+        }
+        $confirm_text = strtr($confirm_text, $tr);
+        return $this->io()->confirm($confirm_text, false);
+    }
 }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -72,6 +72,7 @@ use Robo\Runner as RoboRunner;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use VCR\VCR;
 
@@ -105,6 +106,8 @@ class Terminus implements ConfigAwareInterface
 
         $application = new Application('Terminus', $config->get('version'));
         $container = Robo::createDefaultContainer($input, $output, $application, $config);
+
+        $this->addDefaultArgumentsAndOptions($application);
 
         $this->configureContainer($container);
 
@@ -278,6 +281,16 @@ class Terminus implements ConfigAwareInterface
         // Tell the command loader to only allow command functions that have a name/alias.
         $factory = $container->get('commandFactory');
         $factory->setIncludeAllPublicMethods(false);
+    }
+
+    /**
+     * Add any global arguments or options that apply to all commands.
+     *
+     * @param \Symfony\Component\Console\Application $app
+     */
+    private function addDefaultArgumentsAndOptions(Application $app)
+    {
+        $app->getDefinition()->addOption(new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer all confirmations with "yes"'));
     }
 
     /**

--- a/tests/features/backup-restore.feature
+++ b/tests/features/backup-restore.feature
@@ -9,10 +9,10 @@ Feature: Restore a backup for a site
 
   @vcr backup-restore.yml
   Scenario: Restore the latest code backup
-    When I run "terminus backup:restore [[test_site_name]].dev --element=code"
+    When I run "terminus backup:restore [[test_site_name]].dev --element=code --yes"
     Then I should get: "Restored the backup to dev."
 
   @vcr backup-restore.yml
   Scenario: Restore a specific backup referenced by filename
-    When I run "terminus backup:restore [[test_site_name]].dev --file=[[test_site_name]]_dev_2016-10-25T19-13-37_UTC_files.tar.gz"
+    When I run "terminus backup:restore [[test_site_name]].dev --file=[[test_site_name]]_dev_2016-10-25T19-13-37_UTC_files.tar.gz --yes"
     Then I should get: "Restored the backup to dev."

--- a/tests/features/env-clone.feature
+++ b/tests/features/env-clone.feature
@@ -9,7 +9,7 @@ Feature: Cloning site content
 
   @vcr env-clone.yml
   Scenario: Site Clone Environment
-    When I run "terminus env:clone-content [[test_site_name]].test dev"
+    When I run "terminus env:clone-content [[test_site_name]].test dev --yes"
     Then I should get:
     """
     Cloned files from "test" to "dev"
@@ -21,7 +21,7 @@ Feature: Cloning site content
 
   @vcr env-clone.yml
   Scenario: Site Clone Files Only
-    When I run "terminus env:clone-content [[test_site_name]].test dev --files-only"
+    When I run "terminus env:clone-content [[test_site_name]].test dev --files-only --yes"
     Then I should get:
     """
     Cloned files from "test" to "dev"
@@ -29,7 +29,7 @@ Feature: Cloning site content
 
   @vcr env-clone.yml
   Scenario: Site Clone Files Only
-    When I run "terminus env:clone-content [[test_site_name]].test dev --db-only"
+    When I run "terminus env:clone-content [[test_site_name]].test dev --db-only --yes"
     Then I should get:
     """
     Cloned database from "test" to "dev"

--- a/tests/features/env-wipe.feature
+++ b/tests/features/env-wipe.feature
@@ -9,7 +9,7 @@ Feature: Wipe the content in a site's environment
 
   @vcr env-wipe.yml
   Scenario: Wipe Environment
-    When I run "terminus env:wipe [[test_site_name]].dev"
+    When I run "terminus env:wipe [[test_site_name]].dev  --yes"
     Then I should get:
     """
     Wiping the "dev" environment of "[[test_site_name]]"

--- a/tests/features/import.feature
+++ b/tests/features/import.feature
@@ -9,7 +9,7 @@ Feature: Import a a site and its content onto Pantheon
 
   @vcr import.yml
   Scenario: Importing a site archive onto Pantheon
-    When I run "terminus import:site [[test_site_name]] https://s3.amazonaws.com/pantheondemofiles/archive.tar.gz"
+    When I run "terminus import:site [[test_site_name]] https://s3.amazonaws.com/pantheondemofiles/archive.tar.gz --yes"
     Then I should get "."
     Then I should get:
     """
@@ -18,7 +18,7 @@ Feature: Import a a site and its content onto Pantheon
 
   @vcr import-files.yml
   Scenario: Import files into the site
-    When I run "terminus import:files [[test_site_name]].dev https://s3.amazonaws.com/pantheondemofiles/files.tar.gz"
+    When I run "terminus import:files [[test_site_name]].dev https://s3.amazonaws.com/pantheondemofiles/files.tar.gz --yes"
     Then I should get "."
     Then I should get:
     """
@@ -27,7 +27,7 @@ Feature: Import a a site and its content onto Pantheon
 
   @vcr import-database.yml
   Scenario: Import database into the site
-    When I run "terminus import:database [[test_site_name]].dev https://s3.amazonaws.com/pantheondemofiles/database.tar.gz"
+    When I run "terminus import:database [[test_site_name]].dev https://s3.amazonaws.com/pantheondemofiles/database.tar.gz --yes"
     Then I should get "."
     Then I should get:
     """

--- a/tests/features/machine-token.feature
+++ b/tests/features/machine-token.feature
@@ -16,7 +16,7 @@ Feature: Machine tokens command
 
   @vcr machine-token-delete.yml
   Scenario: Delete machine token
-    When I run "terminus machine-token:delete [[machine_token_id]]"
+    When I run "terminus machine-token:delete [[machine_token_id]] --yes"
     Then I should get:
     """
     Deleted [[machine_token_device]]!

--- a/tests/features/multidev-delete.feature
+++ b/tests/features/multidev-delete.feature
@@ -9,7 +9,7 @@ Feature: Deleting a site's multidev environments
 
   @vcr multidev-delete.yml
   Scenario: Deleting a multidev environment
-    When I run "terminus multidev:delete [[test_site_name]].multidev"
+    When I run "terminus multidev:delete [[test_site_name]].multidev --yes"
     Then I should get:
     """
     Deleted the multidev environment multidev.
@@ -17,7 +17,7 @@ Feature: Deleting a site's multidev environments
 
   @vcr multidev-delete.yml
   Scenario: Failing to delete a multidev environment when the specified environment does not exist
-    When I run "terminus multidev:delete [[test_site_name]].invalid"
+    When I run "terminus multidev:delete [[test_site_name]].invalid --yes"
     Then I should get:
     """
     Could not find Pantheon\Terminus\Models\Environment "invalid"

--- a/tests/features/site-delete.feature
+++ b/tests/features/site-delete.feature
@@ -9,5 +9,5 @@ Feature: Deleting a site
 
   @vcr site-delete.yml
   Scenario: Delete Site
-    When I run "terminus site:delete [[test_site_name]]"
+    When I run "terminus site:delete [[test_site_name]] --yes"
     Then I should get: "Deleted [[test_site_name]] from Pantheon"

--- a/tests/unit_tests/Commands/Backup/RestoreCommandTest.php
+++ b/tests/unit_tests/Commands/Backup/RestoreCommandTest.php
@@ -21,6 +21,7 @@ class RestoreCommandTest extends BackupCommandTest
         $this->command = new RestoreCommand($this->sites);
         $this->command->setLogger($this->logger);
         $this->command->setSites($this->sites);
+        $this->command->setInput($this->input);
     }
 
     /**

--- a/tests/unit_tests/Commands/CommandTestCase.php
+++ b/tests/unit_tests/Commands/CommandTestCase.php
@@ -6,6 +6,7 @@ use League\Container\Container;
 use Pantheon\Terminus\Config\TerminusConfig;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Output\OutputInterface;
 use Pantheon\Terminus\Collections\Environments;
 use Pantheon\Terminus\Collections\Sites;
@@ -137,8 +138,12 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->site2->id = 'def';
 
-
-
+        // Always say yes to confirmations
+        $this->input = $this->getMockBuilder(Input::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->input->method('hasOption')->with('yes')->willReturn(true);
+        $this->input->method('getOption')->with('yes')->willReturn(true);
 
         $this->sites = $this->getMockBuilder(Sites::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/Commands/Env/CloneCommandTest.php
+++ b/tests/unit_tests/Commands/Env/CloneCommandTest.php
@@ -24,11 +24,12 @@ class CloneCommandTest extends EnvCommandTest
         $this->command = new CloneContentCommand();
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($this->input);
     }
 
     public function testCloneFiles()
     {
-        $this->environment->expects($this->once())
+        $this->environment->expects($this->any())
             ->method('getName')
             ->willReturn('dev');
         $this->environment->expects($this->once())
@@ -53,7 +54,7 @@ class CloneCommandTest extends EnvCommandTest
 
     public function testCloneDatabase()
     {
-        $this->environment->expects($this->once())
+        $this->environment->expects($this->any())
             ->method('getName')
             ->willReturn('dev');
         $this->environment->expects($this->once())
@@ -78,7 +79,7 @@ class CloneCommandTest extends EnvCommandTest
 
     public function testCloneAll()
     {
-        $this->environment->expects($this->once())
+        $this->environment->expects($this->any())
             ->method('getName')
             ->willReturn('dev');
 

--- a/tests/unit_tests/Commands/Env/WipeCommandTest.php
+++ b/tests/unit_tests/Commands/Env/WipeCommandTest.php
@@ -53,6 +53,7 @@ class WipeCommandTest extends EnvCommandTest
         $this->command = new WipeCommand();
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($this->input);
 
         $out = $this->command->wipe("$site_name.{$this->environment->id}");
         $this->assertNull($out);

--- a/tests/unit_tests/Commands/Import/DatabaseCommandTest.php
+++ b/tests/unit_tests/Commands/Import/DatabaseCommandTest.php
@@ -22,6 +22,7 @@ class DatabaseCommandTest extends CommandTestCase
         $this->command = new DatabaseCommand($this->getConfig());
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($this->input);
     }
     
     /**

--- a/tests/unit_tests/Commands/Import/FilesCommandTest.php
+++ b/tests/unit_tests/Commands/Import/FilesCommandTest.php
@@ -22,6 +22,7 @@ class FilesCommandTest extends CommandTestCase
         $this->command = new FilesCommand($this->getConfig());
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($this->input);
     }
     
     /**

--- a/tests/unit_tests/Commands/Import/SiteCommandTest.php
+++ b/tests/unit_tests/Commands/Import/SiteCommandTest.php
@@ -22,6 +22,7 @@ class SiteCommandTest extends CommandTestCase
         $this->command = new SiteCommand($this->getConfig());
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($this->input);
     }
     
     /**

--- a/tests/unit_tests/Commands/MachineToken/MachineTokenCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokenCommandTest.php
@@ -25,6 +25,8 @@ abstract class MachineTokenCommandTest extends CommandTestCase
      */
     protected function setUp()
     {
+        parent::setUp();
+        
         $this->machine_tokens = $this->getMockBuilder(MachineTokens::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
@@ -20,17 +20,11 @@ class MachineTokenDeleteCommandTest extends MachineTokenCommandTest
     protected function setUp()
     {
         parent::setUp();
-
-        $input = $this->getMockBuilder(Input::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $input->method('hasOption')->with('yes')->willReturn(true);
-        $input->method('getOption')->with('yes')->willReturn(true);
-
+        
         $this->command = new DeleteCommand(new Config());
         $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
-        $this->command->setInput($input);
+        $this->command->setInput($this->input);
     }
 
     /**

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
@@ -5,6 +5,7 @@ use Pantheon\Terminus\Commands\MachineToken\DeleteCommand;
 use Robo\Config;
 use Pantheon\Terminus\Models\MachineToken;
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Symfony\Component\Console\Input\Input;
 
 /**
  * Class MachineTokenDeleteCommandTest
@@ -20,11 +21,17 @@ class MachineTokenDeleteCommandTest extends MachineTokenCommandTest
     {
         parent::setUp();
 
+        $input = $this->getMockBuilder(Input::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $input->method('hasOption')->with('yes')->willReturn(true);
+        $input->method('getOption')->with('yes')->willReturn(true);
+
         $this->command = new DeleteCommand(new Config());
         $this->command->setSession($this->session);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($input);
     }
-
 
     /**
      * Tests the machine-token:delete command.
@@ -50,7 +57,6 @@ class MachineTokenDeleteCommandTest extends MachineTokenCommandTest
             ->willReturn(
                 $token
             );
-
 
         $this->command->delete('123');
     }

--- a/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
@@ -3,6 +3,7 @@
 namespace Pantheon\Terminus\UnitTests\Commands\Multidev;
 
 use Pantheon\Terminus\Commands\Multidev\DeleteCommand;
+use Symfony\Component\Console\Input\Input;
 
 /**
  * Class DeleteCommandTest
@@ -18,10 +19,18 @@ class DeleteCommandTest extends MultidevCommandTest
     {
         parent::setUp();
 
+        $input = $this->getMockBuilder(Input::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $input->method('hasOption')->with('yes')->willReturn(true);
+        $input->method('getOption')->with('yes')->willReturn(true);
+
+
         $this->command = new DeleteCommand($this->getConfig());
         $this->command->setLogger($this->logger);
         $this->command->setSites($this->sites);
         $this->environment->method('delete')->willReturn($this->workflow);
+        $this->command->setInput($input);
     }
 
     /**

--- a/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
@@ -18,19 +18,12 @@ class DeleteCommandTest extends MultidevCommandTest
     protected function setUp()
     {
         parent::setUp();
-
-        $input = $this->getMockBuilder(Input::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $input->method('hasOption')->with('yes')->willReturn(true);
-        $input->method('getOption')->with('yes')->willReturn(true);
-
-
+        
         $this->command = new DeleteCommand($this->getConfig());
         $this->command->setLogger($this->logger);
         $this->command->setSites($this->sites);
         $this->environment->method('delete')->willReturn($this->workflow);
-        $this->command->setInput($input);
+        $this->command->setInput($this->input);
     }
 
     /**

--- a/tests/unit_tests/Commands/Site/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Site/DeleteCommandTest.php
@@ -21,16 +21,10 @@ class DeleteCommandTest extends CommandTestCase
     {
         parent::setUp();
 
-        $input = $this->getMockBuilder(Input::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $input->method('hasOption')->with('yes')->willReturn(true);
-        $input->method('getOption')->with('yes')->willReturn(true);
-
         $this->command = new DeleteCommand($this->getConfig());
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
-        $this->command->setInput($input);
+        $this->command->setInput($this->input);
     }
 
     /**

--- a/tests/unit_tests/Commands/Site/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Site/DeleteCommandTest.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\UnitTests\Commands\Site;
 
 use Pantheon\Terminus\Commands\Site\DeleteCommand;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+use Symfony\Component\Console\Input\Input;
 
 /**
  * Class DeleteCommandTest
@@ -19,9 +20,17 @@ class DeleteCommandTest extends CommandTestCase
     protected function setup()
     {
         parent::setUp();
+
+        $input = $this->getMockBuilder(Input::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $input->method('hasOption')->with('yes')->willReturn(true);
+        $input->method('getOption')->with('yes')->willReturn(true);
+
         $this->command = new DeleteCommand($this->getConfig());
         $this->command->setSites($this->sites);
         $this->command->setLogger($this->logger);
+        $this->command->setInput($input);
     }
 
     /**


### PR DESCRIPTION
This is not the permanent solution. It just acts like one.

The code is quick an dirty but it does the following:

1. Adds a confirmation step to `delete:env/multidev`, `delete:machine-tokens` and `delete:site`
2. Defaults confirmations to 'no' which is standard for extremely distructive commands
3. Adds a `--yes/-y` flag to ALL commands (regardless of whether they need confirmation) to automatically choose yes for all confirmations.

That should help us define the UX we wish to commit to for 1.x.

Two things that we may want to consider:

1. This does not cover `backup:restore`, `env:wipe` or `import:*` which are also very destructive and not undoable.
2. If we decide that the `--yes` flag should only exist for commands that need it then it'll cause a backwards incompatible change.

As for (1), I don't know where we draw the line on how destructive an op has to be, but where we draw it it stays for the entire 1.x major version.

As for (2) above, I think `--yes` should be universal so that people can add it and not worry about it. That's how `--no-interaction` works too so this feels like a good choice.
