### PR TITLE
Clear env cache

### DIFF
--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -145,6 +145,16 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
     }
 
     /**
+     * Reset our environments cache. This may be necessary after calling
+     * $site->getEnvironments()->create($to_env_id, $from_env), as Terminus
+     * will not have any information about the new environment in its cache.
+     */
+    public function unsetEnvironments()
+    {
+        unset($this->environments);
+    }
+
+    /**
      * @return Environments
      */
     public function getEnvironments()

--- a/tests/unit_tests/Models/SiteTest.php
+++ b/tests/unit_tests/Models/SiteTest.php
@@ -83,6 +83,9 @@ class SiteTest extends ModelTestCase
         $this->branches = $this->getMockBuilder(Branches::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->branches = $this->getMockBuilder(Branches::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->container = new Container();
         $this->environments = $this->getMockBuilder(Environments::class)
             ->disableOriginalConstructor()
@@ -263,6 +266,48 @@ class SiteTest extends ModelTestCase
     {
         $environments = $this->model->getEnvironments();
         $this->assertEquals($this->environments, $environments);
+    }
+
+    /**
+     * Tests Site::getEnvironments()
+     */
+    public function testUnsetEnvironments()
+    {
+        $container = $this->getMockBuilder(Container::class)
+            ->setMethods(['get'])
+            ->getMock();
+
+        $model = new Site($this->site_data);
+
+        $model->setContainer($container);
+        $model->setRequest($this->request);
+        $model->setConfig($this->config);
+
+        // We can call 'getEnvironments()' as many times as we like;
+        // it will not be re-fetched from the container until after
+        // unsetEnvironments() is called.
+        $container->expects($this->exactly(2))
+            ->method('get')
+            ->with(
+                $this->equalTo(Environments::class),
+                $this->equalTo([['site' => $model,],])
+            )
+            ->willReturn($this->environments);
+
+        // First call fetches from container
+        $environments = $model->getEnvironments();
+
+        // Does not fetch from container
+        $environments = $model->getEnvironments();
+
+        // Erases Site::$environments
+        $model->unsetEnvironments();
+
+        // Re-fetches environments from container
+        $environments = $model->getEnvironments();
+
+        // Does not fetch from container
+        $environments = $model->getEnvironments();
     }
 
     /**


### PR DESCRIPTION
In the Terminus Build Tools plugin, I have the following workaround:
```
        // Clear the environments, so that they will be re-fetched.
        // Otherwise, the new environment will not be found immediately
        // after it is first created. If we set the connection mode to
        // git mode, then Terminus will think it is still in sftp mode
        // if we do not re-fetch.
        $site->environments = null;

        // Get (or re-fetch) a reference to our target multidev site.
        $target_env = $site->getEnvironments()->get($multidev);
```
This isn't a great practice, but without it, there is no way to fetch $multidev, as Terminus does not have it in its Site object environments cache.

Unfortunately for my hack, 85c0c19a made `Site::$environments` protected, which is, overall, a good change.

This PR adds a new public method to allow plugins to clear the environments cache, so that they may continue to create a multidev environment and then operate on it.