### PR TITLE
Fix function prototype for Symfony Process wait() method

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -57,8 +57,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $output = $this->output();
         $result = $this->environment->sendCommandViaSsh(
             $command_line,
-            function ($buffer) use ($output) {
-                $output->writeln($buffer);
+            function ($type, $buffer) use ($output) {
             }
         );
         $output = $result['output'];


### PR DESCRIPTION
Also eliminate double output.  Prior to this PR, the function prototype for the command callback was wrong. This caused it to produce spurious output consisting of the strings `out` and `err`, as it was sending the $type parameter to the output stream, and ignoring the $buffer parameter.

Fixing the function prototype caused double output.  Simply not using the callback seems to be the right thing to do here.

Tried:
- Interactive commands such as `terminus drush core-cli` and `terminus drush cc`
- Slow commands that produce incremental output, such as `terminus composer update`
- Commands that redirect the output, such as `terminus > file` and `v=$(terminus)`

These use-cases all seem to work correctly now.

Addresses #1507
