### PR TITLE
Don't run the update check in non-interactive mode.

### DIFF
--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -260,6 +260,13 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
      */
     private function runUpdateChecker()
     {
+        // Skip the update check when in non-interactive mode; this is
+        // particularly helpful for scripts.
+        $container = $this->getContainer();
+        $input = $container->get('input');
+        if (!$input->isInteractive()) {
+            return;
+        }
         $file_store = new FileStore($this->getConfig()->get('cache_dir'));
         $this->runner->getContainer()->get(UpdateChecker::class, [$file_store,])->run();
     }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -103,7 +103,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $status_code = $this->runner->run($input, $output, null, $this->commands);
         if (!empty($cassette) && !empty($mode)) {
             $this->stopVCR();
-        } else {
+        } elseif ($input->isInteractive()) {
             $this->runUpdateChecker();
         }
         return $status_code;
@@ -260,13 +260,6 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
      */
     private function runUpdateChecker()
     {
-        // Skip the update check when in non-interactive mode; this is
-        // particularly helpful for scripts.
-        $container = $this->getContainer();
-        $input = $container->get('input');
-        if (!$input->isInteractive()) {
-            return;
-        }
         $file_store = new FileStore($this->getConfig()->get('cache_dir'));
         $this->runner->getContainer()->get(UpdateChecker::class, [$file_store,])->run();
     }

--- a/src/Update/UpdateChecker.php
+++ b/src/Update/UpdateChecker.php
@@ -28,7 +28,7 @@ class UpdateChecker implements ConfigAwareInterface, ContainerAwareInterface, Da
     const UPDATE_COMMAND = 'curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install';
     const UPDATE_NOTICE = <<<EOT
 A new Terminus version v{latest_version} is available.
-You are currently using version v{running_version}. 
+You are currently using version v{running_version}.
 You can update Terminus by running `composer update` or using the Terminus installer:
 {update_command}
 EOT;
@@ -45,6 +45,9 @@ EOT;
 
     public function run()
     {
+        if (!$this->shouldCheckForUpdates()) {
+            return;
+        }
         $running_version = $this->getRunningVersion();
         try {
             $latest_version = $this->getContainer()->get(LatestRelease::class, [$this->getDataStore(),])->get('version');
@@ -60,6 +63,19 @@ EOT;
                 'update_command' => self::UPDATE_VARS_COLOR . self::UPDATE_COMMAND,
             ]);
         }
+    }
+
+    /**
+     * Avoid running the update checker in instances where the output might
+     * interfere with scripts.
+     */
+    private function shouldCheckForUpdates()
+    {
+        // Also skip the update check whenever output is redirected.
+        if (function_exists('posix_isatty')) {
+            return (posix_isatty(STDOUT) && posix_isatty(STDIN));
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Some folks in #power-users were complaining that the output from the update check was sometimes getting injected into their script results, breaking their output. (I think maybe some were accidentally running dev-master, and were experiencing the version that checked every time.)

Here is just one possible idea of how to fix this that I'm putting out just to get things started. This skips the check if the `-n` / `--no-interactive` option is specified. This mode will commonly be used by scripts, so it would be a useful technique to avoid update messages. 

Other solutions are possible; you could define an environment variable to disable it, or maybe try sending the update notice to stderr, if it isn't already going that way.

Please do as you like and take this to completion.