### PR TITLE
Build a Terminus phar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+# https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
+defaults: &defaults
+  working_directory: ~/terminus
+  docker:
+    - image: quay.io/pantheon-public/php-ci:1.x
+  environment:
+    TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    TERM: dumb
+
+version: 2.1
+jobs:
+  functional:
+    <<: *defaults
+    steps:
+      - checkout
+      # Install without dev components to build a smaller phar
+      - run: composer install --no-dev --no-interaction --prefer-dist
+      - run: composer phar:install-tools
+      - run: composer phar:build
+      # Re-install with dev components so that we can run phpunit
+      - run: composer install --no-interaction --prefer-dist
+      - run: composer functional
+
+workflows:
+  version: 2
+  terminus:
+    jobs:
+      - functional

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
 /*.phar
 /builds
+/tools
 /tests/logs
 
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,18 @@ cache:
   directories:
     - $HOME/.cache/composer
     - $HOME/.composer/cache
+
+before_deploy:
+  - composer phar:install-tools
+  - composer install --prefer-dist --no-dev --no-interaction
+  - composer phar:build
+
+deploy:
+  provider: releases
+  api_key:
+    secure: LQSoZ2NKrPq+C4Ho1brcSCHKmQ7oWphvZY7wKurcaRm0hE7cTjk7Y3FTb2YaPTgO7mRaK0wQRzfR7iBOcW1vvU+0va0TvahameR8RnN9iI6V1NMJMtasBJoCy2dGlA5Wv1O37A4ueLTgPJHPmnTzFxbnxoEY/lDDOsvP73mKY20=
+  file: terminus.phar
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: pantheon-systems/terminus

--- a/bin/terminus
+++ b/bin/terminus
@@ -9,7 +9,10 @@
  *   - Exits with a status code
  */
 
-if (file_exists($path = __DIR__ . '/../vendor/autoload.php')
+$pharPath = \Phar::running(true);
+if ($pharPath) {
+    include_once("$pharPath/vendor/autoload.php");
+} elseif (file_exists($path = __DIR__ . '/../vendor/autoload.php')
     || file_exists($path = __DIR__ . '/../../autoload.php')
     || file_exists($path = __DIR__ . '/../../../autoload.php')
 ) {

--- a/box.json
+++ b/box.json
@@ -1,0 +1,25 @@
+{
+  "alias": "terminus.phar",
+  "chmod": "0755",
+  "compactors": [],
+  "directories": ["assets", "bin", "config", "docs", "src"],
+  "files": ["README.md"],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": [
+        "test",
+        "tests",
+        "Test",
+        "Tests",
+        "Tester"
+      ],
+      "in": "vendor"
+    }
+  ],
+  "git-commit": "git-commit",
+  "git-version": "git-version",
+  "output": "terminus.phar",
+  "main": "bin/terminus",
+  "stub": true
+}

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,16 @@
     "bin/terminus"
   ],
   "scripts": {
+      "phar:install-tools": [
+        "gem install mime-types -v 2.6.2",
+        "curl -LSs https://box-project.github.io/box2/installer.php | php",
+        "mkdir -p tools",
+        "mv -f box.phar tools/box"
+      ],
+      "phar:build": "env PATH=tools:$PATH box build",
+      "release": [
+          "release --pattern=\"^TERMINUS_VERSION:[ \t]*'SEMVER'$\" config/constants.yml"
+      ],
       "behat": "SHELL_INTERACTIVE=true behat --colors -c=tests/config/behat.yml --suite=default",
       "cbf": "phpcbf --standard=PSR2 -n tests/unit_tests/* bin/terminus src/*",
       "clover": "phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml",

--- a/composer.json
+++ b/composer.json
@@ -53,12 +53,13 @@
       "docs": "php scripts/make-docs.php",
       "lint": "@cs",
       "phpunit": "SHELL_INTERACTIVE=true phpunit --colors=always  -c tests/config/phpunit.xml.dist --debug",
-      "test": "set -ex ; composer cs ; composer phpunit ; composer behat"
+      "functional": "phpunit --colors=always -c tests/config/functional.phpunit.xml.dist --debug",
+      "test": "set -ex ; composer cs ; composer phpunit ; composer behat ; composer functional"
   },
   "require-dev": {
     "behat/behat": "^3.2.2",
     "php-vcr/php-vcr": "^1.4",
-    "phpunit/phpunit": "^4.0",
+    "phpunit/phpunit": "^4.8.36",
     "php-coveralls/php-coveralls": "^2.1",
     "sebastian/phpcpd": "^2.0",
     "squizlabs/php_codesniffer": "^2.7"

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,6 @@
       ],
       "phar:build": "env PATH=tools:$PATH box build",
       "update-class-lists": ["\\Terminus\\UpdateClassLists::update"],
-      "release": [
-          "release --pattern=\"^TERMINUS_VERSION:[ \t]*'SEMVER'$\" config/constants.yml"
-      ],
       "behat": "SHELL_INTERACTIVE=true behat --colors -c=tests/config/behat.yml --suite=default",
       "cbf": "phpcbf --standard=PSR2 -n tests/unit_tests/* bin/terminus src/*",
       "clover": "phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "psr-4": {
       "Pantheon\\Terminus\\UnitTests\\": "tests/unit_tests/",
       "Pantheon\\Terminus\\FeatureTests\\": "tests/features/bootstrap/"
-    }
+    },
+    "classmap": ["scripts/UpdateClassLists.php"]
   },
   "bin": [
     "bin/terminus"
@@ -40,6 +41,7 @@
         "mv -f box.phar tools/box"
       ],
       "phar:build": "env PATH=tools:$PATH box build",
+      "update-class-lists": ["\\Terminus\\UpdateClassLists::update"],
       "release": [
           "release --pattern=\"^TERMINUS_VERSION:[ \t]*'SEMVER'$\" config/constants.yml"
       ],

--- a/composer.lock
+++ b/composer.lock
@@ -70,16 +70,16 @@
         },
         {
             "name": "consolidation/annotated-command",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "288593672a8ca9ead2c73a8bfbfa4737862bfd6a"
+                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/288593672a8ca9ead2c73a8bfbfa4737862bfd6a",
-                "reference": "288593672a8ca9ead2c73a8bfbfa4737862bfd6a",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
+                "reference": "5cbb8c320e0d3d2e6905374d56dc3610b7443f7b",
                 "shasum": ""
             },
             "require": {
@@ -162,7 +162,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2018-12-14T01:52:35+00:00"
+            "time": "2018-12-21T03:50:15+00:00"
         },
         {
             "name": "consolidation/config",
@@ -325,20 +325,20 @@
         },
         {
             "name": "consolidation/robo",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "01789e1c4f3b0d7e5b4ee0aca1843a9438ff4983"
+                "reference": "8cdaf834d378d7700cf0c7e8b2b57a00025d8dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/01789e1c4f3b0d7e5b4ee0aca1843a9438ff4983",
-                "reference": "01789e1c4f3b0d7e5b4ee0aca1843a9438ff4983",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/8cdaf834d378d7700cf0c7e8b2b57a00025d8dd3",
+                "reference": "8cdaf834d378d7700cf0c7e8b2b57a00025d8dd3",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "^2.10.1",
+                "consolidation/annotated-command": "^2.10.2",
                 "consolidation/config": "^1.0.10",
                 "consolidation/log": "~1",
                 "consolidation/output-formatters": "^3.1.13",
@@ -429,7 +429,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2018-12-14T02:54:30+00:00"
+            "time": "2018-12-21T04:14:26+00:00"
         },
         {
             "name": "consolidation/self-update",
@@ -3823,20 +3823,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -3869,7 +3870,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/scripts/UpdateClassLists.php
+++ b/scripts/UpdateClassLists.php
@@ -118,7 +118,7 @@ __EOT__;
             if (strpos($file, 'abstract class') === false) {
                 preg_match('/namespace (.*?);/', $file, $namespace);
                 preg_match('/class (.*?) /', $file, $class);
-                $result[] = $namespace[1] . '\\' . $class[1];
+                $result[] = '\\' . $namespace[1] . '\\' . $class[1];
             }
         }
         return $result;

--- a/scripts/UpdateClassLists.php
+++ b/scripts/UpdateClassLists.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Terminus;
+
+use Consolidation\AnnotatedCommand\CommandFileDiscovery;
+use Symfony\Component\Finder\Finder;
+
+class UpdateClassLists
+{
+    static function update()
+    {
+        $base = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
+        $commands = static::getCommands(
+            $base . 'Commands',
+            'Pantheon\Terminus\Commands'
+        );
+        $hooks = static::getHooks(
+            $base . 'Hooks',
+            'Pantheon\Terminus\Hooks'
+        );
+        sort($hooks);
+        sort($commands);
+        $all = array_merge($hooks, $commands);
+        $all = array_map(
+            function ($item) {
+                return str_replace('\\', '\\\\', var_export($item, true));
+            },
+            $all
+        );
+
+        $lineBreak = "\n            ";
+        $commandList = $lineBreak . implode(",$lineBreak", $all);
+
+        $srcPath = $base . 'Terminus.php';
+        $contents = file_get_contents($srcPath);
+
+        $header = "// List of all hooks and commands. Update via 'composer update-class-lists'";
+        $replacement = $header . "\n" . <<<__EOT__
+        \$this->commands = [$commandList
+        ];
+__EOT__;
+
+        $contents = preg_replace("#{$header}[^;]*;#ms", $replacement, $contents);
+
+        $models = static::getClassesInDir($base . 'Models');
+        $collections = static::getClassesInDir($base . 'Collections');
+
+        $header = "// List of all Models and Collections. Update via 'composer update-class-lists'";
+        $replacement = $header . "\n" .
+            static::generateAddToContainerCode('Models', $models) .
+            "\n" .
+            static::generateAddToContainerCode('Collections', $collections);
+
+        $contents = preg_replace("#{$header}[^}]*;#ms", $replacement, $contents);
+
+        file_put_contents($srcPath, $contents);
+    }
+
+    static function generateAddToContainerCode($what, $classList)
+    {
+        sort($classList);
+
+        $lineBreak = "\n        ";
+        return
+            "{$lineBreak}// {$what}{$lineBreak}" .
+            implode(
+                $lineBreak,
+                array_map(
+                    function ($item) {
+                        return "\$container->add({$item}::class);";
+                    },
+                    $classList
+                )
+            );
+    }
+
+    /**
+     * Discovers command classes using CommandFileDiscovery
+     *
+     * @param string[] $options Elements as follow
+     *        string path      The full path to the directory to search for commands
+     *        string namespace The full namespace associated with given the command directory
+     * @return TerminusCommand[] An array of TerminusCommand instances
+     */
+    static function getCommands($path, $baseNamespace)
+    {
+        $discovery = new CommandFileDiscovery();
+        $discovery->setSearchPattern('*Command.php')->setSearchLocations([]);
+        return $discovery->discover($path, $baseNamespace);
+    }
+
+    /**
+     * Discovers hook classes using CommandFileDiscovery
+     *
+     * @param string[] $options Elements as follow
+     *        string path      The full path to the directory to search for hooks
+     *        string namespace The full namespace associated with given the hooks directory
+     * @return array An array of hook instances
+     */
+    static function getHooks($path, $baseNamespace)
+    {
+        $discovery = new CommandFileDiscovery();
+        $discovery->setSearchPattern('*.php')->setSearchLocations([]);
+        return $discovery->discover($path, $baseNamespace);
+    }
+
+    /**
+     * Adds every non-abstract class in a directory to the container
+     *
+     * @param string $path
+     */
+    static function getClassesInDir($path)
+    {
+        $result = [];
+        $files = Finder::create()->files()->in($path)->name('*.php');
+        foreach ($files as $file) {
+            $file = str_replace(PHP_EOL, ' ', file_get_contents($file->getRealpath()));
+            if (strpos($file, 'abstract class') === false) {
+                preg_match('/namespace (.*?);/', $file, $namespace);
+                preg_match('/class (.*?) /', $file, $class);
+                $result[] = $namespace[1] . '\\' . $class[1];
+            }
+        }
+        return $result;
+    }
+
+}

--- a/src/Config/DefaultsConfig.php
+++ b/src/Config/DefaultsConfig.php
@@ -61,6 +61,10 @@ class DefaultsConfig extends TerminusConfig
         if (file_exists($current_dir . DIRECTORY_SEPARATOR . 'composer.json')) {
             return $current_dir;
         }
+        $pharPath = \Phar::running(true);
+        if ($pharPath) {
+            return $pharPath;
+        }
         $dir = explode(DIRECTORY_SEPARATOR, $current_dir);
         array_pop($dir);
         if (empty($dir)) {

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -122,134 +122,128 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
      */
     private function addBuiltInCommandsAndHooks()
     {
-/*
-        $commands = $this->getCommands([
-            'path' => __DIR__ . '/Commands',
-            'namespace' => 'Pantheon\Terminus\Commands',
-        ]);
-        $hooks = [
-            'Pantheon\Terminus\Hooks\Authorizer',
-        ];
-        $this->commands = array_merge($commands, $hooks);
-*/
+        // List of all hooks and commands. Update via 'composer update-class-lists'
         $this->commands = [
             'Pantheon\\Terminus\\Hooks\\Authorizer',
-            'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\HTTPS\\SetCommand',
-            'Pantheon\\Terminus\\Commands\\HTTPS\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteAllCommand',
-            'Pantheon\\Terminus\\Commands\\MachineToken\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteCommand',
-            'Pantheon\\Terminus\\Commands\\Branch\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\PaymentMethod\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\PaymentMethod\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\PaymentMethod\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Owner\\SetCommand',
-            'Pantheon\\Terminus\\Commands\\Connection\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Connection\\SetCommand',
-            'Pantheon\\Terminus\\Commands\\Redis\\EnableCommand',
-            'Pantheon\\Terminus\\Commands\\Redis\\DisableCommand',
-            'Pantheon\\Terminus\\Commands\\Auth\\WhoamiCommand',
+            'Pantheon\\Terminus\\Commands\\AliasesCommand',
+            'Pantheon\\Terminus\\Commands\\ArtCommand',
             'Pantheon\\Terminus\\Commands\\Auth\\LoginCommand',
             'Pantheon\\Terminus\\Commands\\Auth\\LogoutCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\People\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\People\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\People\\RoleCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\People\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\Site\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\Site\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Org\\Upstream\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\AliasesCommand',
-            'Pantheon\\Terminus\\Commands\\Lock\\EnableCommand',
-            'Pantheon\\Terminus\\Commands\\Lock\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Lock\\DisableCommand',
-            'Pantheon\\Terminus\\Commands\\ServiceLevel\\SetCommand',
-            'Pantheon\\Terminus\\Commands\\Solr\\EnableCommand',
-            'Pantheon\\Terminus\\Commands\\Solr\\DisableCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\CommitCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\MetricsCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\DiffStatCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\DeployCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
-            'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
+            'Pantheon\\Terminus\\Commands\\Auth\\WhoamiCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\BackupCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\CreateCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\GetCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\RestoreCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\SingleBackupCommand',
+            'Pantheon\\Terminus\\Commands\\Branch\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Connection\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Connection\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Dashboard\\ViewCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\DNSCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\LookupCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ClearCacheCommand',
             'Pantheon\\Terminus\\Commands\\Env\\CloneContentCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\CommitCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\DeployCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\DiffStatCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\MetricsCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ViewCommand',
-            'Pantheon\\Terminus\\Commands\\ArtCommand',
-            'Pantheon\\Terminus\\Commands\\Dashboard\\ViewCommand',
-            'Pantheon\\Terminus\\Commands\\Multidev\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\CompleteCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\DatabaseCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\FilesCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\SiteCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteAllCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Multidev\\CreateCommand',
             'Pantheon\\Terminus\\Commands\\Multidev\\DeleteCommand',
-            'Pantheon\\Terminus\\Commands\\Multidev\\MergeToDevCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Multidev\\MergeFromDevCommand',
-            'Pantheon\\Terminus\\Commands\\Self\\ConfigDumpCommand',
-            'Pantheon\\Terminus\\Commands\\Self\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Self\\ConsoleCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\MergeToDevCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\RoleCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Site\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Site\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Upstream\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Owner\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Plan\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Plan\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Plan\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Redis\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Redis\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\DrushCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\SSHBaseCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\WPCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\RemoveCommand',
             'Pantheon\\Terminus\\Commands\\Self\\ClearCacheCommand',
-            'Pantheon\\Terminus\\Commands\\Workflow\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\ConfigDumpCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\ConsoleCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\ServiceLevel\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\CreateCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\DeleteCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\LookupCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\SiteCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\RoleCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\ClearCacheCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Solr\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Solr\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\TagCommand',
+            'Pantheon\\Terminus\\Commands\\TerminusCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ApplyCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\StatusCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\UpdatesCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\InfoBaseCommand',
             'Pantheon\\Terminus\\Commands\\Workflow\\Info\\LogsCommand',
             'Pantheon\\Terminus\\Commands\\Workflow\\Info\\OperationsCommand',
             'Pantheon\\Terminus\\Commands\\Workflow\\Info\\StatusCommand',
-            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\InfoBaseCommand',
-            'Pantheon\\Terminus\\Commands\\Workflow\\WatchCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\LookupCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\SiteCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Org\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Org\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Org\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Team\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Team\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Team\\RoleCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Team\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\CreateCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\DeleteCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\SetCommand',
-            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\ClearCacheCommand',
-            'Pantheon\\Terminus\\Commands\\NewRelic\\EnableCommand',
-            'Pantheon\\Terminus\\Commands\\NewRelic\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\NewRelic\\DisableCommand',
-            'Pantheon\\Terminus\\Commands\\SSHKey\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\SSHKey\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\SSHKey\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\GetCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\SingleBackupCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\RestoreCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\EnableCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\DisableCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\CreateCommand',
-            'Pantheon\\Terminus\\Commands\\Backup\\BackupCommand',
-            'Pantheon\\Terminus\\Commands\\Import\\DatabaseCommand',
-            'Pantheon\\Terminus\\Commands\\Import\\SiteCommand',
-            'Pantheon\\Terminus\\Commands\\Import\\CompleteCommand',
-            'Pantheon\\Terminus\\Commands\\Import\\FilesCommand',
-            'Pantheon\\Terminus\\Commands\\Domain\\LookupCommand',
-            'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Domain\\DNSCommand',
-            'Pantheon\\Terminus\\Commands\\Domain\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\Domain\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Tag\\RemoveCommand',
-            'Pantheon\\Terminus\\Commands\\Tag\\AddCommand',
-            'Pantheon\\Terminus\\Commands\\Tag\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Tag\\TagCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\InfoCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\UpdatesCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ApplyCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\StatusCommand',
-            'Pantheon\\Terminus\\Commands\\Upstream\\ListCommand',
-            'Pantheon\\Terminus\\Commands\\TerminusCommand',
-            'Pantheon\\Terminus\\Commands\\Remote\\SSHBaseCommand',
-            'Pantheon\\Terminus\\Commands\\Remote\\DrushCommand',
-            'Pantheon\\Terminus\\Commands\\Remote\\WPCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\WatchCommand'
         ];
     }
 
@@ -263,25 +257,6 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $app->getDefinition()->addOption(
             new InputOption('--yes', '-y', InputOption::VALUE_NONE, 'Answer all confirmations with "yes"')
         );
-    }
-
-    /**
-     * Adds every non-abstract class in a directory to the container
-     *
-     * @param string $relative_dir
-     */
-    private function addDirToContainer($relative_dir)
-    {
-        $container = $this->getContainer();
-        $files = Finder::create()->files()->in(__DIR__ . DIRECTORY_SEPARATOR . $relative_dir)->name('*.php');
-        foreach ($files as $file) {
-            $file = str_replace(PHP_EOL, ' ', file_get_contents($file->getRealpath()));
-            if (strpos($file, 'abstract class') === false) {
-                preg_match('/namespace (.*?);/', $file, $namespace);
-                preg_match('/class (.*?) /', $file, $class);
-                $container->add($namespace[1] . '\\' . $class[1]);
-            }
-        }
     }
 
     /**
@@ -335,74 +310,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $container->inflector(SavedTokens::class)
             ->invokeMethod('setDataStore', [$token_store]);
 
-/*
-        // Add the models and collections
-        $this->addDirToContainer('Models');
-        $this->addDirToContainer('Collections');
-*/
-        // Models
-        $container->add(\Pantheon\Terminus\Models\Backup::class);
-        $container->add(\Pantheon\Terminus\Models\Binding::class);
-        $container->add(\Pantheon\Terminus\Models\Branch::class);
-        $container->add(\Pantheon\Terminus\Models\Commit::class);
-        $container->add(\Pantheon\Terminus\Models\DNSRecord::class);
-        $container->add(\Pantheon\Terminus\Models\Domain::class);
-        $container->add(\Pantheon\Terminus\Models\Environment::class);
-        $container->add(\Pantheon\Terminus\Models\Lock::class);
-        $container->add(\Pantheon\Terminus\Models\MachineToken::class);
-        $container->add(\Pantheon\Terminus\Models\Metric::class);
-        $container->add(\Pantheon\Terminus\Models\NewRelic::class);
-        $container->add(\Pantheon\Terminus\Models\Organization::class);
-        $container->add(\Pantheon\Terminus\Models\OrganizationSiteMembership::class);
-        $container->add(\Pantheon\Terminus\Models\OrganizationUpstream::class);
-        $container->add(\Pantheon\Terminus\Models\OrganizationUserMembership::class);
-        $container->add(\Pantheon\Terminus\Models\PaymentMethod::class);
-        $container->add(\Pantheon\Terminus\Models\Profile::class);
-        $container->add(\Pantheon\Terminus\Models\Redis::class);
-        $container->add(\Pantheon\Terminus\Models\SavedToken::class);
-        $container->add(\Pantheon\Terminus\Models\Site::class);
-        $container->add(\Pantheon\Terminus\Models\SiteAuthorization::class);
-        $container->add(\Pantheon\Terminus\Models\SiteOrganizationMembership::class);
-        $container->add(\Pantheon\Terminus\Models\SiteUpstream::class);
-        $container->add(\Pantheon\Terminus\Models\SiteUserMembership::class);
-        $container->add(\Pantheon\Terminus\Models\Solr::class);
-        $container->add(\Pantheon\Terminus\Models\SSHKey::class);
-        $container->add(\Pantheon\Terminus\Models\Tag::class);
-        $container->add(\Pantheon\Terminus\Models\Upstream::class);
-        $container->add(\Pantheon\Terminus\Models\UpstreamStatus::class);
-        $container->add(\Pantheon\Terminus\Models\User::class);
-        $container->add(\Pantheon\Terminus\Models\UserOrganizationMembership::class);
-        $container->add(\Pantheon\Terminus\Models\UserSiteMembership::class);
-        $container->add(\Pantheon\Terminus\Models\Workflow::class);
-        $container->add(\Pantheon\Terminus\Models\WorkflowOperation::class);
-
-        // Collections
-        $container->add(\Pantheon\Terminus\Collections\Backups::class);
-        $container->add(\Pantheon\Terminus\Collections\Bindings::class);
-        $container->add(\Pantheon\Terminus\Collections\Branches::class);
-        $container->add(\Pantheon\Terminus\Collections\Commits::class);
-        $container->add(\Pantheon\Terminus\Collections\DNSRecords::class);
-        $container->add(\Pantheon\Terminus\Collections\Domains::class);
-        $container->add(\Pantheon\Terminus\Collections\EnvironmentMetrics::class);
-        $container->add(\Pantheon\Terminus\Collections\Environments::class);
-        $container->add(\Pantheon\Terminus\Collections\MachineTokens::class);
-        $container->add(\Pantheon\Terminus\Collections\OrganizationSiteMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\OrganizationUpstreams::class);
-        $container->add(\Pantheon\Terminus\Collections\OrganizationUserMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\PaymentMethods::class);
-        $container->add(\Pantheon\Terminus\Collections\SavedTokens::class);
-        $container->add(\Pantheon\Terminus\Collections\SiteAuthorizations::class);
-        $container->add(\Pantheon\Terminus\Collections\SiteMetrics::class);
-        $container->add(\Pantheon\Terminus\Collections\SiteOrganizationMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\Sites::class);
-        $container->add(\Pantheon\Terminus\Collections\SiteUserMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\SSHKeys::class);
-        $container->add(\Pantheon\Terminus\Collections\Tags::class);
-        $container->add(\Pantheon\Terminus\Collections\Upstreams::class);
-        $container->add(\Pantheon\Terminus\Collections\UserOrganizationMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\UserSiteMemberships::class);
-        $container->add(\Pantheon\Terminus\Collections\WorkflowOperations::class);
-        $container->add(\Pantheon\Terminus\Collections\Workflows::class);
+        $this->configureModulesAndCollections();
 
         // Helpers
         $container->add(LocalMachineHelper::class);
@@ -438,19 +346,77 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $factory->hookManager()->addInitializeHook($pluginAutoloadDependencies);
     }
 
-    /**
-     * Discovers command classes using CommandFileDiscovery
-     *
-     * @param string[] $options Elements as follow
-     *        string path      The full path to the directory to search for commands
-     *        string namespace The full namespace associated with given the command directory
-     * @return TerminusCommand[] An array of TerminusCommand instances
-     */
-    private function getCommands(array $options = ['path' => null, 'namespace' => null,])
+    private function configureModulesAndCollections()
     {
-        $discovery = new CommandFileDiscovery();
-        $discovery->setSearchPattern('*Command.php')->setSearchLocations([]);
-        return $discovery->discover($options['path'], $options['namespace']);
+        $container = $this->getContainer();
+
+        // List of all Models and Collections. Update via 'composer update-class-lists'
+
+        // Models
+        $container->add(Pantheon\Terminus\Models\Backup::class);
+        $container->add(Pantheon\Terminus\Models\Binding::class);
+        $container->add(Pantheon\Terminus\Models\Branch::class);
+        $container->add(Pantheon\Terminus\Models\Commit::class);
+        $container->add(Pantheon\Terminus\Models\DNSRecord::class);
+        $container->add(Pantheon\Terminus\Models\Domain::class);
+        $container->add(Pantheon\Terminus\Models\Environment::class);
+        $container->add(Pantheon\Terminus\Models\Lock::class);
+        $container->add(Pantheon\Terminus\Models\MachineToken::class);
+        $container->add(Pantheon\Terminus\Models\Metric::class);
+        $container->add(Pantheon\Terminus\Models\NewRelic::class);
+        $container->add(Pantheon\Terminus\Models\Organization::class);
+        $container->add(Pantheon\Terminus\Models\OrganizationSiteMembership::class);
+        $container->add(Pantheon\Terminus\Models\OrganizationUpstream::class);
+        $container->add(Pantheon\Terminus\Models\OrganizationUserMembership::class);
+        $container->add(Pantheon\Terminus\Models\PaymentMethod::class);
+        $container->add(Pantheon\Terminus\Models\Plan::class);
+        $container->add(Pantheon\Terminus\Models\Profile::class);
+        $container->add(Pantheon\Terminus\Models\Redis::class);
+        $container->add(Pantheon\Terminus\Models\SSHKey::class);
+        $container->add(Pantheon\Terminus\Models\SavedToken::class);
+        $container->add(Pantheon\Terminus\Models\Site::class);
+        $container->add(Pantheon\Terminus\Models\SiteAuthorization::class);
+        $container->add(Pantheon\Terminus\Models\SiteOrganizationMembership::class);
+        $container->add(Pantheon\Terminus\Models\SiteUpstream::class);
+        $container->add(Pantheon\Terminus\Models\SiteUserMembership::class);
+        $container->add(Pantheon\Terminus\Models\Solr::class);
+        $container->add(Pantheon\Terminus\Models\Tag::class);
+        $container->add(Pantheon\Terminus\Models\Upstream::class);
+        $container->add(Pantheon\Terminus\Models\UpstreamStatus::class);
+        $container->add(Pantheon\Terminus\Models\User::class);
+        $container->add(Pantheon\Terminus\Models\UserOrganizationMembership::class);
+        $container->add(Pantheon\Terminus\Models\UserSiteMembership::class);
+        $container->add(Pantheon\Terminus\Models\Workflow::class);
+        $container->add(Pantheon\Terminus\Models\WorkflowOperation::class);
+
+        // Collections
+        $container->add(Pantheon\Terminus\Collections\Backups::class);
+        $container->add(Pantheon\Terminus\Collections\Bindings::class);
+        $container->add(Pantheon\Terminus\Collections\Branches::class);
+        $container->add(Pantheon\Terminus\Collections\Commits::class);
+        $container->add(Pantheon\Terminus\Collections\DNSRecords::class);
+        $container->add(Pantheon\Terminus\Collections\Domains::class);
+        $container->add(Pantheon\Terminus\Collections\EnvironmentMetrics::class);
+        $container->add(Pantheon\Terminus\Collections\Environments::class);
+        $container->add(Pantheon\Terminus\Collections\MachineTokens::class);
+        $container->add(Pantheon\Terminus\Collections\OrganizationSiteMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\OrganizationUpstreams::class);
+        $container->add(Pantheon\Terminus\Collections\OrganizationUserMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\PaymentMethods::class);
+        $container->add(Pantheon\Terminus\Collections\Plans::class);
+        $container->add(Pantheon\Terminus\Collections\SSHKeys::class);
+        $container->add(Pantheon\Terminus\Collections\SavedTokens::class);
+        $container->add(Pantheon\Terminus\Collections\SiteAuthorizations::class);
+        $container->add(Pantheon\Terminus\Collections\SiteMetrics::class);
+        $container->add(Pantheon\Terminus\Collections\SiteOrganizationMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\SiteUserMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\Sites::class);
+        $container->add(Pantheon\Terminus\Collections\Tags::class);
+        $container->add(Pantheon\Terminus\Collections\Upstreams::class);
+        $container->add(Pantheon\Terminus\Collections\UserOrganizationMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\UserSiteMemberships::class);
+        $container->add(Pantheon\Terminus\Collections\WorkflowOperations::class);
+        $container->add(Pantheon\Terminus\Collections\Workflows::class);
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -310,7 +310,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $container->inflector(SavedTokens::class)
             ->invokeMethod('setDataStore', [$token_store]);
 
-        $this->configureModulesAndCollections();
+        $this->configureModulesAndCollections($container);
 
         // Helpers
         $container->add(LocalMachineHelper::class);
@@ -346,77 +346,75 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $factory->hookManager()->addInitializeHook($pluginAutoloadDependencies);
     }
 
-    private function configureModulesAndCollections()
+    private function configureModulesAndCollections($container)
     {
-        $container = $this->getContainer();
-
         // List of all Models and Collections. Update via 'composer update-class-lists'
 
         // Models
-        $container->add(Pantheon\Terminus\Models\Backup::class);
-        $container->add(Pantheon\Terminus\Models\Binding::class);
-        $container->add(Pantheon\Terminus\Models\Branch::class);
-        $container->add(Pantheon\Terminus\Models\Commit::class);
-        $container->add(Pantheon\Terminus\Models\DNSRecord::class);
-        $container->add(Pantheon\Terminus\Models\Domain::class);
-        $container->add(Pantheon\Terminus\Models\Environment::class);
-        $container->add(Pantheon\Terminus\Models\Lock::class);
-        $container->add(Pantheon\Terminus\Models\MachineToken::class);
-        $container->add(Pantheon\Terminus\Models\Metric::class);
-        $container->add(Pantheon\Terminus\Models\NewRelic::class);
-        $container->add(Pantheon\Terminus\Models\Organization::class);
-        $container->add(Pantheon\Terminus\Models\OrganizationSiteMembership::class);
-        $container->add(Pantheon\Terminus\Models\OrganizationUpstream::class);
-        $container->add(Pantheon\Terminus\Models\OrganizationUserMembership::class);
-        $container->add(Pantheon\Terminus\Models\PaymentMethod::class);
-        $container->add(Pantheon\Terminus\Models\Plan::class);
-        $container->add(Pantheon\Terminus\Models\Profile::class);
-        $container->add(Pantheon\Terminus\Models\Redis::class);
-        $container->add(Pantheon\Terminus\Models\SSHKey::class);
-        $container->add(Pantheon\Terminus\Models\SavedToken::class);
-        $container->add(Pantheon\Terminus\Models\Site::class);
-        $container->add(Pantheon\Terminus\Models\SiteAuthorization::class);
-        $container->add(Pantheon\Terminus\Models\SiteOrganizationMembership::class);
-        $container->add(Pantheon\Terminus\Models\SiteUpstream::class);
-        $container->add(Pantheon\Terminus\Models\SiteUserMembership::class);
-        $container->add(Pantheon\Terminus\Models\Solr::class);
-        $container->add(Pantheon\Terminus\Models\Tag::class);
-        $container->add(Pantheon\Terminus\Models\Upstream::class);
-        $container->add(Pantheon\Terminus\Models\UpstreamStatus::class);
-        $container->add(Pantheon\Terminus\Models\User::class);
-        $container->add(Pantheon\Terminus\Models\UserOrganizationMembership::class);
-        $container->add(Pantheon\Terminus\Models\UserSiteMembership::class);
-        $container->add(Pantheon\Terminus\Models\Workflow::class);
-        $container->add(Pantheon\Terminus\Models\WorkflowOperation::class);
+        $container->add(\Pantheon\Terminus\Models\Backup::class);
+        $container->add(\Pantheon\Terminus\Models\Binding::class);
+        $container->add(\Pantheon\Terminus\Models\Branch::class);
+        $container->add(\Pantheon\Terminus\Models\Commit::class);
+        $container->add(\Pantheon\Terminus\Models\DNSRecord::class);
+        $container->add(\Pantheon\Terminus\Models\Domain::class);
+        $container->add(\Pantheon\Terminus\Models\Environment::class);
+        $container->add(\Pantheon\Terminus\Models\Lock::class);
+        $container->add(\Pantheon\Terminus\Models\MachineToken::class);
+        $container->add(\Pantheon\Terminus\Models\Metric::class);
+        $container->add(\Pantheon\Terminus\Models\NewRelic::class);
+        $container->add(\Pantheon\Terminus\Models\Organization::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationSiteMembership::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationUpstream::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationUserMembership::class);
+        $container->add(\Pantheon\Terminus\Models\PaymentMethod::class);
+        $container->add(\Pantheon\Terminus\Models\Plan::class);
+        $container->add(\Pantheon\Terminus\Models\Profile::class);
+        $container->add(\Pantheon\Terminus\Models\Redis::class);
+        $container->add(\Pantheon\Terminus\Models\SSHKey::class);
+        $container->add(\Pantheon\Terminus\Models\SavedToken::class);
+        $container->add(\Pantheon\Terminus\Models\Site::class);
+        $container->add(\Pantheon\Terminus\Models\SiteAuthorization::class);
+        $container->add(\Pantheon\Terminus\Models\SiteOrganizationMembership::class);
+        $container->add(\Pantheon\Terminus\Models\SiteUpstream::class);
+        $container->add(\Pantheon\Terminus\Models\SiteUserMembership::class);
+        $container->add(\Pantheon\Terminus\Models\Solr::class);
+        $container->add(\Pantheon\Terminus\Models\Tag::class);
+        $container->add(\Pantheon\Terminus\Models\Upstream::class);
+        $container->add(\Pantheon\Terminus\Models\UpstreamStatus::class);
+        $container->add(\Pantheon\Terminus\Models\User::class);
+        $container->add(\Pantheon\Terminus\Models\UserOrganizationMembership::class);
+        $container->add(\Pantheon\Terminus\Models\UserSiteMembership::class);
+        $container->add(\Pantheon\Terminus\Models\Workflow::class);
+        $container->add(\Pantheon\Terminus\Models\WorkflowOperation::class);
 
         // Collections
-        $container->add(Pantheon\Terminus\Collections\Backups::class);
-        $container->add(Pantheon\Terminus\Collections\Bindings::class);
-        $container->add(Pantheon\Terminus\Collections\Branches::class);
-        $container->add(Pantheon\Terminus\Collections\Commits::class);
-        $container->add(Pantheon\Terminus\Collections\DNSRecords::class);
-        $container->add(Pantheon\Terminus\Collections\Domains::class);
-        $container->add(Pantheon\Terminus\Collections\EnvironmentMetrics::class);
-        $container->add(Pantheon\Terminus\Collections\Environments::class);
-        $container->add(Pantheon\Terminus\Collections\MachineTokens::class);
-        $container->add(Pantheon\Terminus\Collections\OrganizationSiteMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\OrganizationUpstreams::class);
-        $container->add(Pantheon\Terminus\Collections\OrganizationUserMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\PaymentMethods::class);
-        $container->add(Pantheon\Terminus\Collections\Plans::class);
-        $container->add(Pantheon\Terminus\Collections\SSHKeys::class);
-        $container->add(Pantheon\Terminus\Collections\SavedTokens::class);
-        $container->add(Pantheon\Terminus\Collections\SiteAuthorizations::class);
-        $container->add(Pantheon\Terminus\Collections\SiteMetrics::class);
-        $container->add(Pantheon\Terminus\Collections\SiteOrganizationMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\SiteUserMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\Sites::class);
-        $container->add(Pantheon\Terminus\Collections\Tags::class);
-        $container->add(Pantheon\Terminus\Collections\Upstreams::class);
-        $container->add(Pantheon\Terminus\Collections\UserOrganizationMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\UserSiteMemberships::class);
-        $container->add(Pantheon\Terminus\Collections\WorkflowOperations::class);
-        $container->add(Pantheon\Terminus\Collections\Workflows::class);
+        $container->add(\Pantheon\Terminus\Collections\Backups::class);
+        $container->add(\Pantheon\Terminus\Collections\Bindings::class);
+        $container->add(\Pantheon\Terminus\Collections\Branches::class);
+        $container->add(\Pantheon\Terminus\Collections\Commits::class);
+        $container->add(\Pantheon\Terminus\Collections\DNSRecords::class);
+        $container->add(\Pantheon\Terminus\Collections\Domains::class);
+        $container->add(\Pantheon\Terminus\Collections\EnvironmentMetrics::class);
+        $container->add(\Pantheon\Terminus\Collections\Environments::class);
+        $container->add(\Pantheon\Terminus\Collections\MachineTokens::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationSiteMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationUpstreams::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationUserMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\PaymentMethods::class);
+        $container->add(\Pantheon\Terminus\Collections\Plans::class);
+        $container->add(\Pantheon\Terminus\Collections\SSHKeys::class);
+        $container->add(\Pantheon\Terminus\Collections\SavedTokens::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteAuthorizations::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteMetrics::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteOrganizationMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteUserMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\Sites::class);
+        $container->add(\Pantheon\Terminus\Collections\Tags::class);
+        $container->add(\Pantheon\Terminus\Collections\Upstreams::class);
+        $container->add(\Pantheon\Terminus\Collections\UserOrganizationMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\UserSiteMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\WorkflowOperations::class);
+        $container->add(\Pantheon\Terminus\Collections\Workflows::class);
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -32,6 +32,7 @@ use Robo\Config;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Robo;
 use Robo\Runner as RoboRunner;
+use SelfUpdate\SelfUpdateCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -80,6 +81,11 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $this->addBuiltInCommandsAndHooks();
         $this->addPluginsCommandsAndHooks();
 
+        if (\Phar::running(true)) {
+            $cmd = new SelfUpdateCommand('Terminus', $config->get('version'), 'pantheon-systems/terminus');
+            $application->add($cmd);
+        }
+
         $this->runner = new RoboRunner();
         $this->runner->setContainer($container);
 
@@ -116,6 +122,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
      */
     private function addBuiltInCommandsAndHooks()
     {
+/*
         $commands = $this->getCommands([
             'path' => __DIR__ . '/Commands',
             'namespace' => 'Pantheon\Terminus\Commands',
@@ -124,6 +131,126 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
             'Pantheon\Terminus\Hooks\Authorizer',
         ];
         $this->commands = array_merge($commands, $hooks);
+*/
+        $this->commands = [
+            'Pantheon\\Terminus\\Hooks\\Authorizer',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\HTTPS\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteAllCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\MachineToken\\DeleteCommand',
+            'Pantheon\\Terminus\\Commands\\Branch\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\PaymentMethod\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Owner\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Connection\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Connection\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Redis\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Redis\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Auth\\WhoamiCommand',
+            'Pantheon\\Terminus\\Commands\\Auth\\LoginCommand',
+            'Pantheon\\Terminus\\Commands\\Auth\\LogoutCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\RoleCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\People\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Site\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Site\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Org\\Upstream\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\AliasesCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Lock\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\ServiceLevel\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Solr\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Solr\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\CodeLogCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\CommitCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\MetricsCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\DiffStatCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\DeployCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\ClearCacheCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\CloneContentCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\ViewCommand',
+            'Pantheon\\Terminus\\Commands\\ArtCommand',
+            'Pantheon\\Terminus\\Commands\\Dashboard\\ViewCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\CreateCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\DeleteCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\MergeToDevCommand',
+            'Pantheon\\Terminus\\Commands\\Multidev\\MergeFromDevCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\ConfigDumpCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\ConsoleCommand',
+            'Pantheon\\Terminus\\Commands\\Self\\ClearCacheCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\LogsCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\OperationsCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\StatusCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\Info\\InfoBaseCommand',
+            'Pantheon\\Terminus\\Commands\\Workflow\\WatchCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\LookupCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\SiteCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Org\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\RoleCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Team\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\CreateCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\DeleteCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Site\\Upstream\\ClearCacheCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\NewRelic\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\SSHKey\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\GetCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\SingleBackupCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\RestoreCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\EnableCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\Automatic\\DisableCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\CreateCommand',
+            'Pantheon\\Terminus\\Commands\\Backup\\BackupCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\DatabaseCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\SiteCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\CompleteCommand',
+            'Pantheon\\Terminus\\Commands\\Import\\FilesCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\LookupCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\DNSCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Domain\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\RemoveCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\AddCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Tag\\TagCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\InfoCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\UpdatesCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\ApplyCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\Updates\\StatusCommand',
+            'Pantheon\\Terminus\\Commands\\Upstream\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\TerminusCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\SSHBaseCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\DrushCommand',
+            'Pantheon\\Terminus\\Commands\\Remote\\WPCommand',
+        ];
     }
 
     /**
@@ -208,9 +335,74 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $container->inflector(SavedTokens::class)
             ->invokeMethod('setDataStore', [$token_store]);
 
+/*
         // Add the models and collections
         $this->addDirToContainer('Models');
         $this->addDirToContainer('Collections');
+*/
+        // Models
+        $container->add(\Pantheon\Terminus\Models\Backup::class);
+        $container->add(\Pantheon\Terminus\Models\Binding::class);
+        $container->add(\Pantheon\Terminus\Models\Branch::class);
+        $container->add(\Pantheon\Terminus\Models\Commit::class);
+        $container->add(\Pantheon\Terminus\Models\DNSRecord::class);
+        $container->add(\Pantheon\Terminus\Models\Domain::class);
+        $container->add(\Pantheon\Terminus\Models\Environment::class);
+        $container->add(\Pantheon\Terminus\Models\Lock::class);
+        $container->add(\Pantheon\Terminus\Models\MachineToken::class);
+        $container->add(\Pantheon\Terminus\Models\Metric::class);
+        $container->add(\Pantheon\Terminus\Models\NewRelic::class);
+        $container->add(\Pantheon\Terminus\Models\Organization::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationSiteMembership::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationUpstream::class);
+        $container->add(\Pantheon\Terminus\Models\OrganizationUserMembership::class);
+        $container->add(\Pantheon\Terminus\Models\PaymentMethod::class);
+        $container->add(\Pantheon\Terminus\Models\Profile::class);
+        $container->add(\Pantheon\Terminus\Models\Redis::class);
+        $container->add(\Pantheon\Terminus\Models\SavedToken::class);
+        $container->add(\Pantheon\Terminus\Models\Site::class);
+        $container->add(\Pantheon\Terminus\Models\SiteAuthorization::class);
+        $container->add(\Pantheon\Terminus\Models\SiteOrganizationMembership::class);
+        $container->add(\Pantheon\Terminus\Models\SiteUpstream::class);
+        $container->add(\Pantheon\Terminus\Models\SiteUserMembership::class);
+        $container->add(\Pantheon\Terminus\Models\Solr::class);
+        $container->add(\Pantheon\Terminus\Models\SSHKey::class);
+        $container->add(\Pantheon\Terminus\Models\Tag::class);
+        $container->add(\Pantheon\Terminus\Models\Upstream::class);
+        $container->add(\Pantheon\Terminus\Models\UpstreamStatus::class);
+        $container->add(\Pantheon\Terminus\Models\User::class);
+        $container->add(\Pantheon\Terminus\Models\UserOrganizationMembership::class);
+        $container->add(\Pantheon\Terminus\Models\UserSiteMembership::class);
+        $container->add(\Pantheon\Terminus\Models\Workflow::class);
+        $container->add(\Pantheon\Terminus\Models\WorkflowOperation::class);
+
+        // Collections
+        $container->add(\Pantheon\Terminus\Collections\Backups::class);
+        $container->add(\Pantheon\Terminus\Collections\Bindings::class);
+        $container->add(\Pantheon\Terminus\Collections\Branches::class);
+        $container->add(\Pantheon\Terminus\Collections\Commits::class);
+        $container->add(\Pantheon\Terminus\Collections\DNSRecords::class);
+        $container->add(\Pantheon\Terminus\Collections\Domains::class);
+        $container->add(\Pantheon\Terminus\Collections\EnvironmentMetrics::class);
+        $container->add(\Pantheon\Terminus\Collections\Environments::class);
+        $container->add(\Pantheon\Terminus\Collections\MachineTokens::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationSiteMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationUpstreams::class);
+        $container->add(\Pantheon\Terminus\Collections\OrganizationUserMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\PaymentMethods::class);
+        $container->add(\Pantheon\Terminus\Collections\SavedTokens::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteAuthorizations::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteMetrics::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteOrganizationMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\Sites::class);
+        $container->add(\Pantheon\Terminus\Collections\SiteUserMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\SSHKeys::class);
+        $container->add(\Pantheon\Terminus\Collections\Tags::class);
+        $container->add(\Pantheon\Terminus\Collections\Upstreams::class);
+        $container->add(\Pantheon\Terminus\Collections\UserOrganizationMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\UserSiteMemberships::class);
+        $container->add(\Pantheon\Terminus\Collections\WorkflowOperations::class);
+        $container->add(\Pantheon\Terminus\Collections\Workflows::class);
 
         // Helpers
         $container->add(LocalMachineHelper::class);

--- a/tests/config/functional.phpunit.xml.dist
+++ b/tests/config/functional.phpunit.xml.dist
@@ -1,0 +1,18 @@
+<phpunit
+  bootstrap="../functional_tests/bootstrap.php"
+  colors="true"
+  >
+  <testsuites>
+    <testsuite>
+      <directory suffix="Test.php">../functional_tests/</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+        <directory suffix=".php">../../src/</directory>
+        <exclude>
+            <directory suffix=".php">../../vendor/</directory>
+        </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -4,6 +4,9 @@ use PHPUnit\Framework\TestCase;
 
 class FunctionalTest extends TestCase
 {
+    /**
+     * If there is a terminus token, then log in.
+     */
     public function setupForClass()
     {
         $token = getenv('TERMINUS_TOKEN');
@@ -12,8 +15,10 @@ class FunctionalTest extends TestCase
         }
     }
 
-    // Test to see if we can use terminus.phar and get rational results
-    // back from the Hermes API.
+    /**
+     * Test to see if we can use terminus.phar and get rational results
+     * back from the Hermes API.
+     */
     public function testSiteInfo()
     {
         $site = getenv('TERMINUS_SITE') ?: 'ci-wordpress-core';
@@ -22,14 +27,22 @@ class FunctionalTest extends TestCase
         $this->assertContains('framework: wordpress', $output);
     }
 
+    /**
+     * Run a terminus command.
+     *
+     * @param string $command The command to run
+     * @param integer|bool $status The required status code for the
+     *   provided command, or `false` to ignore the status.
+     */
     protected function terminus($command, $expected_status = 0)
     {
         $project_dir = dirname(dirname(__DIR__));
         exec("$project_dir/terminus.phar " . $command, $output, $status);
+        $output = implode("\n", $output);
         if ($expected_status !== false) {
-            $this->assertEquals($expected_status, $status);
+            $this->assertEquals($expected_status, $status, $output);
         }
 
-        return implode("\n", $output);
+        return $output;
     }
 }

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -11,7 +11,7 @@ class FunctionalTest extends TestCase
     {
         $token = getenv('TERMINUS_TOKEN');
         if ($token) {
-            $this->terminus("auth:login --token=$token");
+            $this->terminus("auth:login --machine-token=$token");
         }
     }
 

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -11,7 +11,7 @@ class FunctionalTest extends TestCase
     {
         $token = getenv('TERMINUS_TOKEN');
         if ($token) {
-            $this->terminus("auth:login --machine-token=$token");
+            static::terminus("auth:login --machine-token=$token");
         }
     }
 
@@ -22,7 +22,7 @@ class FunctionalTest extends TestCase
     public function testSiteInfo()
     {
         $site = getenv('TERMINUS_SITE') ?: 'ci-wordpress-core';
-        $output = $this->terminus("site:info $site --format=yaml");
+        $output = static::("site:info $site --format=yaml");
 
         $this->assertContains('framework: wordpress', $output);
     }
@@ -34,7 +34,7 @@ class FunctionalTest extends TestCase
      * @param integer|bool $status The required status code for the
      *   provided command, or `false` to ignore the status.
      */
-    protected function terminus($command, $expected_status = 0)
+    protected static function terminus($command, $expected_status = 0)
     {
         $project_dir = dirname(dirname(__DIR__));
         exec("$project_dir/terminus.phar " . $command, $output, $status);

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -11,7 +11,7 @@ class FunctionalTest extends TestCase
     {
         $token = getenv('TERMINUS_TOKEN');
         if ($token) {
-            static::terminus("auth:login --machine-token=$token");
+            static::call_terminus("auth:login --machine-token=$token");
         }
     }
 
@@ -22,7 +22,7 @@ class FunctionalTest extends TestCase
     public function testSiteInfo()
     {
         $site = getenv('TERMINUS_SITE') ?: 'ci-wordpress-core';
-        $output = static::("site:info $site --format=yaml");
+        $output = $this->terminus("site:info $site --format=yaml");
 
         $this->assertContains('framework: wordpress', $output);
     }
@@ -31,18 +31,28 @@ class FunctionalTest extends TestCase
      * Run a terminus command.
      *
      * @param string $command The command to run
-     * @param integer|bool $status The required status code for the
-     *   provided command, or `false` to ignore the status.
+     * @param integer $status The required status code for the
+     *   provided command
      */
-    protected static function terminus($command, $expected_status = 0)
+    protected function terminus($command, $expected_status = 0)
+    {
+        list($output, $status) = static::call_terminus($command);
+        $this->assertEquals($expected_status, $status, $output);
+
+        return $output;
+    }
+
+    /**
+     * Run a terminus command.
+     *
+     * @param string $command The command to run
+     */
+    protected static function call_terminus($command)
     {
         $project_dir = dirname(dirname(__DIR__));
         exec("$project_dir/terminus.phar " . $command, $output, $status);
         $output = implode("\n", $output);
-        if ($expected_status !== false) {
-            $this->assertEquals($expected_status, $status, $output);
-        }
 
-        return $output;
+        return [$output, $status];
     }
 }

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -7,7 +7,7 @@ class FunctionalTest extends TestCase
     /**
      * If there is a terminus token, then log in.
      */
-    public function setUpBeforeClass()
+    public static function setUpBeforeClass()
     {
         $token = getenv('TERMINUS_TOKEN');
         if ($token) {

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FunctionalTest extends TestCase
+{
+    public function setupForClass()
+    {
+        $token = getenv('TERMINUS_TOKEN');
+        if ($token) {
+            $this->terminus("auth:login --token=$token");
+        }
+    }
+
+    // Test to see if we can use terminus.phar and get rational results
+    // back from the Hermes API.
+    public function testSiteInfo()
+    {
+        $site = getenv('TERMINUS_SITE') ?: 'ci-wordpress-core';
+        $output = $this->terminus("site:info $site --format=yaml");
+
+        $this->assertContains('framework: wordpress', $output);
+    }
+
+    protected function terminus($command, $expected_status = 0)
+    {
+        $project_dir = dirname(dirname(__DIR__));
+        exec("$project_dir/terminus.phar " . $command, $output, $status);
+        if ($expected_status !== false) {
+            $this->assertEquals($expected_status, $status);
+        }
+
+        return implode("\n", $output);
+    }
+}

--- a/tests/functional_tests/FunctionalTest.php
+++ b/tests/functional_tests/FunctionalTest.php
@@ -7,7 +7,7 @@ class FunctionalTest extends TestCase
     /**
      * If there is a terminus token, then log in.
      */
-    public function setupForClass()
+    public function setUpBeforeClass()
     {
         $token = getenv('TERMINUS_TOKEN');
         if ($token) {

--- a/tests/functional_tests/bootstrap.php
+++ b/tests/functional_tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Bootstrap file for functional tests
+ */
+
+// Override the default cache directory by setting an environment variable. This prevents our tests from overwriting
+// the user's real cache and session.
+$home = getenv('HOME');
+putenv("TERMINUS_CACHE_DIR=$home/.terminus/testcache");

--- a/tests/unit_tests/TerminusTest.php
+++ b/tests/unit_tests/TerminusTest.php
@@ -7,8 +7,9 @@ use League\Container\ContainerInterface;
 use Robo\Config;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use PHPUnit\Framework\TestCase;
 
-class TerminusTest extends \PHPUnit_Framework_TestCase
+class TerminusTest extends TestCase
 {
     /**
      * @var Robo\Config

--- a/tests/unit_tests/bootstrap.php
+++ b/tests/unit_tests/bootstrap.php
@@ -13,4 +13,5 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 // the user's real cache and session.
 // @TODO: Unit tests should not rely on side effects like these. When the Config object is properly injectable this
 // will not be necessary.
-putenv("TERMINUS_CACHE_DIR=~/.terminus/testcache");
+$home = getenv('HOME');
+putenv("TERMINUS_CACHE_DIR=$home/.terminus/testcache");


### PR DESCRIPTION
**How to use:**
- Use `composer release` to tag a new version of Terminus.
  - `-dev` is stripped off of the current `TERMINUS_VERSION` in constants.yml
  - Terminus is tagged, and the new tag is pushed up to GitHub
  - `TERMINUS_VERSION` is updated with the next `-dev` release, which is committed and pushed.
- The `terminus.phar` build is automatically attached to the GitHub release for each tag
- Users may use `terminus self:update` to update Terminus when a new release is available.

**Todo:**
- [x] Add a `composer release` command to automatically update version and tag release
- [x] Build a phar and publish it to GitHub every time a tag is pushed
- [x] Use the `self:update` command from https://github.com/consolidation/self-update
- [x] Create a test for the phar. (Test in CircleCI to avoid complicating the Travis matrix tests)
- [x] Optional: write a utility to update the list of command files and models
- [ ] Update Terminus installer to simply download the phar from GitHub (or update docs to tell users to manage their own $PATH)
