### PR TITLE
Do not log entire command line for remote commands

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -52,6 +52,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
     {
         $this->validateEnvironment($this->site, $this->environment);
 
+        $command_summary = $this->getCommandSummary($command_args);
         $command_line = $this->getCommandLine($command_args);
 
         $output = $this->output();
@@ -66,7 +67,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $this->log()->notice('Command: {site}.{env} -- {command} [Exit: {exit}]', [
             'site'    => $this->site->get('name'),
             'env'     => $this->environment->id,
-            'command' => ProcessUtils::escapeArgument($command_line),
+            'command' => $command_summary,
             'exit'    => $exit,
         ]);
 
@@ -113,6 +114,36 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
     {
         array_unshift($command_args, $this->command);
         return implode(" ", $this->escapeArguments($command_args));
+    }
+
+    /**
+     * Return a summary of the command that does not include the
+     * arguments. This avoids potential information disclosure in
+     * CI scripts.
+     *
+     * @param array $command_args
+     * @return string
+     */
+    private function getCommandSummary($command_args)
+    {
+        return $this->command . ' ' . $this->firstArgument($command_args);
+    }
+
+    /**
+     * Return the first item of the $command_args that is not an option.
+     *
+     * @param array $command_args
+     * @return string
+     */
+    private function firstArgument($command_args)
+    {
+        while (!empty($command_args)) {
+            $first = array_shift($command_args);
+            if ($first[0] != '-') {
+                return $first;
+            }
+        }
+        return '';
     }
 
     /**

--- a/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -72,7 +72,7 @@ class SSHBaseCommandTest extends CommandTestCase
         $this->environment->id = 'env_id';
         $command = 'dummy ' . implode(' ', $options);
 
-        $expectedEscapedCommand = ProcessUtils::escapeArgument($command);
+        $expectedLoggedCommand = 'dummy arg1';
 
         $this->environment->expects($this->once())
             ->method('get')
@@ -96,7 +96,7 @@ class SSHBaseCommandTest extends CommandTestCase
                 $this->equalTo([
                     'site' => $site_name,
                     'env' => $this->environment->id,
-                    'command' => "$expectedEscapedCommand",
+                    'command' => "$expectedLoggedCommand",
                     'exit' => $status_code,
                 ])
             );
@@ -119,7 +119,7 @@ class SSHBaseCommandTest extends CommandTestCase
         $status_code = 0;
         $command = 'dummy ' . implode(' ', $options);
 
-        $expectedEscapedCommand = ProcessUtils::escapeArgument($command);
+        $expectedLoggedCommand = 'dummy arg1';
 
         $this->environment->expects($this->once())
             ->method('get')
@@ -148,7 +148,7 @@ class SSHBaseCommandTest extends CommandTestCase
                 $this->equalTo([
                     'site' => $site_name,
                     'env' => $this->environment->id,
-                    'command' => "$expectedEscapedCommand",
+                    'command' => "$expectedLoggedCommand",
                     'exit' => $status_code,
                 ])
             );


### PR DESCRIPTION
 (e.g. drush, wp, drupal, composer), as these may contain sensitive information that should not be printed in the CI log.