### PR TITLE
Fixes #1734: Be smarter about selecting the right value for 'useTty'

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -57,6 +57,9 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
 
         $input = $this->input();
         $useTty = $input->isInteractive() ? null : false;
+        if ($input->isInteractive() && function_exists('posix_isatty') && !posix_isatty(STDOUT)) {
+            $useTty = false;
+        }
 
         $output = $this->output();
         $echoOutputFn = function ($type, $buffer) {


### PR DESCRIPTION
We sometimes get this wrong when redirecting stdout in 'terminus drush' and 'terminus wp'.