### PR TITLE
Fix fatal error by adding back use statement for ProcessUtils

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -7,6 +7,7 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Exceptions\TerminusProcessException;
+use Symfony\Component\Process\ProcessUtils;
 
 /**
  * Class SSHBaseCommand


### PR DESCRIPTION
@greg-1-anderson, @TeslaDethray These two PRs were being worked on at the same time and somehow the `use` statement added in  https://github.com/pantheon-systems/terminus/pull/1484 was removed in https://github.com/pantheon-systems/terminus/pull/1480. The actual invocation of class remained.

I saw an error in a script that wasn't yet using the argument separator https://circleci.com/gh/pantheon-systems/search_api_pantheon/561

The error was triggered by `terminus drush $SITE_ENV "pm-uninstall search -y"` (which of course needed to change anway to `terminus drush $SITE_ENV -- pm-uninstall search -y`).