### PR TITLE
Fixes #1719: Avoid double output with certain 'terminus drush' commands.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   #Install PHP per https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
   - ps: appveyor-retry cinst --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
-  - cd c:\tools\php
+  - cd c:\tools\php70
   - copy php.ini-production php.ini
 
   - echo extension_dir=ext >> php.ini
@@ -43,7 +43,7 @@ install:
   - echo extension=php_pdo_sqlite.dll >> php.ini
   - echo extension=php_pgsql.dll >> php.ini
   - echo extension=php_gd2.dll >> php.ini
-  - SET PATH=C:\tools\php;%PATH%
+  - SET PATH=C:\tools\php70;%PATH%
   #Install Composer
   - cd %APPVEYOR_BUILD_FOLDER%
   #- appveyor DownloadFile https://getcomposer.org/composer.phar

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -81,8 +81,6 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         if ($exit != 0) {
             throw new TerminusProcessException($output);
         }
-
-        return rtrim($output);
     }
 
     /**

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -741,10 +741,12 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
 
         // Catch Terminus running in test mode
         if ($this->getConfig()->get('test_mode')) {
-            return [
-                'output' => "Terminus is in test mode. "
+            $output = "Terminus is in test mode. "
                     . "Environment::sendCommandViaSsh commands will not be sent over the wire. "
-                    . "SSH Command: ${ssh_command}",
+                    . "SSH Command: ${ssh_command}";
+            print "$output";
+            return [
+                'output' => $output,
                 'exit_code' => 0
             ];
         }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -744,7 +744,9 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
             $output = "Terminus is in test mode. "
                     . "Environment::sendCommandViaSsh commands will not be sent over the wire. "
                     . "SSH Command: ${ssh_command}";
-            print "$output";
+            if ($this->getContainer()->has('output')) {
+                $this->getContainer()->get('output')->write($output);
+            }
             return [
                 'output' => $output,
                 'exit_code' => 0

--- a/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -56,7 +56,7 @@ class SSHBaseCommandTest extends CommandTestCase
             ->willReturn(['output' => $dummy_output, 'exit_code' => 0,]);
 
         $out = $this->command->dummyCommand("$site_name.env", $options);
-        $this->assertEquals($dummy_output, $out);
+        $this->assertNull($out);
     }
 
     /**
@@ -158,6 +158,6 @@ class SSHBaseCommandTest extends CommandTestCase
             ->willReturn(['output' => $dummy_output, 'exit_code' => $status_code,]);
 
         $out = $this->command->dummyCommand("$site_name.env", $options);
-        $this->assertEquals($dummy_output, $out);
+        $this->assertNull($out);
     }
 }


### PR DESCRIPTION
#1700 altered `SSHBaseCommand::executeCommand()` such that it always echo's its output, regardless of what mode it is in. If the Symfony Process component is being called in a mode where the output is not echo'ed to the terminal, then a function callback is provided to ensure that output is incrementally printed.

When running non-interactively, the Symfony Process component will return the command output. In interactive mode, it returns nothing. This means that #1700 introduced some situations where output is both echo'ed by the Symfony Process component *and* returned as the function result, which results in double output. This caused #1719.

The correct behavior is that the process output should never be returned, since the output is always printed while running now.