### PR TITLE
Fixes #1797: clear workflow data 

### DIFF
--- a/src/Commands/Workflow/WatchCommand.php
+++ b/src/Commands/Workflow/WatchCommand.php
@@ -50,6 +50,8 @@ class WatchCommand extends TerminusCommand implements SiteAwareInterface
             $last_wf_created_at = $site->getWorkflows()->lastCreatedAt();
             $last_wf_finished_at = $site->getWorkflows()->lastFinishedAt();
             sleep(self::WORKFLOWS_WATCH_INTERVAL);
+            // Clear cached data
+            $site->getWorkflows()->setData([]);
             $site->getWorkflows()->fetchWithOperations();
 
             $workflows = $site->getWorkflows()->all();


### PR DESCRIPTION
The workflow:watch command makes no progress without this, because otherwise it pulls the same cached workflow data every time.