### PR TITLE
Fix incorrect var name in UpstreamStatus

### DIFF
--- a/src/Models/UpstreamStatus.php
+++ b/src/Models/UpstreamStatus.php
@@ -51,7 +51,7 @@ class UpstreamStatus extends TerminusModel
         } else {
             $base_branch = $this->env->id;
         }
-        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?base_branch={$branch_name}")['data'];
+        return $this->request()->request("sites/{$this->env->site->id}/code-upstream-updates?base_branch={$base_branch}")['data'];
     }
 
     /**


### PR DESCRIPTION
I am shocked that this was not caught by a test or linter.