### PR TITLE
Pinning PHP-VCR to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 #Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## MASTER
+### Fixed
+- Pinned PHP-VCR version to 1.3.1 due to issues with turning PUT into POST. (#1501)
+
 ## 1.0.0-beta.1 - 2016-12-21
 ### Changed
 - Moved to Symfony Console

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "rmccue/requests": "^1.7",
     "phpunit/phpcov": "^2.0",
     "phpunit/phpunit": "^4.0",
-    "php-vcr/php-vcr": "^1.3",
+    "php-vcr/php-vcr": "1.3.1",
     "sebastian/phpcpd": "^2.0",
     "squizlabs/php_codesniffer": "^2.7",
     "satooshi/php-coveralls": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "13c0c2522230fb09d48a9cca5ecfe486",
-    "content-hash": "6eb1c6995b28a6d5507eb3d41e22d378",
+    "hash": "df4cdbcd8ba74cacba89bb9dc2dc081e",
+    "content-hash": "206cd377eda7f4ab771f8d2d30ea2a04",
     "packages": [
         {
             "name": "composer/semver",
@@ -1698,21 +1698,22 @@
         },
         {
             "name": "behat/behat",
-            "version": "v3.2.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Behat.git",
-                "reference": "30aa3836825416f28581ee55fcfe6a5b0cdeeb85"
+                "reference": "15a3a1857457eaa29cdf41564a5e421effb09526"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Behat/zipball/30aa3836825416f28581ee55fcfe6a5b0cdeeb85",
-                "reference": "30aa3836825416f28581ee55fcfe6a5b0cdeeb85",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/15a3a1857457eaa29cdf41564a5e421effb09526",
+                "reference": "15a3a1857457eaa29cdf41564a5e421effb09526",
                 "shasum": ""
             },
             "require": {
                 "behat/gherkin": "^4.4.4",
                 "behat/transliterator": "~1.0",
+                "container-interop/container-interop": "^1.1",
                 "ext-mbstring": "*",
                 "php": ">=5.3.3",
                 "symfony/class-loader": "~2.1||~3.0",
@@ -1775,7 +1776,7 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2016-11-05 17:13:53"
+            "time": "2016-12-25 13:43:52"
         },
         {
             "name": "behat/gherkin",


### PR DESCRIPTION
This will prevent PUT from being changed to POST in tests. I've opened [an issue about it](https://github.com/php-vcr/php-vcr/issues/187).