### PR TITLE
Ask json_decode to produce arrays rather than objects.

### DIFF
--- a/src/Collections/SavedTokens.php
+++ b/src/Collections/SavedTokens.php
@@ -97,7 +97,7 @@ class SavedTokens extends TerminusCollection implements ConfigAwareInterface, Da
     {
         $tokens = [];
         foreach ($this->getDataStore()->keys() as $key) {
-            $tokens[] = $this->getDataStore()->get($key);
+            $tokens[] = (object)$this->getDataStore()->get($key);
         }
         return $tokens;
     }

--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -34,7 +34,7 @@ class FileStore implements DataStoreInterface
         $path = $this->getFileName($key);
         if (file_exists($path)) {
             $out = file_get_contents($path);
-            $out = json_decode($out);
+            $out = json_decode($out, true);
         }
         return $out;
     }


### PR DESCRIPTION
See the [manual entry for json_decode](http://php.net/manual/en/function.json-decode.php).

If you do this, then the result you get back will consist of pure associative arrays (and strings). This reduces the need to cast the nested results to (array) everywhere.

I maintained all of the typecasts in the Annotated Commands code, so this is not necessary. You might want to do this to clean up Terminus code, though -- presuming that you are not depending on the results being stdclass objects elsewhere, anyway.