### PR TITLE
Moves machine token deletion out of clear-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fixed `env` commands to not err when the site is frozen and the test or live environment is to be accessed. (#1537)
 
 ### Changed
+- Clear cache no longer deletes stored machine tokens. Logout now deletes stored machine tokens. (#1542)
 - Terminus now checks for new versions after every command run. (#1523)
 - `site:create` now checks to see whether a site name is taken before attempting to create it. (#1536)
 

--- a/src/Commands/Auth/LogoutCommand.php
+++ b/src/Commands/Auth/LogoutCommand.php
@@ -12,17 +12,18 @@ class LogoutCommand extends TerminusCommand
 {
 
     /**
-     * Logs out the currently logged-in user.
+     * Logs out the currently logged-in user and deletes any saved machine tokens.
      *
      * @command auth:logout
      * @aliases logout
      *
      * @usage terminus auth:logout
-     *     Logs out of Pantheon and removes saved session.
+     *     Logs out of Pantheon and removes saved session and machine tokens.
      */
     public function logOut()
     {
+        $this->session()->getTokens()->deleteAll();
         $this->session()->destroy();
-        $this->log()->notice('You have been logged out of Pantheon.');
+        $this->log()->notice('Your saved machine tokens have been deleted and you have been logged out.');
     }
 }

--- a/src/Commands/Self/ClearCacheCommand.php
+++ b/src/Commands/Self/ClearCacheCommand.php
@@ -15,7 +15,7 @@ class ClearCacheCommand extends TerminusCommand implements ContainerAwareInterfa
     use ContainerAwareTrait;
 
     /**
-     * Clears the local Terminus session cache and all locally saved machine tokens.
+     * Clears the local Terminus command cache.
      *
      * @command self:clear-cache
      * @aliases self:cc
@@ -25,10 +25,6 @@ class ClearCacheCommand extends TerminusCommand implements ContainerAwareInterfa
      */
     public function clearCache()
     {
-        $tokens  = $this->session()->getTokens();
-
-        $tokens->deleteAll();
-        $this->session()->destroy();
-        $this->log()->notice('Your saved machine tokens have been deleted and you have been logged out.');
+        $this->log()->notice('The local Terminus cache has been cleared.');
     }
 }

--- a/tests/features/auth.feature
+++ b/tests/features/auth.feature
@@ -47,7 +47,13 @@ Feature: Authorization command
     When I run "terminus auth:logout"
     Then I should get:
     """
-    You have been logged out of Pantheon.
+    Your saved machine tokens have been deleted and you have been logged out.
+    """
+    And I run "terminus auth:whoami"
+    Then I should get: "You are not logged in."
+    And I should not get:
+    """
+    [[username]]
     """
 
   @vcr auth-whoami.yml

--- a/tests/features/machine-token.feature
+++ b/tests/features/machine-token.feature
@@ -21,3 +21,4 @@ Feature: Machine tokens command
     """
     Deleted [[machine_token_device]]!
     """
+

--- a/tests/features/self.feature
+++ b/tests/features/self.feature
@@ -12,23 +12,10 @@ Feature: CLI Commands
 
   @vcr self-env-cache-clear.yml
   Scenario: Deleting the Terminus cache
-    Given I am authenticated
-    And I have at least "1" saved machine tokens
-    When I run "terminus auth:whoami"
+    When I run "terminus self:clear-cache"
     Then I should get:
     """
-    [[username]]
-    """
-    And I run "terminus self:clear-cache"
-    Then I should get:
-    """
-    Your saved machine tokens have been deleted and you have been logged out.
-    """
-    And I run "terminus auth:whoami"
-    Then I should get: "You are not logged in."
-    And I run "terminus auth:login"
-    """
-    Please visit the dashboard to generate a machine token:
+    The local Terminus cache has been cleared.
     """
 
   Scenario: Dumping Terminus configuration

--- a/tests/unit_tests/Commands/Self/ClearCacheCommandTest.php
+++ b/tests/unit_tests/Commands/Self/ClearCacheCommandTest.php
@@ -2,10 +2,7 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Self;
 
-use Pantheon\Terminus\Collections\SavedTokens;
 use Pantheon\Terminus\Commands\Self\ClearCacheCommand;
-use Pantheon\Terminus\Models\SavedToken;
-use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
 /**
@@ -16,52 +13,19 @@ use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 class ClearCacheCommandTest extends CommandTestCase
 {
     /**
-     * Tests the self:clear-cache commadn
+     * Tests the self:clear-cache command
      */
     public function testClearCache()
     {
-        $this->session = $this->getMockBuilder(Session::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $token = $this->getMockBuilder(SavedToken::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $token->expects($this->once())
-            ->method('delete');
-
-        $token2 = $this->getMockBuilder(SavedToken::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $token2->expects($this->once())
-            ->method('delete');
-
-        $tokens = $this->getMockBuilder(SavedTokens::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getMembers'])
-            ->getMock();
-        $tokens->expects($this->any())
-            ->method('getMembers')
-            ->willReturn([$token, $token2]);
-
-        $this->session->expects($this->any())
-            ->method('getTokens')
-            ->willReturn($tokens);
-        $this->session->expects($this->once())
-            ->method('destroy');
-
-
         $this->logger->expects($this->once())
             ->method('log')
             ->with(
                 $this->equalTo('notice'),
-                $this->equalTo('Your saved machine tokens have been deleted and you have been logged out.')
+                $this->equalTo('The local Terminus cache has been cleared.')
             );
 
         $command = new ClearCacheCommand();
-        $command->setConfig($this->config);
         $command->setLogger($this->logger);
-        $command->setSession($this->session);
 
         $command->clearCache();
     }


### PR DESCRIPTION
This pulls the cache-clear change out of #1533

The cache clear function now does nothing (but that's because we're not actually caching anything yet).

I've moved the 'delete all saved machine tokens' logic to `auth:logout` which I think is the correct behavior for this command. Previously `auth:logout` was meaningless since, if you have a machine token saved, you will be automatically logged back in next time you run a command. "Logout" should remove your local credentials so that you need to re-authenticate next time you want to use terminus.