### PR TITLE
Fixes #1873: disable strict key checking for remote commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## MASTER
+### Fixed
+- Removed the prompt displayed when running Drush or wp-cli commands on a Pantheon server to avoid locking up auotmation scripts.
+
 ## 1.8.1 - 2018-06-08
 ### Fixed
 - Fixed bug wherein messages that are passed in as arrays to TerminusException cause failure. (#1863)

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -731,7 +731,7 @@ class Environment extends TerminusModel implements ConfigAwareInterface, Contain
     {
         $sftp = $this->sftpConnectionInfo();
         $ssh_command = vsprintf(
-            'ssh -T %s@%s -p %s -o "AddressFamily inet" %s',
+            'ssh -T %s@%s -p %s -o "StrictHostKeyChecking=no" -o "AddressFamily inet" %s',
             [$sftp['username'], $sftp['host'], $sftp['port'], ProcessUtils::escapeArgument($command),]
         );
 

--- a/tests/unit_tests/Models/EnvironmentTest.php
+++ b/tests/unit_tests/Models/EnvironmentTest.php
@@ -846,7 +846,7 @@ class EnvironmentTest extends ModelTestCase
         $expected = ['output' => 'Hello, World!', 'exit_code' => 0,];
         $this->local_machine->expects($this->at(0))
             ->method('execInteractive')
-            ->with('ssh -T dev.abc@appserver.dev.abc.drush.in -p 2222 -o "AddressFamily inet" ' . $expectedCommand)
+            ->with('ssh -T dev.abc@appserver.dev.abc.drush.in -p 2222 -o "StrictHostKeyChecking=no" -o "AddressFamily inet" ' . $expectedCommand)
             ->willReturn($expected);
 
         $actual = $this->model->sendCommandViaSsh($command);
@@ -856,7 +856,7 @@ class EnvironmentTest extends ModelTestCase
         $expected = [
             'output' => "Terminus is in test mode. "
                 . "Environment::sendCommandViaSsh commands will not be sent over the wire. "
-                . "SSH Command: ssh -T dev.abc@appserver.dev.abc.drush.in -p 2222 -o \"AddressFamily inet\" $expectedCommand",
+                . "SSH Command: ssh -T dev.abc@appserver.dev.abc.drush.in -p 2222 -o \"StrictHostKeyChecking=no\" -o \"AddressFamily inet\" $expectedCommand",
             'exit_code' => 0
         ];
 


### PR DESCRIPTION
Don't prompt when users connect to a new app server.