### PR TITLE
Require users to login to use upstream commands

### DIFF
--- a/src/Commands/Upstream/InfoCommand.php
+++ b/src/Commands/Upstream/InfoCommand.php
@@ -14,6 +14,8 @@ class InfoCommand extends TerminusCommand
     /**
      * Displays information about an upstream.
      *
+     * @authorize
+     *
      * @command upstream:info
      *
      * @param string $upstream Upstream name or UUID

--- a/src/Commands/Upstream/ListCommand.php
+++ b/src/Commands/Upstream/ListCommand.php
@@ -14,6 +14,8 @@ class ListCommand extends TerminusCommand
     /**
      * Displays the list of upstreams accessible to the currently logged-in user.
      *
+     * @authorize
+     *
      * @command upstream:list
      * @aliases upstreams
      *


### PR DESCRIPTION
The upstreams API is dependent on the user context in order to display upstream data. This PR adds the `@authorize` annotation to ensure users have an active session in order to use upstream commands which improves the UI giving people an appropriate message vs 404s against the API