### PR TITLE
AL-769 upstream:updates:list command should include environment

### DIFF
--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -42,7 +42,7 @@ class ApplyCommand extends UpdatesCommand
             );
         }
 
-        $updates = $this->getUpstreamUpdatesLog($site);
+        $updates = $this->getUpstreamUpdatesLog($env);
         $count = count($updates);
         if ($count) {
             $this->log()->notice(

--- a/src/Commands/Upstream/Updates/ListCommand.php
+++ b/src/Commands/Upstream/Updates/ListCommand.php
@@ -12,7 +12,7 @@ use Pantheon\Terminus\Exceptions\TerminusException;
 class ListCommand extends UpdatesCommand
 {
     /**
-     * Displays a list of new code commits available from the upstream for a site's Dev environment.
+     * Displays a list of new code commits available from the upstream for a site's development environment.
      *
      * @authorize
      *
@@ -26,18 +26,19 @@ class ListCommand extends UpdatesCommand
      *     author: Author
      * @return RowsOfFields
      *
-     * @param string $site_id Site name
+     * @param string $site_env Site & development environment
      *
      * @throws TerminusException
      *
-     * @usage terminus upstream:updates:list <site>
-     *     Displays a list of new code commits available from the upstream for <site>'s Dev environment.
+     * @usage terminus upstream:updates:list <site>.<env>
+     *     Displays a list of new code commits available from the upstream for <site>'s <env> environment.
      */
-    public function listUpstreamUpdates($site_id)
+    public function listUpstreamUpdates($site_env)
     {
-        $site = $this->getSite($site_id);
+        list($site, $env) = $this->getSiteEnv($site_env, 'dev');
+
         $data = [];
-        foreach ($this->getUpstreamUpdatesLog($site) as $commit) {
+        foreach ($this->getUpstreamUpdatesLog($env) as $commit) {
             $data[] = [
                 'hash' => $commit->hash,
                 'datetime' => $commit->datetime,

--- a/src/Commands/Upstream/Updates/UpdatesCommand.php
+++ b/src/Commands/Upstream/Updates/UpdatesCommand.php
@@ -22,9 +22,9 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
      * @return object The upstream information
      * @throws TerminusException
      */
-    protected function getUpstreamUpdates($site)
+    protected function getUpstreamUpdates($env)
     {
-        if (empty($upstream = $site->getUpstream()->getUpdates())) {
+        if (empty($upstream = $env->getUpstreamStatus()->getUpdates())) {
             throw new TerminusException('There was a problem checking your upstream status. Please try again.');
         }
         return $upstream;
@@ -37,9 +37,9 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
      * @return array The list of updates
      * @throws TerminusException
      */
-    protected function getUpstreamUpdatesLog($site)
+    protected function getUpstreamUpdatesLog($env)
     {
-        $upstream = $this->getUpstreamUpdates($site);
+        $upstream = $this->getUpstreamUpdates($env);
 
         if (!empty($upstream->update_log)) {
             return (array)$upstream->update_log;

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -12,6 +12,7 @@ use Pantheon\Terminus\Collections\Domains;
 use Pantheon\Terminus\Collections\Loadbalancers;
 use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
+use Pantheon\Terminus\Models\UpstreamStatus;
 use Robo\Common\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Pantheon\Terminus\Exceptions\TerminusException;
@@ -45,6 +46,10 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
      * @var Loadbalancers
      */
     public $loadbalancers;
+    /**
+     * @var UpstreamStatus
+     */
+    public $upstream_status;
     /**
      * @var Site
      */
@@ -885,6 +890,18 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
         }
         return $this->workflows;
     }
+
+    /**
+     * @return UpstreamStatus
+     */
+    public function getUpstreamStatus()
+    {
+        if (empty($this->upstream_status)) {
+            $this->upstream_status = $this->getContainer()->get(UpstreamStatus::class, [[], ['environment' => $this,]]);
+        }
+        return $this->upstream_status;
+    }
+
 
     /**
      * @return Workflows

--- a/src/Models/Upstream.php
+++ b/src/Models/Upstream.php
@@ -9,19 +9,11 @@ namespace Pantheon\Terminus\Models;
 class Upstream extends TerminusModel
 {
     /**
-     * @var Site
-     */
-    public $site;
-
-    /**
      * @inheritdoc
      */
     public function __construct($attributes, array $options = [])
     {
         parent::__construct($attributes, $options);
-        if (isset($options['site'])) {
-            $this->site = $options['site'];
-        }
     }
 
     /**
@@ -30,42 +22,6 @@ class Upstream extends TerminusModel
     public function __toString()
     {
         return "{$this->id}: {$this->get('url')}";
-    }
-
-    /**
-     * Returns the status of this site's upstream updates
-     *
-     * @return string $status 'outdated' or 'current'
-     */
-    public function getStatus()
-    {
-        if ($this->hasUpdates()) {
-            $status = 'outdated';
-        } else {
-            $status = 'current';
-        }
-        return $status;
-    }
-
-    /**
-     * Retrives upstream updates
-     *
-     * @return \stdClass
-     */
-    public function getUpdates()
-    {
-        return $this->request()->request("sites/{$this->site->id}/code-upstream-updates")['data'];
-    }
-
-    /**
-     * Determines whether there are any updates to be applied.
-     *
-     * @return boolean
-     */
-    public function hasUpdates()
-    {
-        $updates = $this->getUpdates();
-        return ($updates->behind > 0);
     }
 
     /**
@@ -78,7 +34,6 @@ class Upstream extends TerminusModel
                 'url' => $this->get('url'),
                 'product_id' => $this->get('product_id'),
                 'branch' => $this->get('branch'),
-                'status' => $this->getStatus(),
             ];
         }
         return (array)$this->attributes;

--- a/src/Models/UpstreamStatus.php
+++ b/src/Models/UpstreamStatus.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pantheon\Terminus\Models;
+
+/**
+ * Class UpstreamStatus
+ * @package Pantheon\Terminus\Models
+ */
+class UpstreamStatus extends TerminusModel
+{
+    /**
+     * @var Env
+     */
+    public $env;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct($attributes, array $options = [])
+    {
+        parent::__construct($attributes, $options);
+        if (isset($options['environment'])) {
+            $this->env = $options['environment'];
+        }
+    }
+
+    /**
+     * Returns the status of this site's upstream updates
+     *
+     * @return string $status 'outdated' or 'current'
+     */
+    public function getStatus()
+    {
+        if ($this->hasUpdates()) {
+            $status = 'outdated';
+        } else {
+            $status = 'current';
+        }
+        return $status;
+    }
+
+    /**
+     * Retrives upstream updates
+     *
+     * @return \stdClass
+     */
+    public function getUpdates()
+    {
+        if (!$this->env->isMultidev()) {
+            $base_branch = 'master';
+        } else {
+            $base_branch = $this->env->id;
+        }
+        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?base_branch={$branch_name}")['data'];
+    }
+
+    /**
+     * Determines whether there are any updates to be applied.
+     *
+     * @return boolean
+     */
+    public function hasUpdates()
+    {
+        $updates = $this->getUpdates();
+        return ($updates->behind > 0);
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -52,6 +52,7 @@ use Pantheon\Terminus\Models\Solr;
 use Pantheon\Terminus\Models\SSHKey;
 use Pantheon\Terminus\Models\Tag;
 use Pantheon\Terminus\Models\Upstream;
+use Pantheon\Terminus\Models\UpstreamStatus;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\UserOrganizationMembership;
 use Pantheon\Terminus\Models\UserSiteMembership;
@@ -232,6 +233,7 @@ class Terminus implements ConfigAwareInterface
         $container->add(MachineToken::class);
         $container->add(Upstream::class);
         $container->add(Upstreams::class);
+        $container->add(UpstreamStatus::class);
         $container->add(UserSiteMemberships::class);
         $container->add(UserSiteMembership::class);
         $container->add(UserOrganizationMemberships::class);

--- a/tests/features/upstream-updates-list.feature
+++ b/tests/features/upstream-updates-list.feature
@@ -10,7 +10,7 @@ Feature: Update a site with all its upstream's updates
 
   @vcr upstream-updates.yml
   Scenario: Check for upstream updates and there aren't any
-    When I run "terminus upstream:updates:list [[test_site_name]]"
+    When I run "terminus upstream:updates:list [[test_site_name]].dev"
     Then I should get: "There are no available updates for this site."
     And I should get: "----------- ----------- --------- --------"
     And I should get: "Commit ID   Timestamp   Message   Author"
@@ -18,7 +18,7 @@ Feature: Update a site with all its upstream's updates
 
   @vcr upstream-update-list.yml
   Scenario: Check for upstream updates and there are some
-    When I run "terminus upstream:updates:list [[test_site_name]]"
+    When I run "terminus upstream:updates:list [[test_site_name]].dev"
     Then I should get: "------------------------------------------ --------------------- -------------------------------------------------------------------------------------------------------------------------------------------- ---------------------"
     And I should get: "Commit ID                                  Timestamp             Message                                                                                                                                      Author"
     And I should get: "------------------------------------------ --------------------- -------------------------------------------------------------------------------------------------------------------------------------------- ---------------------"

--- a/tests/fixtures/upstream-update-list.yml
+++ b/tests/fixtures/upstream-update-list.yml
@@ -144,7 +144,43 @@
 -
     request:
         method: GET
-        url: 'https://terminus.pantheon.io/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates'
+        url: 'https://terminus.pantheon.io/api/sites/11111111-1111-1111-1111-111111111111/environments'
+        headers:
+            Host: onebox
+            Accept-Encoding: null
+            User-Agent: 'Terminus/0.11.4 (php_version=7.0.6&script=boot-fs.php)'
+            Content-type: application/json
+            Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:0a9ec146-6647-11e6-957b-bc764e10b0ce:Qy0LJnAlzPix9zH6FA0xm'
+            headers: 'Bearer 11111111-1111-1111-1111-111111111111:0a9ec146-6647-11e6-957b-bc764e10b0ce:Qy0LJnAlzPix9zH6FA0xm'
+            verify: '1'
+            method: get
+            absolute_url: ''
+            options: get
+            Accept: null
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Server: nginx
+            Date: 'Fri, 19 Aug 2016 19:56:41 GMT'
+            Content-Type: application/json
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            X-Pantheon-Trace-Id: 0c064ef0-6647-11e6-a69e-9d129c74acd7
+            X-Frame-Options: deny
+            Access-Control-Allow-Methods: GET
+            Access-Control-Allow-Headers: 'Origin, Content-Type, Accept'
+            Cache-Control: no-cache
+            Pragma: no-cache
+            Vary: Accept-Encoding
+            Strict-Transport-Security: max-age=31536000
+        body: '{"dev": {"watchers": 1, "diffstat": {}, "on_server_development": true, "environment_created": 1471385341, "dns_zone": "pantheonsite.io", "randseed": "DAWMHE2LTF12P5H2DY3URABPX8N16US9", "styx_cluster": "styx-03.pantheon.io", "target_ref": "refs/heads/master", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "cb3f7bbe08bbdc0d2f68e3fa66655c860ec6c24b", "drush_version": 8}, "test": {"environment_created": 1471385344, "dns_zone": "pantheonsite.io", "randseed": "2768L88WYTOBH0MIQPOB6KY42C3L4WZI", "target_ref": "refs/tags/pantheon_test_2", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "cb3f7bbe08bbdc0d2f68e3fa66655c860ec6c24b", "styx_cluster": "styx-03.pantheon.io"}, "live": {"environment_created": 1471385345, "dns_zone": "pantheonsite.io", "randseed": "0G8KI1O49B4E19HYWI5YUYREYHP0A4TJ", "target_ref": "refs/tags/pantheon_live_1", "lock": {"username": null, "password": null, "locked": false}, "target_commit": "1fdf194d3d7a0c930a4f118e1398412765320328", "styx_cluster": "styx-02.pantheon.io"}}'
+-
+    request:
+        method: GET
+        url: 'https://terminus.pantheon.io/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates?base_branch=master'
         headers:
             Host: terminus.pantheon.io
             Accept-Encoding: null

--- a/tests/fixtures/upstream-updates.yml
+++ b/tests/fixtures/upstream-updates.yml
@@ -182,7 +182,7 @@
 -
     request:
         method: GET
-        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates'
+        url: 'https://onebox/api/sites/11111111-1111-1111-1111-111111111111/code-upstream-updates?base_branch=master'
         headers:
             Host: onebox
             Accept-Encoding: null

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -32,16 +32,16 @@ class ApplyCommandTest extends UpdatesCommandTest
     {
         $this->environment->id = 'dev';
 
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[],
         ];
 
-        $this->upstream->expects($this->once())
+        $this->upstream_status->expects($this->once())
             ->method('getUpdates')
             ->with()
-            ->willReturn($upstream);
+            ->willReturn($upstream_data);
 
         $this->logger->expects($this->once())
             ->method('log')
@@ -64,7 +64,7 @@ class ApplyCommandTest extends UpdatesCommandTest
     {
         $this->environment->id = 'dev';
 
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[
@@ -96,8 +96,8 @@ class ApplyCommandTest extends UpdatesCommandTest
                 ],
             ],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
+        $this->upstream_status->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $workflow = $this->getMockBuilder(Workflow::class)
             ->disableOriginalConstructor()

--- a/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
@@ -29,13 +29,13 @@ class ListCommandTest extends UpdatesCommandTest
      */
     public function testListUpstreamsEmpty()
     {
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
+        $this->upstream_status->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $this->logger->expects($this->once())
             ->method('log')
@@ -55,7 +55,7 @@ class ListCommandTest extends UpdatesCommandTest
      */
     public function testListUpstreams()
     {
-        $upstream = (object)[
+        $upstream_data = (object)[
             'remote_head' => '2f1c945d01cd03250e2b6668ad77bf24f54a5a56',
             'ahead' => 1,
             'update_log' => (object)[
@@ -87,9 +87,8 @@ class ListCommandTest extends UpdatesCommandTest
                 ],
             ],
         ];
-        $this->upstream->method('getUpdates')
-            ->willReturn($upstream);
-
+        $this->upstream_status->method('getUpdates')
+            ->willReturn($upstream_data);
 
         $out = $this->command->listUpstreamUpdates('123');
         $result = [

--- a/tests/unit_tests/Commands/Upstream/Updates/UpdatesCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/UpdatesCommandTest.php
@@ -2,7 +2,7 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Upstream\Updates;
 
-use Pantheon\Terminus\Models\Upstream;
+use Pantheon\Terminus\Models\UpstreamStatus;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
 /**
@@ -14,7 +14,7 @@ abstract class UpdatesCommandTest extends CommandTestCase
     /**
      * @var Upstream
      */
-    protected $upstream;
+    protected $upstream_status;
 
     /**
      * @inheritdoc
@@ -23,9 +23,9 @@ abstract class UpdatesCommandTest extends CommandTestCase
     {
         parent::setUp();
 
-        $this->upstream = $this->getMockBuilder(Upstream::class)
+        $this->upstream_status = $this->getMockBuilder(UpstreamStatus::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->site->method('getUpstream')->willReturn($this->upstream);
+        $this->environment->method('getUpstreamStatus')->willReturn($this->upstream_status);
     }
 }


### PR DESCRIPTION
Previously `Upstream` model represented two different concepts:

1. information about an upstream repository
2. the state of unmerged of code commits between that upstream repository and the site

...but the problem with the latter is that the unmerged commits only make sense between the repo (and its default branch) and an environment's code branch. 

Previously the `upstream:updates:list` command didn't include an environment so it only defaulted to the Dev environment. 

This PR adds the `env` as a required argument to `upstream:updates:list`.

Note: this command answers the question of "what code has not been merged into this branch?", but does not answer the question of "has the upstream code been entirely deployed to the Live environment?". The command that answers does not currently exist. 