### PR TITLE
BUGS-1506 - Fixed environment deploys for unfrozen sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 - Changed the Domains collection to use a newer API call, fixing `domain:dns`. (#1756)
-- Fixed environment operations for sites that have been unfrozen.
+- Fixed operations for sites that have been unfrozen. (#1766)
 
 ### Removed
 - Removed the now-obsolete `Domains::setHydration(string)` function. (#1756)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 - Changed the Domains collection to use a newer API call, fixing `domain:dns`. (#1756)
+- Fixed environment operations for sites that have been unfrozen.
 
 ### Removed
 - Removed the now-obsolete `Domains::setHydration(string)` function. (#1756)

--- a/src/Collections/Environments.php
+++ b/src/Collections/Environments.php
@@ -88,7 +88,7 @@ class Environments extends SiteOwnedCollection
      */
     public function serialize()
     {
-        $site_is_frozen = !is_null($this->getSite()->get('frozen'));
+        $site_is_frozen = $this->getSite()->isFrozen();
         $models = [];
         foreach ($this->getMembers() as $id => $model) {
             if (!$site_is_frozen || !in_array($id, ['test', 'live',])) {

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -40,7 +40,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     public function listEnvs($site_id)
     {
         $site = $this->getSite($site_id);
-        if (!is_null($site->get('frozen'))) {
+        if ($site->isFrozen()) {
             $this->log()->warning('This site is frozen. Its test and live environments are unavailable.');
         }
         return new RowsOfFields($site->getEnvironments()->serialize());

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -304,6 +304,16 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
     }
 
     /**
+     * Returns whether the site is frozen or not.
+     *
+     * @return boolean
+     */
+    public function isFrozen()
+    {
+        return !empty($this->get('frozen'));
+    }
+
+    /**
      * Remove this site's payment method
      *
      * @return Workflow
@@ -337,7 +347,7 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
             'holder_type' => $this->get('holder_type'),
             'holder_id' => $this->get('holder_id'),
             'owner' => $this->get('owner'),
-            'frozen' => is_null($this->get('frozen')) ? 'false' : 'true',
+            'frozen' => $this->isFrozen() ? 'true' : 'false',
         ];
         if (isset($this->tags)) {
             $data['tags'] = implode(',', $this->tags->ids());

--- a/src/Site/SiteAwareTrait.php
+++ b/src/Site/SiteAwareTrait.php
@@ -103,7 +103,7 @@ trait SiteAwareTrait
     {
         list($site, $env) = $this->getSiteEnv($site_env_id, $default_env);
 
-        if (!is_null($site->get('frozen'))) {
+        if ($site->isFrozen()) {
             throw new TerminusException(
                 'This site is frozen. Its test and live environments and many commands will be '
                 . 'unavailable while it remains frozen.'

--- a/tests/unit_tests/Collections/EnvironmentsTest.php
+++ b/tests/unit_tests/Collections/EnvironmentsTest.php
@@ -136,8 +136,7 @@ class EnvironmentsTest extends CollectionTestCase
     public function testSerializeFrozen()
     {
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
+            ->method('isFrozen')
             ->willReturn(true);
         $this->makeEnvironmentsFetchable();
         $expected = array_map(function ($data) {
@@ -154,9 +153,8 @@ class EnvironmentsTest extends CollectionTestCase
     public function testSerializeUnfrozen()
     {
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
-            ->willReturn(null);
+            ->method('isFrozen')
+            ->willReturn(false);
         $this->makeEnvironmentsFetchable();
         $expected = array_map(function ($env) {
             return (array)$env;

--- a/tests/unit_tests/Commands/Env/DeployCommandTest.php
+++ b/tests/unit_tests/Commands/Env/DeployCommandTest.php
@@ -164,6 +164,9 @@ class DeployCommandTest extends EnvCommandTest
             ->method('deploy');
         $this->workflow->expects($this->never())
             ->method('checkProgress');
+        $this->site->expects($this->once())
+            ->method('isFrozen')
+            ->willReturn(false);
 
         $this->setExpectedException(
             TerminusException::class,

--- a/tests/unit_tests/Commands/Env/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Env/ListCommandTest.php
@@ -52,11 +52,9 @@ class ListCommandTest extends EnvCommandTest
      */
     public function testListEnvs()
     {
-
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
-            ->willReturn(null);
+            ->method('isFrozen')
+            ->willReturn(false);
         $this->logger->expects($this->never())
             ->method('warning');
 
@@ -71,9 +69,8 @@ class ListCommandTest extends EnvCommandTest
     public function testListFrozenEnvs()
     {
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
-            ->willReturn('anything but null');
+            ->method('isFrozen')
+            ->willReturn(true);
         $this->logger->expects($this->once())
             ->method('warning')
             ->with(

--- a/tests/unit_tests/Commands/Env/WipeCommandTest.php
+++ b/tests/unit_tests/Commands/Env/WipeCommandTest.php
@@ -81,9 +81,8 @@ class WipeCommandTest extends EnvCommandTest
         $this->workflow->expects($this->never())
           ->method('getMessage');
         $this->site->expects($this->once())
-          ->method('get')
-          ->with('frozen')
-          ->willReturn(null);
+            ->method('isFrozen')
+            ->willReturn(false);
         $this->environment->expects($this->never())
           ->method('wipe');
         $this->logger->expects($this->never())

--- a/tests/unit_tests/Commands/Import/DatabaseCommandTest.php
+++ b/tests/unit_tests/Commands/Import/DatabaseCommandTest.php
@@ -83,9 +83,8 @@ class DatabaseCommandTest extends CommandTestCase
         $this->workflow->expects($this->never())
           ->method('checkProgress');
         $this->site->expects($this->once())
-          ->method('get')
-          ->with('frozen')
-          ->willReturn(null);
+            ->method('isFrozen')
+            ->willReturn(false);
         $this->logger->expects($this->never())
           ->method('log');
 

--- a/tests/unit_tests/Models/SiteTest.php
+++ b/tests/unit_tests/Models/SiteTest.php
@@ -424,6 +424,27 @@ class SiteTest extends ModelTestCase
     }
 
     /**
+     * Tests Site::isFrozen()
+     */
+    public function testIsFrozen()
+    {
+        $frozen = $this->model->isFrozen();
+        $this->assertEquals(false, $frozen);
+
+        $this->model->set('frozen', null);
+        $frozen = $this->model->isFrozen();
+        $this->assertEquals(false, $frozen);
+
+        $this->model->set('frozen', true);
+        $frozen = $this->model->isFrozen();
+        $this->assertEquals(true, $frozen);
+
+        $this->model->set('frozen', 'yes');
+        $frozen = $this->model->isFrozen();
+        $this->assertEquals(true, $frozen);
+    }
+
+    /**
      * Tests Site::removePaymentMethod()
      */
     public function testRemovePaymentMethod()

--- a/tests/unit_tests/Site/SiteAwareTraitTest.php
+++ b/tests/unit_tests/Site/SiteAwareTraitTest.php
@@ -56,9 +56,8 @@ class SiteAwareTraitTest extends CommandTestCase
         $this->environment->id = 'live';
 
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
-            ->willReturn(null);
+            ->method('isFrozen')
+            ->willReturn(false);
 
         list($site, $env) = $this->class->getUnfrozenSiteEnv("{$this->site->id}.{$this->environment->id}");
 
@@ -75,9 +74,8 @@ class SiteAwareTraitTest extends CommandTestCase
         $this->environment->id = 'live';
 
         $this->site->expects($this->once())
-            ->method('get')
-            ->with($this->equalTo('frozen'))
-            ->willReturn('anything but null');
+            ->method('isFrozen')
+            ->willReturn(true);
 
         $this->setExpectedException(
             TerminusException::class,


### PR DESCRIPTION
The API returns different values for a site which has never been frozen than it does for a site which was previously frozen and then unfrozen. This was causing a number of operations including environment deploy to fail on previously-frozen sites.