### PR TITLE
Add a Windows 'build status' badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
  
 ## Status
 [![Build Status](https://travis-ci.org/pantheon-systems/terminus.svg?branch=master)](https://travis-ci.org/pantheon-systems/terminus)
+[![Windows CI](https://ci.appveyor.com/api/projects/status/niiheng08p25mgnm?svg=true)](https://ci.appveyor.com/project/greg-1-anderson/terminus)
 [![Dependency Status](https://gemnasium.com/pantheon-systems/terminus.svg)](https://gemnasium.com/pantheon-systems/terminus)
 [![Coverage Status](https://coveralls.io/repos/github/pantheon-systems/terminus/badge.svg?branch=master)](https://coveralls.io/github/pantheon-systems/terminus?branch=master)
  


### PR DESCRIPTION
Badge all the things!

It is useful to have the Appveyor build status on the main README with all of the other badges. I wish this badge could say "[ Windows | Passing ]", so that we do not get the side-by-side 

[![Build Status](https://travis-ci.org/pantheon-systems/terminus.svg?branch=master)](https://travis-ci.org/pantheon-systems/terminus) [![Windows CI](https://ci.appveyor.com/api/projects/status/niiheng08p25mgnm?svg=true)](https://ci.appveyor.com/project/greg-1-anderson/terminus)

display; unfortunately, Appveyor does not allow for this sort of customization to its badges.

We could also have a line-by-line display:

Platform | Status
-------- | ------
Mac / Linux | [![Build Status](https://travis-ci.org/pantheon-systems/terminus.svg?branch=master)](https://travis-ci.org/pantheon-systems/terminus)
Windows | [![Windows CI](https://ci.appveyor.com/api/projects/status/niiheng08p25mgnm?svg=true)](https://ci.appveyor.com/project/greg-1-anderson/terminus)

However, this seems a little too verbose to me. Users can always click on the badges to discover what they indicate.
