### PR TITLE
Request for Help: Add model to capture the status of upstream updates against an environment

### DIFF
--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -42,7 +42,7 @@ class ApplyCommand extends UpdatesCommand
             );
         }
 
-        $updates = $this->getUpstreamUpdatesLog($site);
+        $updates = $this->getUpstreamUpdatesLog($env);
         $count = count($updates);
         if ($count) {
             $this->log()->notice(

--- a/src/Commands/Upstream/Updates/ListCommand.php
+++ b/src/Commands/Upstream/Updates/ListCommand.php
@@ -12,7 +12,7 @@ use Pantheon\Terminus\Exceptions\TerminusException;
 class ListCommand extends UpdatesCommand
 {
     /**
-     * Displays a list of new code commits available from the upstream for a site's Dev environment.
+     * Displays a list of new code commits available from the upstream for a site's development environment.
      *
      * @authorize
      *
@@ -26,18 +26,19 @@ class ListCommand extends UpdatesCommand
      *     author: Author
      * @return RowsOfFields
      *
-     * @param string $site_id Site name
+     * @param string $site_env Site & development environment
      *
      * @throws TerminusException
      *
-     * @usage terminus upstream:updates:list <site>
-     *     Displays a list of new code commits available from the upstream for <site>'s Dev environment.
+     * @usage terminus upstream:updates:list <site>.<env>
+     *     Displays a list of new code commits available from the upstream for <site>'s <env> environment.
      */
-    public function listUpstreamUpdates($site_id)
+    public function listUpstreamUpdates($site_env)
     {
-        $site = $this->getSite($site_id);
+        list($site, $env) = $this->getSiteEnv($site_env, 'dev');
+
         $data = [];
-        foreach ($this->getUpstreamUpdatesLog($site) as $commit) {
+        foreach ($this->getUpstreamUpdatesLog($env) as $commit) {
             $data[] = [
                 'hash' => $commit->hash,
                 'datetime' => $commit->datetime,

--- a/src/Commands/Upstream/Updates/UpdatesCommand.php
+++ b/src/Commands/Upstream/Updates/UpdatesCommand.php
@@ -22,9 +22,9 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
      * @return object The upstream information
      * @throws TerminusException
      */
-    protected function getUpstreamUpdates($site)
+    protected function getUpstreamUpdates($env)
     {
-        if (empty($upstream = $site->getUpstream()->getUpdates())) {
+        if (empty($upstream = $env->getUpstreamUpdate()->getUpdates())) {
             throw new TerminusException('There was a problem checking your upstream status. Please try again.');
         }
         return $upstream;
@@ -37,9 +37,9 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
      * @return array The list of updates
      * @throws TerminusException
      */
-    protected function getUpstreamUpdatesLog($site)
+    protected function getUpstreamUpdatesLog($env)
     {
-        $upstream = $this->getUpstreamUpdates($site);
+        $upstream = $this->getUpstreamUpdates($env);
 
         if (!empty($upstream->update_log)) {
             return (array)$upstream->update_log;

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -897,7 +897,7 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
     public function getUpstreamUpdate()
     {
         if (empty($this->upstream_update)) {
-            $this->upstream_update = new UpstreamUpdate([], ['environment' => $this,]);
+            $this->upstream_update = $this->getContainer()->get(UpstreamUpdate::class, [[], ['environment' => $this,]]);
         }
         return $this->upstream_update;
     }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -12,6 +12,7 @@ use Pantheon\Terminus\Collections\Domains;
 use Pantheon\Terminus\Collections\Loadbalancers;
 use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
+use Pantheon\Terminus\Models\UpstreamUpdate;
 use Robo\Common\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Pantheon\Terminus\Exceptions\TerminusException;
@@ -45,6 +46,10 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
      * @var Loadbalancers
      */
     public $loadbalancers;
+    /**
+     * @var UpstreamUpdate
+     */
+    public $upstream_update;
     /**
      * @var Site
      */
@@ -885,6 +890,18 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
         }
         return $this->workflows;
     }
+
+    /**
+     * @return UpstreamUpdate
+     */
+    public function getUpstreamUpdate()
+    {
+        if (empty($this->upstream_update)) {
+            $this->upstream_update = new UpstreamUpdate([], ['environment' => $this,]);
+        }
+        return $this->upstream_update;
+    }
+
 
     /**
      * @return Workflows

--- a/src/Models/Upstream.php
+++ b/src/Models/Upstream.php
@@ -33,42 +33,6 @@ class Upstream extends TerminusModel
     }
 
     /**
-     * Returns the status of this site's upstream updates
-     *
-     * @return string $status 'outdated' or 'current'
-     */
-    public function getStatus()
-    {
-        if ($this->hasUpdates()) {
-            $status = 'outdated';
-        } else {
-            $status = 'current';
-        }
-        return $status;
-    }
-
-    /**
-     * Retrives upstream updates
-     *
-     * @return \stdClass
-     */
-    public function getUpdates()
-    {
-        return $this->request()->request("sites/{$this->site->id}/code-upstream-updates")['data'];
-    }
-
-    /**
-     * Determines whether there are any updates to be applied.
-     *
-     * @return boolean
-     */
-    public function hasUpdates()
-    {
-        $updates = $this->getUpdates();
-        return ($updates->behind > 0);
-    }
-
-    /**
      * @inheritdoc
      */
     public function serialize()

--- a/src/Models/Upstream.php
+++ b/src/Models/Upstream.php
@@ -9,19 +9,11 @@ namespace Pantheon\Terminus\Models;
 class Upstream extends TerminusModel
 {
     /**
-     * @var Site
-     */
-    public $site;
-
-    /**
      * @inheritdoc
      */
     public function __construct($attributes, array $options = [])
     {
         parent::__construct($attributes, $options);
-        if (isset($options['site'])) {
-            $this->site = $options['site'];
-        }
     }
 
     /**
@@ -42,7 +34,6 @@ class Upstream extends TerminusModel
                 'url' => $this->get('url'),
                 'product_id' => $this->get('product_id'),
                 'branch' => $this->get('branch'),
-                'status' => $this->getStatus(),
             ];
         }
         return (array)$this->attributes;

--- a/src/Models/UpstreamUpdate.php
+++ b/src/Models/UpstreamUpdate.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+/**
+ * Class UpstreamUpdate
+ * @package Pantheon\Terminus\Models
+ */
+class UpstreamUpdate extends TerminusModel
+{
+    /**
+     * @var Env
+     */
+    public $env;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($attributes, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        if (isset($options['environment'])) {
+            $this->env = $options['environment'];
+        }
+    }
+
+    /**
+     * Returns the status of this site's upstream updates
+     *
+     * @return string $status 'outdated' or 'current'
+     */
+    public function getStatus()
+    {
+        if ($this->hasUpdates()) {
+            $status = 'outdated';
+        } else {
+            $status = 'current';
+        }
+        return $status;
+    }
+
+    /**
+     * Retrives upstream updates
+     *
+     * @return \stdClass
+     */
+    public function getUpdates()
+    {
+        if (!$this->env->isMultidev()) {
+            $branch_name = 'master';
+        } else {
+            $branch_name = $this->env->id;
+        }
+        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?branch_name={$branch_name}")['data'];
+    }
+
+    /**
+     * Determines whether there are any updates to be applied.
+     *
+     * @return boolean
+     */
+    public function hasUpdates()
+    {
+        $updates = $this->getUpdates();
+        return ($updates->behind > 0);
+    }
+}

--- a/src/Models/UpstreamUpdate.php
+++ b/src/Models/UpstreamUpdate.php
@@ -47,11 +47,11 @@ class UpstreamUpdate extends TerminusModel
     public function getUpdates()
     {
         if (!$this->env->isMultidev()) {
-            $branch_name = 'master';
+            $base_branch = 'master';
         } else {
-            $branch_name = $this->env->id;
+            $base_branch = $this->env->id;
         }
-        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?branch_name={$branch_name}")['data'];
+        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?base_branch={$branch_name}")['data'];
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -52,6 +52,7 @@ use Pantheon\Terminus\Models\Solr;
 use Pantheon\Terminus\Models\SSHKey;
 use Pantheon\Terminus\Models\Tag;
 use Pantheon\Terminus\Models\Upstream;
+use Pantheon\Terminus\Models\UpstreamUpdate;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\UserOrganizationMembership;
 use Pantheon\Terminus\Models\UserSiteMembership;
@@ -229,6 +230,7 @@ class Terminus implements ConfigAwareInterface
         $container->add(MachineToken::class);
         $container->add(Upstream::class);
         $container->add(Upstreams::class);
+        $container->add(UpstreamUpdate::class);
         $container->add(UserSiteMemberships::class);
         $container->add(UserSiteMembership::class);
         $container->add(UserOrganizationMemberships::class);

--- a/tests/features/upstream-updates-list.feature
+++ b/tests/features/upstream-updates-list.feature
@@ -10,7 +10,7 @@ Feature: Update a site with all its upstream's updates
 
   @vcr upstream-updates.yml
   Scenario: Check for upstream updates and there aren't any
-    When I run "terminus upstream:updates:list [[test_site_name]]"
+    When I run "terminus upstream:updates:list [[test_site_name]].dev"
     Then I should get: "There are no available updates for this site."
     And I should get: "----------- ----------- --------- --------"
     And I should get: "Commit ID   Timestamp   Message   Author"
@@ -18,7 +18,7 @@ Feature: Update a site with all its upstream's updates
 
   @vcr upstream-update-list.yml
   Scenario: Check for upstream updates and there are some
-    When I run "terminus upstream:updates:list [[test_site_name]]"
+    When I run "terminus upstream:updates:list [[test_site_name]].dev"
     Then I should get: "------------------------------------------ --------------------- -------------------------------------------------------------------------------------------------------------------------------------------- ---------------------"
     And I should get: "Commit ID                                  Timestamp             Message                                                                                                                                      Author"
     And I should get: "------------------------------------------ --------------------- -------------------------------------------------------------------------------------------------------------------------------------------- ---------------------"

--- a/tests/fixtures/upstream-update-list.yml
+++ b/tests/fixtures/upstream-update-list.yml
@@ -144,7 +144,7 @@
 -
     request:
         method: GET
-        url: 'https://terminus.pantheon.io/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates'
+        url: 'https://terminus.pantheon.io/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates?base_branch=master'
         headers:
             Host: terminus.pantheon.io
             Accept-Encoding: null

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -32,16 +32,16 @@ class ApplyCommandTest extends UpdatesCommandTest
     {
         $this->environment->id = 'dev';
 
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[],
         ];
 
-        $this->upstream->expects($this->once())
+        $this->upstream_update->expects($this->once())
             ->method('getUpdates')
             ->with()
-            ->willReturn($upstream);
+            ->willReturn($upstream_data);
 
         $this->logger->expects($this->once())
             ->method('log')
@@ -64,7 +64,7 @@ class ApplyCommandTest extends UpdatesCommandTest
     {
         $this->environment->id = 'dev';
 
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[
@@ -96,8 +96,8 @@ class ApplyCommandTest extends UpdatesCommandTest
                 ],
             ],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
+        $this->upstream_update->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $workflow = $this->getMockBuilder(Workflow::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
@@ -29,13 +29,13 @@ class ListCommandTest extends UpdatesCommandTest
      */
     public function testListUpstreamsEmpty()
     {
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
+        $this->upstream_update->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $this->logger->expects($this->once())
             ->method('log')
@@ -55,7 +55,7 @@ class ListCommandTest extends UpdatesCommandTest
      */
     public function testListUpstreams()
     {
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[
@@ -87,9 +87,8 @@ class ListCommandTest extends UpdatesCommandTest
                 ],
             ],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
-
+        $this->upstream_update->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $out = $this->command->listUpstreamUpdates('123');
         $result = [

--- a/tests/unit_tests/Commands/Upstream/Updates/UpdatesCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/UpdatesCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Upstream\Updates;
 
-use Pantheon\Terminus\Models\Upstream;
+use Pantheon\Terminus\Models\UpstreamUpdate;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
 /**
@@ -23,9 +23,9 @@ abstract class UpdatesCommandTest extends CommandTestCase
     {
         parent::setUp();
 
-        $this->upstream = $this->getMockBuilder(Upstream::class)
+        $this->upstream_update = $this->getMockBuilder(UpstreamUpdate::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->site->method('getUpstream')->willReturn($this->upstream);
+        $this->environment->method('getUpstreamUpdate')->willReturn($this->upstream_update);
     }
 }


### PR DESCRIPTION
This is my first stab at resolving the conflation of the information about an upstream (e.g. the git url) and the information about whether an upstream's commits have been fully merged into an environment.

The latter was previously placed into the Upstream model. I quickly extracted that into a separate UpstreamUpdate model. It more likely would be a collection of commit objects, but I'm trying to do it quickly :-)

I'm having some issues with `$this->request` within the UpstreamUpdate model being undefined. Could someone help me overcome that issue?

You can try debugging it using `$ terminus self:console canary.dev`, then pasting `$env->getUpstreamUpdate->getStatus()`

 