### PR TITLE
Adds exponential backoff retries to http requests

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -253,9 +253,6 @@ class Request implements ConfigAwareInterface, ContainerAwareInterface, LoggerAw
                 usleep($sleep * 1000);
             }
         }
-
-        // Retry timeout exceeded. Throw an error.
-        new TerminusException('Unable to complete https request. Maximum retry timeout exceeded after {tries} attempts.', compact('tries'));
     }
 
     /**

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -126,19 +126,6 @@ class Request implements ConfigAwareInterface, ContainerAwareInterface, LoggerAw
      */
     public function request($path, array $options = [])
     {
-        $data = $this->send($path, $options);
-        return $data;
-    }
-
-    /**
-     * Sends a request to the API
-     *
-     * @param string $path API path (URL)
-     * @param array $arg_options Request parameters
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    private function send($path, array $options = [])
-    {
         // Set headers
         $headers = $this->getDefaultHeaders();
         if (isset($options['headers'])) {
@@ -169,8 +156,8 @@ class Request implements ConfigAwareInterface, ContainerAwareInterface, LoggerAw
         $method = isset($options['method']) ? strtoupper($options['method']) : 'GET';
 
         $client = $this->getContainer()->get(Client::class, [[
-            'base_uri' => $base_uri,
-            RequestOptions::VERIFY => (boolean)$this->getConfig()->get('verify_host_cert', true),
+           'base_uri' => $base_uri,
+           RequestOptions::VERIFY => (boolean)$this->getConfig()->get('verify_host_cert', true),
         ]]);
 
         $this->logger->debug(


### PR DESCRIPTION
This should prevent Terminus and the scripts that depend on it from failing when there are temporary network or platform issues.

This PR has each request perform retries on failure with exponential back off. The back off should prevent this functionality from overwhelming the platform when the issues are load-based. Terminus stops after a set number of retries. It does not retry on client errors (4xx) or too-many-redirect errors.

The requests back off by doubling the length of time between retries with each attempt. There is also a small amount of random jitter added to prevent clients from accidentally getting in lock-step and increasing concurrency.

Open questions:
* What is the appropriate initial interval between request retries?
* How many times should we retry before giving up?
* Do we need to alter our behavior for non-idempotent requests (PUTs etc.)?

