### PR TITLE
Extend \Robo\Tasks so that Robo plugins may use core Robo tasks by default

### DIFF
--- a/src/Commands/TerminusCommand.php
+++ b/src/Commands/TerminusCommand.php
@@ -17,7 +17,7 @@ use Robo\Common\IO;
  * Class TerminusCommand
  * @package Pantheon\Terminus\Commands
  */
-abstract class TerminusCommand implements
+abstract class TerminusCommand extends \Robo\Tasks implements
     IOAwareInterface,
     LoggerAwareInterface,
     ConfigAwareInterface,


### PR DESCRIPTION
It is possible for Terminus plugins to use Robo tasks already; all they need to do is use the LoadAllTasks trait. e.g.: https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/37/files#diff-fc5464c631b7689f52fbd057675b0d61R38

However, if Terminus itself started to use Robo tasks in core, it wouldn't be able to add them to the TerminusCommand base class, as doing so would break any plugin already using tasks. Currently there are no plugins using tasks; this will change once https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/37 is merged.

This PR is not necessary; as an alternative, it would also be possible for Terminus core commands to use the LoadAllTasks trait individually. This would not break plugins using tasks.