### PR TITLE
Fixes #1487: Fix 'Creating default object from empty value' warning.

### DIFF
--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -111,7 +111,7 @@ abstract class TerminusCollection implements RequestAwareInterface, ContainerAwa
      */
     public function fetch(array $options = [])
     {
-        $results = $this->getCollectionData($options);
+        $results = array_filter((array)$this->getCollectionData($options));
 
         foreach ($results as $id => $model_data) {
             if (!isset($model_data->id)) {


### PR DESCRIPTION
This warning message appears when there is an empty entry in one of the data stores. I'm not sure exactly how those get inserted, but I've got one in my cached data.