### PR TITLE
Issue #1532 Workflow logs not hydrated

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -157,6 +157,10 @@ class Request implements ConfigAwareInterface, ContainerAwareInterface, LoggerAw
             $uri = $path;
         }
 
+        if (!empty($options['query'])) {
+            $uri .= '?' . http_build_query($options['query'], null, '&', PHP_QUERY_RFC3986);
+        }
+
         $body = isset($options['form_params']) ? json_encode($options['form_params']) : null;
 
         $method = isset($options['method']) ? strtoupper($options['method']) : 'GET';

--- a/tests/unit_tests/Request/RequestTest.php
+++ b/tests/unit_tests/Request/RequestTest.php
@@ -224,6 +224,30 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->makeRequest($client_options, $request_options, 'http://foo.bar/a/b/c');
     }
 
+    public function testRequestWithQuery()
+    {
+        $this->session->method('get')->with('session')->willReturn(false);
+
+        $client_options = ['base_uri' => 'https://example.com:443', RequestOptions::VERIFY => true];
+
+        $method = 'GET';
+        $uri = 'https://example.com:443/api/foo/bar?foo=bar';
+        $headers = [
+          'Content-type' => 'application/json',
+          'User-Agent' => 'Terminus/1.1.1 (php_version=7.0.0&script=foo/bar/baz.php)'
+        ];
+        $body = '';
+        $request_options = [$method, $uri, $headers, $body];
+        $actual = $this->makeRequest($client_options, $request_options, 'foo/bar', ['query' => ['foo' => 'bar']]);
+        $expected = [
+          'data' => (object)['abc' => '123'],
+          'headers' => ['Content-type' => 'application/json'],
+          'status_code' => 200,
+        ];
+        $this->assertEquals($expected, $actual);
+    }
+
+
     public function testRequestNoVerify()
     {
         $this->config->set('verify_host_cert', false);


### PR DESCRIPTION
Note: I've added a unit test for the new code but I don't have access to the fixtures needed to create a new behat test for `workflow:watch` in time for release. A behat test would have probably caught this regression so we should really add one when we can.