### PR TITLE
Do not warn if ssh key is missing a comment field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 ## MASTER
 ### Fixed
 - Removed the prompt displayed when running Drush or WP-CLI commands on a Pantheon server to avoid locking up auotmation scripts. (#1881)
+- Fixed php warning when ssh key is missing its comment field. (#1843)
 
 ## 1.8.1 - 2018-06-08
 ### Fixed

--- a/src/Models/SSHKey.php
+++ b/src/Models/SSHKey.php
@@ -40,7 +40,7 @@ class SSHKey extends TerminusModel implements UserInterface
     public function getComment()
     {
         $key_parts = explode(' ', $this->get('key'));
-        $comment = $key_parts[2];
+        $comment = isset($key_parts[2]) ? $key_parts[2] : '';
         return $comment;
     }
 


### PR DESCRIPTION
Very minor, but `ssh:key:list` can throw a php warning for ssh keys that have no comment field.