### PR TITLE
Loosen specific version constraint on composer/semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.5.9",
-    "composer/semver": "1.4",
+    "composer/semver": "^1.0",
     "consolidation/robo": "^1.0.5",
     "guzzlehttp/guzzle": "^6.2",
     "psy/psysh": "^0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "27df489e02b27313204fb63a25601df6",
-    "content-hash": "ec5a4ce94be5c9e46dd671edae12ed6e",
+    "hash": "f0ff8bfaa7d9be3fcf0fea7da9fb10e7",
+    "content-hash": "deb52da1f90030a0b9cfbac70555ce0a",
     "packages": [
         {
             "name": "composer/semver",
-            "version": "1.4.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8"
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/84c47f3d8901440403217afc120683c7385aecb8",
-                "reference": "84c47f3d8901440403217afc120683c7385aecb8",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-03-30 13:16:03"
+            "time": "2016-08-30 16:08:34"
         },
         {
             "name": "consolidation/annotated-command",


### PR DESCRIPTION
composer itself [uses a constraint](https://github.com/composer/composer/blob/master/composer.json#L28) of `^1.0` on `composer/semver`.

Using the more specific `1.4.0` means that terminus cannot peacefully coexist with many other composer packages that have been updated to the latest v1.4.2 of that package, [including wp-cli](https://github.com/wp-cli/wp-cli/blob/master/composer.lock#L146)!