### PR TITLE
Adds '--force' option to 'env:commit'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## MASTER
+### Changed
+- `env:commit` now has a `--force` option to force a commit even if no changes are found. (#1115)
+
 ## 1.2.1 - 2017-04-11
 ### Fixed
 - Corrected the command to be used to update Terminus displayed by the `UpdateChecker`. (#1687)

--- a/src/Commands/Env/CommitCommand.php
+++ b/src/Commands/Env/CommitCommand.php
@@ -24,17 +24,25 @@ class CommitCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @option string $message Commit message
+     * @option boolean $force Force a commit even if there doesn't seem to be anything to commit. This can lead to an empty commit.
      *
      * @usage <site>.<env> Commits code changes to <site>'s <env> environment with the default message.
      * @usage <site>.<env> --message=<message> Commits code changes to <site>'s <env> environment with the message <message>.
      */
-    public function commit($site_env, $options = ['message' => 'Terminus commit.'])
+    public function commit($site_env, $options = ['message' => 'Terminus commit.', 'force' => false])
     {
         list(, $env) = $this->getUnfrozenSiteEnv($site_env, 'dev');
 
-        $change_count = count((array)$env->diffstat());
-        if ($change_count === 0) {
-            $this->log()->warning('There is no code to commit.');
+        if (empty($options['force'])) {
+            $change_count = count((array)$env->diffstat());
+            if ($change_count === 0) {
+                $this->log()->warning('There is no code to commit.');
+                return;
+            }
+        }
+
+        if ($env->get('connection_mode') !== 'sftp') {
+            $this->log()->warning('You can only commit code in an environment that is set to sftp mode.');
             return;
         }
 

--- a/tests/unit_tests/Commands/Env/CommitCommandTest.php
+++ b/tests/unit_tests/Commands/Env/CommitCommandTest.php
@@ -11,9 +11,9 @@ use Pantheon\Terminus\Commands\Env\CommitCommand;
  */
 class CommitCommandTest extends EnvCommandTest
 {
-    /**
-     * Sets up the test fixture.
-     */
+  /**
+   * Sets up the test fixture.
+   */
     protected function setUp()
     {
         parent::setUp();
@@ -23,55 +23,122 @@ class CommitCommandTest extends EnvCommandTest
         $this->environment->id = 'dev';
     }
 
-    /**
-     * Tests the env:commit command to success with all parameters
-     */
+  /**
+   * Tests the env:commit command to success with all parameters
+   */
     public function testCommit()
     {
         $message = 'Custom message.';
 
         $this->environment->expects($this->once())
-            ->method('diffstat')
-            ->willReturn(['a', 'b']);
+        ->method('diffstat')
+        ->willReturn(['a', 'b']);
         $this->environment->expects($this->once())
-            ->method('commitChanges')
-            ->with($this->equalTo($message))
-            ->willReturn($this->workflow);
+        ->method('get')
+        ->with('connection_mode')
+        ->willReturn('sftp');
+        $this->environment->expects($this->once())
+        ->method('commitChanges')
+        ->with($this->equalTo($message))
+        ->willReturn($this->workflow);
         $this->workflow->expects($this->once())
-            ->method('checkProgress')
-            ->with()
-            ->willReturn(true);
+        ->method('checkProgress')
+        ->with()
+        ->willReturn(true);
         $this->logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->equalTo('notice'),
-                $this->equalTo('Your code was committed.')
-            );
+        ->method('log')
+        ->with(
+            $this->equalTo('notice'),
+            $this->equalTo('Your code was committed.')
+        );
 
-        $out = $this->command->commit('mysite.' . $this->environment->id, compact('message'));
+        $out = $this->command->commit(
+            'mysite.' . $this->environment->id,
+            compact('message')
+        );
         $this->assertNull($out);
     }
 
-    /**
-     * Tests the env:commit command when there are no changes to be committed
-     */
+  /**
+   * Tests the env:commit command when there are no changes to be committed
+   */
     public function testCommitNoChanges()
     {
         $this->environment->expects($this->once())
-            ->method('diffstat')
-            ->willReturn([]);
+        ->method('diffstat')
+        ->willReturn([]);
         $this->environment->expects($this->never())
-            ->method('commitChanges');
+        ->method('commitChanges');
         $this->workflow->expects($this->never())
-            ->method('checkProgress');
+        ->method('checkProgress');
         $this->logger->expects($this->once())
-            ->method('log')
-            ->with(
-                $this->equalTo('warning'),
-                $this->equalTo('There is no code to commit.')
-            );
+        ->method('log')
+        ->with(
+            $this->equalTo('warning'),
+            $this->equalTo('There is no code to commit.')
+        );
 
         $out = $this->command->commit('mysite.' . $this->environment->id);
+        $this->assertNull($out);
+    }
+
+  /**
+   * Tests the env:commit command when there are no changes to be committed
+   */
+    public function testCommitForce()
+    {
+        $message = 'Custom message.';
+
+        $this->environment->expects($this->once())
+        ->method('get')
+        ->with('connection_mode')
+        ->willReturn('sftp');
+        $this->environment->expects($this->once())
+        ->method('commitChanges')
+        ->with($this->equalTo($message))
+        ->willReturn($this->workflow);
+        $this->workflow->expects($this->once())
+        ->method('checkProgress')
+        ->with()
+        ->willReturn(true);
+        $this->logger->expects($this->once())
+        ->method('log')
+        ->with(
+            $this->equalTo('notice'),
+            $this->equalTo('Your code was committed.')
+        );
+
+        $out = $this->command->commit(
+            'mysite.' . $this->environment->id,
+            ['message' => $message, 'force' => true]
+        );
+        $this->assertNull($out);
+    }
+
+  /**
+   * Tests the env:commit command when there are no changes to be committed
+   */
+    public function testCommitForceGitMode()
+    {
+        $this->environment->expects($this->once())
+        ->method('get')
+        ->with('connection_mode')
+        ->willReturn('git');
+        $this->environment->expects($this->never())
+        ->method('commitChanges');
+        $this->workflow->expects($this->never())
+        ->method('checkProgress');
+        $this->logger->expects($this->once())
+        ->method('log')
+        ->with(
+            $this->equalTo('warning'),
+            $this->equalTo('You can only commit code in an environment that is set to sftp mode.')
+        );
+
+        $out = $this->command->commit(
+            'mysite.' . $this->environment->id,
+            ['force' => true]
+        );
         $this->assertNull($out);
     }
 }


### PR DESCRIPTION
This is a workaround for #1115 

It does not fix the issue where Terminus cannot detect recently changed files, but it does allow the commit command to be run even if Terminus does not believe there are changes to be committed. This should help unblock script workflows while we work on a real solution.