### PR TITLE
Allow automated scripts to hide the update message w/env variable

### DIFF
--- a/src/Update/UpdateChecker.php
+++ b/src/Update/UpdateChecker.php
@@ -53,7 +53,9 @@ EOT;
             return;
         }
 
-        if (version_compare($latest_version, $running_version, '>')) {
+        $update_exists = version_compare($latest_version, $running_version, '>');
+        $should_hide_update = (bool) $this->getConfig()->get('hide_update_message');
+        if ($update_exists && !$should_hide_update) {
             $this->logger->notice($this->getUpdateNotice(), [
                 'latest_version' => self::UPDATE_VARS_COLOR . $latest_version,
                 'running_version' => self::UPDATE_VARS_COLOR . $running_version,

--- a/tests/unit_tests/Update/UpdateCheckerTest.php
+++ b/tests/unit_tests/Update/UpdateCheckerTest.php
@@ -78,11 +78,12 @@ class UpdateCheckerTest extends \PHPUnit_Framework_TestCase
     {
         $running_version_num = '1.0.0-beta.2';
         $latest_version_num = '1.0.0-beta.2';
+        $hide_update_message = null;
 
-        $this->config->expects($this->once())
+        $this->config->expects($this->exactly(2))
             ->method('get')
-            ->with($this->equalTo('version'))
-            ->willReturn($running_version_num);
+            ->withConsecutive(['version'], ['hide_update_message'])
+            ->willReturnOnConsecutiveCalls($running_version_num, $hide_update_message);
         $this->container->expects($this->once())
             ->method('get')
             ->with(
@@ -110,11 +111,12 @@ class UpdateCheckerTest extends \PHPUnit_Framework_TestCase
     {
         $running_version_num = '1.0.0-beta.1';
         $latest_version_num = '1.0.0-beta.2';
+        $hide_update_message = null;
 
-        $this->config->expects($this->once())
+        $this->config->expects($this->exactly(2))
             ->method('get')
-            ->with($this->equalTo('version'))
-            ->willReturn($running_version_num);
+            ->withConsecutive(['version'], ['hide_update_message'])
+            ->willReturnOnConsecutiveCalls($running_version_num, $hide_update_message);
         $this->container->expects($this->once())
             ->method('get')
             ->with(
@@ -127,6 +129,40 @@ class UpdateCheckerTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('version'))
             ->willReturn($latest_version_num);
         $this->logger->expects($this->once())
+            ->method('notice');
+        $this->logger->expects($this->never())
+            ->method('debug');
+
+        $out = $this->update_checker->run();
+        $this->assertNull($out);
+    }
+
+    /**
+     * Tests the run function when the client is out-of-date, but the update
+     * message is configured to be hidden.
+     */
+    public function testClientIsOutOfDateButHideMessage()
+    {
+        $running_version_num = '1.0.0-beta.1';
+        $latest_version_num = '1.0.0-beta.2';
+        $hide_update_message = '1';
+
+        $this->config->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive(['version'], ['hide_update_message'])
+            ->willReturnOnConsecutiveCalls($running_version_num, $hide_update_message);
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo(LatestRelease::class),
+                $this->equalTo([$this->data_store,])
+            )
+           ->willReturn($this->latest_release);
+        $this->latest_release->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('version'))
+            ->willReturn($latest_version_num);
+        $this->logger->expects($this->never())
             ->method('notice');
         $this->logger->expects($this->never())
             ->method('debug');


### PR DESCRIPTION
## What / why
Introduces an optional environment variable that can control the suppression of update messages.

## Review / QA
Existing behavior maintained w/out flag:
```sh
$ TERMINUS_VERSION=1.4.1 ./bin/terminus --version
Terminus 1.4.1
 [notice] A new Terminus version v1.5.0 is available.
You are currently using version v1.4.1. 
You can update Terminus by running `composer update` or using the Terminus installer:
curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar update
```

New behavior w/new flag:
```sh
$ TERMINUS_VERSION=1.4.1 TERMINUS_HIDE_UPDATE_MESSAGE=1 ./bin/terminus --version
Terminus 1.4.1
```

## FYI 
- Closes #1757 