### PR TITLE
AL-1133 - Prevented info log on site:upstream:set when no valid prev upstream on site

### DIFF
--- a/src/Commands/Site/Upstream/SetCommand.php
+++ b/src/Commands/Site/Upstream/SetCommand.php
@@ -31,10 +31,13 @@ class SetCommand extends SiteCommand
         if (!$this->confirm('Are you sure you want change the upstream for {site} to {upstream}?', $msg_params)) {
             return;
         }
-        $this->log()->info(
-            'To undo this change run `terminus site:upstream:set {site} {upstream}`',
-            ['site' => $site->id, 'upstream' => $site->getUpstream()->id,]
-        );
+        $previous_upstream_id = $site->getUpstream()->id;
+        if ($previous_upstream_id) {
+            $this->log()->info(
+                'To undo this change run `terminus site:upstream:set {site} {upstream}`',
+                ['site' => $site->id, 'upstream' => $previous_upstream_id,]
+            );
+        }
 
         $workflow = $site->setUpstream($upstream->id);
         while (!$workflow->checkProgress()) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/868204/30927407-3c3a955e-a36d-11e7-9af3-27d178b5f928.png)