### PR TITLE
Reenabled self:console in PHP 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
 ## MASTER
+### Changed
+- Reenabled the `self:console` command in PHP 7.1. (#1664)
 ### Fixed
 - Corrected typo in `aliases` command which prevented the authorization hook from working on it. (#1663)
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '1.1.1'
+TERMINUS_VERSION: '1.1.2-dev'
 
 # Connectivity
 TERMINUS_HOST:     'terminus.pantheon.io'

--- a/src/Commands/Self/ConsoleCommand.php
+++ b/src/Commands/Self/ConsoleCommand.php
@@ -25,15 +25,9 @@ class ConsoleCommand extends TerminusCommand implements SiteAwareInterface
      * @usage Opens an interactive PHP console within Terminus.
      * @usage <site> Opens an interactive PHP console within Terminus and loads <site> as $site.
      * @usage <site>.<env> Opens an interactive PHP console within Terminus and loads <site> and its <env> environment as $site and $env.
-     *
-     * @todo Remove the version check when PSYSH is updated to work in PHP 7.1.
      */
     public function console($site_env = null)
     {
-        if ((version_compare(PHP_VERSION, '7.1.0') >= 0) || (boolean)$this->getConfig()->get('test_mode_pass')) {
-            $this->log()->error('This command is not compatible with PHP 7.1.');
-            return;
-        }
         list($site, $env) = $this->getOptionalSiteEnv($site_env, null);
         eval(\Psy\sh());
     }

--- a/tests/unit_tests/Commands/Self/ConsoleCommandTest.php
+++ b/tests/unit_tests/Commands/Self/ConsoleCommandTest.php
@@ -28,68 +28,14 @@ class ConsoleCommandTest extends EnvCommandTest
 
         $this->command = new ConsoleCommand();
         $this->command->setSites($this->sites);
-
-        // We do not expect to use the config object in 7.1+
-        if (!$this->isRunningVersion71()) {
-            $this->config = $this->getMockBuilder(TerminusConfig::class)
-                ->disableOriginalConstructor()
-                ->getMock();
-            $this->command->setConfig($this->config);
-        }
     }
 
     /**
      * Tests the self:console command
-     *
-     * @todo Remove the check and incomplete from this test when PSYSH is updated to work with PHP 7.1.
      */
     public function testConsole()
     {
-        if ($this->isRunningVersion71()) {
-            $this->markTestIncomplete('Incompatible message only printed on PHP >= 7.1.');
-        }
-
-        $this->config->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('test_mode_pass'))
-            ->willReturn(false);
         $out = $this->command->console('site.env');
         $this->assertNull($out);
-    }
-
-    /**
-     * Testing the self:console command when in an incompatible PHP version
-     *
-     * @todo Remove this test when PSYSH is updated to work with PHP 7.1.
-     */
-    public function testConsoleIncompatibleMessage()
-    {
-        $logger = $this->getMockBuilder(LoggerInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        if (!$this->isRunningVersion71()) {
-            $this->config->expects($this->once())
-                ->method('get')
-                ->with($this->equalTo('test_mode_pass'))
-                ->willReturn(true);
-        }
-        $logger->expects($this->once())
-            ->method('error')
-            ->with($this->equalTo('This command is not compatible with PHP 7.1.'));
-
-        $this->command->setLogger($logger);
-        $out = $this->command->console('site.env');
-        $this->assertNull($out);
-    }
-
-    /**
-     * Determines whether the code is being run by PHP 7.1
-     *
-     * @return boolean
-     */
-    private function isRunningVersion71()
-    {
-        return (version_compare(PHP_VERSION, '7.1.0') >= 0);
     }
 }


### PR DESCRIPTION
Closes #1601 
Closes #1660 