### PR TITLE
Look up max_num_cdes from settings.

### DIFF
--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -308,6 +308,8 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
      */
     public function serialize()
     {
+        $settings = $this->get('settings');
+
         $created_date = is_numeric($created = $this->get('created')) ? $created : strtotime($created);
         $data = [
             'id' => $this->id,
@@ -317,7 +319,7 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
             'framework' => $this->get('framework'),
             'organization' => $this->get('organization'),
             'service_level' => $this->get('service_level'),
-            'max_num_cdes' => $this->get('max_num_cdes'),
+            'max_num_cdes' => $settings ? $settings->max_num_cdes : 0,
             'upstream' => (string)$this->getUpstream(),
             'php_version' => $this->getPHPVersion(),
             'holder_type' => $this->get('holder_type'),


### PR DESCRIPTION
Oh the irony; no sooner did I finish my cool max_num_cdes feature than the variable moved into `settings`.

Attached fix is proof-of-concept. If you want wrapper methods like `getSetting($key)`, I can provide those as well. Just let me know how you think it should be.