### PR TITLE
Fixes #1699: Do not set up a tty when running Terminus with -n

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -55,11 +55,21 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $command_summary = $this->getCommandSummary($command_args);
         $command_line = $this->getCommandLine($command_args);
 
+        $input = $this->input();
+        $useTty = $input->isInteractive() ? null : false;
+
         $output = $this->output();
+        $echoOutputFn = function ($type, $buffer) {};
+        if ($useTty === false) {
+            $echoOutputFn = function ($type, $buffer) use ($output) {
+                $output->write($buffer);
+            };
+        }
+
         $result = $this->environment->sendCommandViaSsh(
             $command_line,
-            function ($type, $buffer) use ($output) {
-            }
+            $echoOutputFn,
+            $useTty
         );
         $output = $result['output'];
         $exit = $result['exit_code'];
@@ -74,8 +84,6 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         if ($exit != 0) {
             throw new TerminusProcessException($output);
         }
-
-        return rtrim($output);
     }
 
     /**

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -59,7 +59,8 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $useTty = $input->isInteractive() ? null : false;
 
         $output = $this->output();
-        $echoOutputFn = function ($type, $buffer) {};
+        $echoOutputFn = function ($type, $buffer) {
+        };
         if ($useTty === false) {
             $echoOutputFn = function ($type, $buffer) use ($output) {
                 $output->write($buffer);
@@ -84,6 +85,8 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         if ($exit != 0) {
             throw new TerminusProcessException($output);
         }
+
+        return rtrim($output);
     }
 
     /**

--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -43,18 +43,22 @@ class LocalMachineHelper implements ConfigAwareInterface
      *
      * @param string $cmd The command to execute
      * @param callable $callback A function to run while waiting for the process to complete
+     * @param boolean $useTty Whether to allocate a tty when running. Null to autodetect.
      * @return array The command output and exit_code
      */
-    public function execInteractive($cmd, $callback = null)
+    public function execInteractive($cmd, $callback = null, $useTty = null)
     {
         $process = $this->getProcess($cmd);
         // Set tty mode if the user is running terminus iteractively.
         if (function_exists('posix_isatty')) {
-            $process->setTty(posix_isatty(STDOUT) && posix_isatty(STDIN));
+            if (!isset($useTty)) {
+                $useTty = (posix_isatty(STDOUT) && posix_isatty(STDIN));
+            }
             if (!posix_isatty(STDIN)) {
                 $process->setInput(STDIN);
             }
         }
+        $process->setTty($useTty);
         $process->start();
         $process->wait($callback);
         return ['output' => $process->getOutput(), 'exit_code' => $process->getExitCode(),];

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -726,11 +726,12 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
      *
      * @param string $command The command to be run on the platform
      * @param callable $callback An anonymous function to run while waiting for the command to finish
+     * @param boolean $useTty Whether to allocate a tty when running. Null to autodetect.
      * @return string[] $response Elements as follow:
      *         string output    The output from the command run
      *         string exit_code The status code returned by the command run
      */
-    public function sendCommandViaSsh($command, $callback = null)
+    public function sendCommandViaSsh($command, $callback = null, $useTty = null)
     {
         $sftp = $this->sftpConnectionInfo();
         $ssh_command = vsprintf(
@@ -748,7 +749,7 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
             ];
         }
 
-        return $this->getContainer()->get(LocalMachineHelper::class)->execInteractive($ssh_command, $callback);
+        return $this->getContainer()->get(LocalMachineHelper::class)->execInteractive($ssh_command, $callback, $useTty);
     }
 
     /**


### PR DESCRIPTION
Setting up a tty can cause CI systems such as Travis to block. This PR prevents the creation of a tty in --no-interaction mode, allowing Travis users to avoid blocking by using this flag.