### PR TITLE
Ignore dependencies in lock file not installed in plugin vendor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## MASTER
 ### Fixed
-- Removed the prompt displayed when running Drush or WP-CLI commands on a Pantheon server to avoid locking up auotmation scripts. (#1881)
+- Removed the prompt displayed when running Drush or wp-cli commands on a Pantheon server to avoid locking up auotmation scripts. (#1881)
+- Prevent spurious dependency validation failures with Terminus plugins that have `dev` components named in their composer.lock file that have not been installed. (#1880)
 
 ## 1.8.1 - 2018-06-08
 ### Fixed


### PR DESCRIPTION
If a plugin has dependencies that are in the 'require-dev', because they are needed for the tests, but not to run the plugin, then we should not require version matches between the plugin's lock file and terminus' lock file unless said dev dependencies actually exist in the plugin's vendor directory.

This change allows us to install a plugin with 'composer install --no-dev' in order to make a plugin install that has less revlocking with Terminus.