### PR TITLE
Remove custom progress bar formatting.

### DIFF
--- a/src/Style/TerminusStyle.php
+++ b/src/Style/TerminusStyle.php
@@ -13,8 +13,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class TerminusStyle extends SymfonyStyle
 {
-    const NORMAL_PROGRESS_FORMAT = " <bg=blue;fg=black> %message% </>\n <info>Progress: %bar% <info>%percent:3s%%</info> \n <info>Elapsed: %elapsed:6s% \n Estimated Time Remaining: %estimated:-6s%</info>";
-
     /**
      * TerminusStyle constructor.
      *
@@ -23,7 +21,6 @@ class TerminusStyle extends SymfonyStyle
      */
     public function __construct(InputInterface $input, OutputInterface $output)
     {
-        ProgressBar::setFormatDefinition('normal', self::NORMAL_PROGRESS_FORMAT);
         parent::__construct($input, $output);
     }
 }

--- a/src/Style/TerminusStyle.php
+++ b/src/Style/TerminusStyle.php
@@ -13,14 +13,4 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class TerminusStyle extends SymfonyStyle
 {
-    /**
-     * TerminusStyle constructor.
-     *
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     */
-    public function __construct(InputInterface $input, OutputInterface $output)
-    {
-        parent::__construct($input, $output);
-    }
 }


### PR DESCRIPTION
Terminus defines a custom progress bar format via `ProgressBar::setFormatDefinition()`. This changes the format definitions for all progress bars used directly by Terminus, and also applies the same format to progress bars used indirectly by Terminus, e.g. in Robo collections defined by Terminus plugins like the Terminus Build Tools Plugin.

This causes a couple problems:

- The custom style defines `%message%`. This replacement does not exist in the default progress definition, so Robo collection progress bars print a literal string `%message%`, as they do not provide any substitution for this value.
- The custom style contains newline characters, which causes the progress bar to span several lines. When Robo collections hide and re-display the progress bar, the output is not adequately cleaned up, leaving garbage on the screen. Worse, the garbage overwrites some of the status messages, so the user loses some of the important info lines. e.g. the "success" message that prints the URL to your new repository at the end of the build:project:create command is not readable.

It does not appear that Terminus itself is using the progress bar at all. It would be best to just take this out completely until Terminus is ready to use a progress bar, and then fix up the formatting later. Ideally, a single-line format will be used. All of the examples in the Symfony documentation are laid out on a single line. From the observed symptoms here, it seems that the Symfony progress bar does not hide / show correctly when the progress bar spans multiple lines.