### PR TITLE
Add maximum number of multidevs to site:info.

### DIFF
--- a/src/Commands/Site/InfoCommand.php
+++ b/src/Commands/Site/InfoCommand.php
@@ -25,6 +25,7 @@ class InfoCommand extends SiteCommand
      *     framework: Framework
      *     organization: Organization
      *     service_level: Service Level
+     *     max_num_cdes: Max Multidevs
      *     upstream: Upstream
      *     php_version: PHP Version
      *     holder_type: Holder Type

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -307,6 +307,7 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
             'framework' => $this->get('framework'),
             'organization' => $this->get('organization'),
             'service_level' => $this->get('service_level'),
+            'max_num_cdes' => $this->get('max_num_cdes'),
             'upstream' => (string)$this->getUpstream(),
             'php_version' => $this->getPHPVersion(),
             'holder_type' => $this->get('holder_type'),

--- a/tests/unit_tests/Models/SiteTest.php
+++ b/tests/unit_tests/Models/SiteTest.php
@@ -417,6 +417,7 @@ class SiteTest extends ModelTestCase
             'frozen' => 'true',
             'memberships' => implode(',', $this->model->memberships),
             'tags' => implode(',', $tags),
+            'max_num_cdes' => null,
         ];
 
         $this->request->expects($this->once())
@@ -474,6 +475,7 @@ class SiteTest extends ModelTestCase
             'frozen' => 'true',
             'memberships' => implode(',', $this->model->memberships),
             'tags' => implode(',', $tags),
+            'max_num_cdes' => null,
         ];
 
         $this->request->expects($this->once())


### PR DESCRIPTION
It's sometimes useful to know in scripts whether or not a site can create CDEs. This PR adds this info to the `site:info` command.

Low priority, but appreciated. My use-case is within a Terminus plugin, so I'll be getting this info directly from the API anyway. Those doing similar things with bash would benefit from having this exposed through a normal Terminus command.