### PR TITLE
Fix incorrect message when deleting site. Closes #1856

### DIFF
--- a/src/Commands/Site/DeleteCommand.php
+++ b/src/Commands/Site/DeleteCommand.php
@@ -27,7 +27,13 @@ class DeleteCommand extends SiteCommand
             return;
         }
 
-        $site->delete();
-        $this->log()->notice('Deleted {site} from Pantheon', ['site' => $site_name,]);
+        // This is a holdover until Pantheon\Terminus\Models\Site's delete()
+        // function is refactored to use workflows.
+        if ($site->get('service_level') != 'free') {
+            $this->log()->warning('You must downgrade {site} to free tier before deleting', ['site' => $site_name,]);
+        } else {
+            $site->delete();
+            $this->log()->notice('Deleted {site} from Pantheon', ['site' => $site_name,]);
+        }
     }
 }

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -125,6 +125,8 @@ class Site extends TerminusModel implements ConfigAwareInterface, ContainerAware
     {
         $this->request()->request("sites/{$this->id}", ['method' => 'delete',]);
         //TODO: Change this function to use a workflow. The workflow returned always gets 404 on status check.
+        //TODO: After converting this function to use workflows, refactor
+        //      Pantheon\Terminus\Commands\Site\DeleteCommand to display correct message.
         //return $this->workflows->create('delete_site');
     }
 


### PR DESCRIPTION
This is not intended as a long term solution, but at least terminus won't display an incorrect message for now. It looks like the eventual plan is to refactor Site->delete() to use workflows and that's where we'll ultimately want the correct message to be generated.