### PR TITLE
Load plugin autload.php files.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -677,16 +677,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "5b8182cc0abb4b0ff290ba9df6c0e1323286013a"
+                "reference": "0bf561dfe75ba80441c22adecc0529056671a7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5b8182cc0abb4b0ff290ba9df6c0e1323286013a",
-                "reference": "5b8182cc0abb4b0ff290ba9df6c0e1323286013a",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0bf561dfe75ba80441c22adecc0529056671a7d2",
+                "reference": "0bf561dfe75ba80441c22adecc0529056671a7d2",
                 "shasum": ""
             },
             "require": {
@@ -724,7 +724,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-02-03T21:57:31+00:00"
+            "time": "2017-02-10T20:20:03+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/Plugins/PluginAutoload.php
+++ b/src/Plugins/PluginAutoload.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Pantheon\Terminus\Plugins;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Hooks\InitializeHookInterface;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class PluginAutoload
+ */
+class PluginAutoload implements InitializeHookInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * Called at the beginning of every command dispatch.
+     * If this commandfile is a plugin, then search for its
+     * autoload file and load it if necessary.
+     */
+    public function initialize(InputInterface $input, AnnotationData $annotationData)
+    {
+        $autoloadFile = $this->findAutoloadFile($annotationData['_path']);
+        if (!empty($autoloadFile)) {
+            include $autoloadFile;
+        }
+    }
+
+    /**
+     * Given the path to the source file being loaded, return the
+     * path to the autoload file to load.
+     */
+    protected function findAutoloadFile($path)
+    {
+        if (!$path) {
+            return;
+        }
+        $terminusSrcDir = $this->findTerminusSrcDir();
+        if (!$terminusSrcDir) {
+            $this->logger->debug(
+                'Plugin Autoload: Could not find Terminus source directory.'
+            );
+            return;
+        }
+
+        // If the commandfile path is inside Terminus, then
+        // the autoload file has already been loaded.
+        if ($this->pathInside($path, $terminusSrcDir)) {
+            $this->logger->debug(
+                'Plugin Autoload: %dir is a Terminus source file.',
+                ['dir' => $path]
+            );
+            return;
+        }
+
+        // Find the plugin's base directory -- the one that
+        // contains the composer.json file. Abort if we cannot
+        // find a base directory for the plugin.
+        $pluginBaseDir = $this->findPluginBaseDir($path);
+        if (!$pluginBaseDir) {
+            $this->logger->warning(
+                'Plugin Autoload: Could not find the plugin base dir for %dir.',
+                ['dir' => $path]
+            );
+            return;
+        }
+
+        // If there is no autoload file, then we might as well give up
+        $autoloadFile = $this->checkAutoloadPath($pluginBaseDir);
+        if (!$autoloadFile) {
+            // TODO: Maybe we should give a warning if there IS a composer.lock,
+            // but there is NOT an autoload file, so that we can tell the
+            // user to run 'composer install' (or do it for them).
+            // We don't support the composer.lock
+            // at this point anyway. It might be better to have the plugin
+            // manager take care of this at install time. This will happen
+            // automatically if installing via 'composer create-project'.
+            $this->logger->debug(
+                'Plugin Autoload: %dir does not have an autoload file.',
+                ['dir' => $pluginBaseDir]
+            );
+            return;
+        }
+
+        // If there is a composer.lock file here, then
+        // validate that it is safe to load.
+        $this->validateComposerLock($pluginBaseDir, $terminusSrcDir);
+
+        return $autoloadFile;
+    }
+
+    /**
+     * Determine whether the provided path is inside Terminus itself.
+     */
+    protected function findTerminusSrcDir()
+    {
+        // The Terminus class is located at the root of our 'src'
+        // directory. Get the path to the class to determine
+        // whether or not the path we are testing is inside this
+        // same directory.
+        $terminusClass = new \ReflectionClass(\Pantheon\Terminus\Terminus::class);
+        return dirname($terminusClass->getFileName());
+    }
+
+    protected function pathInside($path, $terminusSrcDir)
+    {
+        return substr($path, 0, strlen($terminusSrcDir)) == $terminusSrcDir;
+    }
+
+    protected function findPluginBaseDir($path)
+    {
+        // Walk up one directory. If we are already at the root,
+        // then return.
+        $checkDir = dirname($path);
+        if ($checkDir == $path) {
+            return;
+        }
+
+        // Also stop scanning if we reach the '.terminus' or 'plugins' directory.
+        if ((basename($path) == '.terminus') || (basename($path) == 'plugins')) {
+            return;
+        }
+
+        // If there is a 'composer.json' file here, then we are done.
+        if (file_exists("$checkDir/composer.json")) {
+            return $checkDir;
+        }
+
+        // Otherwise, keep scanning.
+        return $this->findPluginBaseDir($checkDir);
+    }
+
+    protected function validateComposerLock($pluginBaseDir, $terminusSrcDir)
+    {
+        // If there is no composer.lock file, that means that
+        // the plugin has autoload classes, but requires no dependencies.
+        if (!file_exists("$pluginBaseDir/composer.lock")) {
+            return;
+        }
+
+        // TODO: Load the composer.lock and analyze it against
+        // dirname($terminusSrcDir) . '/composer.lock'.
+        throw new TerminusException("Autoloading plugin dependencies is not supported yet.");
+    }
+
+    protected function checkAutoloadPath($path)
+    {
+        $autoloadFile = "$path/vendor/autoload.php";
+        if (file_exists($autoloadFile)) {
+            return $autoloadFile;
+        }
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -62,6 +62,7 @@ use Pantheon\Terminus\Models\UserOrganizationMembership;
 use Pantheon\Terminus\Models\UserSiteMembership;
 use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\Models\WorkflowOperation;
+use Pantheon\Terminus\Plugins\PluginAutoload;
 use Pantheon\Terminus\Plugins\PluginDiscovery;
 use Pantheon\Terminus\Plugins\PluginInfo;
 use Pantheon\Terminus\Request\Request;
@@ -283,6 +284,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $container->add(LocalMachineHelper::class);
 
         // Plugin handlers
+        $container->share('pluginAutoload', PluginAutoload::class);
         $container->add(PluginDiscovery::class);
         $container->add(PluginInfo::class);
 
@@ -301,6 +303,10 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $factory = $container->get('commandFactory');
         $factory->setIncludeAllPublicMethods(false);
         $factory->setDataStore($commandCacheDataStore);
+
+        // Call our autoload loader at the beginning of any command dispatch.
+        $pluginAutoload = $container->get('pluginAutoload');
+        $factory->hookManager()->addInitializeHook($pluginAutoload);
     }
 
     /**

--- a/tests/fixtures/autoload/plugins/invalid-no-composer-json/src/NullCommand.php
+++ b/tests/fixtures/autoload/plugins/invalid-no-composer-json/src/NullCommand.php
@@ -1,0 +1,16 @@
+<?php
+// @codingStandardsIgnoreStart
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}
+// @codingStandardsIgnoreEnd

--- a/tests/fixtures/autoload/plugins/with-autoload/composer.json
+++ b/tests/fixtures/autoload/plugins/with-autoload/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "orgname/with-namespace",
+    "description": "A test Terminus command with namespacing",
+    "type": "terminus-plugin",
+    "extra": {
+        "terminus": {
+            "compatible-version": "1.*"
+        }
+    },
+    "license": "MIT",
+    "autoload": {
+        "psr-4": { "OrgName\\PluginName\\": "src" }
+    }
+}

--- a/tests/fixtures/autoload/plugins/with-autoload/src/Commands/NullCommand.php
+++ b/tests/fixtures/autoload/plugins/with-autoload/src/Commands/NullCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OrgName\PluginName\Commands;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class NullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:null
+     */
+    public function doNothing()
+    {
+    }
+}

--- a/tests/fixtures/autoload/plugins/with-autoload/src/Commands/OptionalCommandGroup/NullCommand.php
+++ b/tests/fixtures/autoload/plugins/with-autoload/src/Commands/OptionalCommandGroup/NullCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OrgName\PluginName\Commands\OptionalCommandGroup;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class GroupNullCommand extends TerminusCommand
+{
+    /**
+     * Do Nothing
+     *
+     * @command test:group:null
+     */
+    public function doNothing()
+    {
+    }
+}

--- a/tests/unit_tests/Plugins/PluginAutoloadTest.php
+++ b/tests/unit_tests/Plugins/PluginAutoloadTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Plugins;
+
+use Pantheon\Terminus\Plugins\PluginAutoload;
+
+use League\Container\Container;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Plugins\PluginDiscovery;
+use Pantheon\Terminus\Plugins\PluginInfo;
+use Psr\Log\NullLogger;
+
+class PluginAutoloadTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PluginAutoload
+     */
+    protected $autoload;
+    /**
+     * @var NullLogger
+     */
+    protected $logger;
+    /**
+     * @var string
+     */
+    protected $plugins_dir;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->logger = $this->getMockBuilder(NullLogger::class)
+            ->setMethods(['warning','debug'])
+            ->getMock();
+        $this->plugins_dir = dirname(dirname(__DIR__)) . '/fixtures/autoload/plugins/';
+
+        $this->autoload = new PluginAutoload($this->plugins_dir);
+        $this->autoload->setLogger($this->logger);
+    }
+
+    public function testDirectMethodCalls()
+    {
+        $path = $this->plugins_dir . 'with-autoload/src/Commands/OptionalCommandGroup/NullCommand.php';
+        $pluginBaseDir = $this->callProtected($this->autoload, 'findPluginBaseDir', [$path]);
+        $this->assertEquals($this->plugins_dir . 'with-autoload', $pluginBaseDir);
+        $autoloadFile = $this->callProtected($this->autoload, 'checkAutoloadPath', [$pluginBaseDir]);
+        $this->assertEquals($this->plugins_dir . 'with-autoload/vendor/autoload.php', $autoloadFile);
+
+        $autoloadFileAgain = $this->callProtected($this->autoload, 'findAutoloadFile', [$path]);
+        $this->assertEquals($this->plugins_dir . 'with-autoload/vendor/autoload.php', $autoloadFileAgain);
+    }
+
+    public static function autoloadTestValues()
+    {
+        return [
+            [
+                'invalid-no-composer-json',
+                'src/NullCommand.php',
+                null,
+            ],
+            [
+                'with-autoload',
+                'src/Commands/OptionalCommandGroup/NullCommand.php',
+                'vendor/autoload.php',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider autoloadTestValues
+     */
+    public function testAutoload($pluginPath, $commandfile, $expected)
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->markTestIncomplete("Plugins not supported on Windows yet.");
+        }
+
+        $pluginPath = $this->plugins_dir . $pluginPath;
+        $path = "$pluginPath/$commandfile";
+        if (!empty($expected)) {
+            $expected = "$pluginPath/$expected";
+        }
+        $actual = $this->callProtected($this->autoload, 'findAutoloadFile', [$path]);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function callProtected($object, $method, $args = [])
+    {
+        $r = new \ReflectionMethod($object, $method);
+        $r->setAccessible(true);
+        return $r->invokeArgs($object, $args);
+    }
+}


### PR DESCRIPTION
**Motivation:**

As plugins become more complex, plugin authors are going to want to place their code in multiple classes. The best way to do this is to use the autoloading facility already provided by Composer. However, if this is left to plugin authors to do for themselves, it becomes likely that some plugins may include things in their autoload files that may conflict with things in Terminus (future versions) or some other plugin (too many permutations to test).

We can't stop plugin authors from doing bad things, but we can reduce the motivation for them needing to hack by providing this capability out-of-the-box. This PR finds and loads autoload.php files included in plugins. If a plugin attempts to include further requirements, the autoloader is rejected, and the plugin will not run.

Note that plugin autoloaders are only included when some command from that particular plugin is run, so there is no need to worry about two different plugins conflicting with each other.

This PR is ready for review -- the only problem is there is a strange Travis failure here. The tests all pass locally, and even show up as passing in the Travis log. Travis reports the test as failing anyway, though. This problem is not unique to this PR; it is happening for all Travis test runs of Terminus at the moment. See below for details.