### PR TITLE
Share a bit more of the command executed by remote commands

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -126,7 +126,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
      */
     private function getCommandSummary($command_args)
     {
-        return $this->command . ' ' . $this->firstArgument($command_args);
+        return $this->command . $this->firstArguments($command_args);
     }
 
     /**
@@ -135,15 +135,17 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
      * @param array $command_args
      * @return string
      */
-    private function firstArgument($command_args)
+    private function firstArguments($command_args)
     {
+        $result = '';
         while (!empty($command_args)) {
             $first = array_shift($command_args);
-            if ($first[0] != '-') {
-                return $first;
+            if ($first[0] == '-') {
+                return $result;
             }
+            $result .= " $first";
         }
-        return '';
+        return $result;
     }
 
     /**

--- a/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -72,7 +72,7 @@ class SSHBaseCommandTest extends CommandTestCase
         $this->environment->id = 'env_id';
         $command = 'dummy ' . implode(' ', $options);
 
-        $expectedLoggedCommand = 'dummy arg1';
+        $expectedLoggedCommand = 'dummy arg1 arg2';
 
         $this->environment->expects($this->once())
             ->method('get')
@@ -113,13 +113,13 @@ class SSHBaseCommandTest extends CommandTestCase
     public function testExecuteCommandInGitMode()
     {
         $dummy_output = 'dummy output';
-        $options = ['arg1', 'arg2',];
+        $options = ['arg1', 'arg2', '--secret', 'somesecret'];
         $site_name = 'site name';
         $mode = 'git';
         $status_code = 0;
         $command = 'dummy ' . implode(' ', $options);
 
-        $expectedLoggedCommand = 'dummy arg1';
+        $expectedLoggedCommand = 'dummy arg1 arg2';
 
         $this->environment->expects($this->once())
             ->method('get')


### PR DESCRIPTION
e.g. so that 'wp core update' is not rendered simply as 'wp core'.