### PR TITLE
Updating to version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 1.1.1 - 2017-03-09
+### Fixed
+- composer.json file now has its `bin` property set to include `bin/terminus`. (#1656)
+
 ## 1.1.0 - 2017-03-09
 ### Added
 - Added an `--element=` option to `backup:list`. (#1563)

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '1.1.0'
+TERMINUS_VERSION: '1.1.1'
 
 # Connectivity
 TERMINUS_HOST:     'terminus.pantheon.io'


### PR DESCRIPTION
### Fixed
- composer.json file now has its `bin` property set to include `bin/terminus`. (#1656)