### PR TITLE
Add Installer Script for upcoming PHAR releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,16 @@ jobs:
       # Re-install with dev components so that we can run phpunit
       - run: composer install --no-interaction --prefer-dist
       - run: composer functional
+  installer-phar:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: php installer.php
+      - run: ~/.local/bin/terminus --version
 
 workflows:
   version: 2
   terminus:
     jobs:
       - functional
+      - installer-phar

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Once you have at least the requirements installed, you can install Terminus via 
 You can install Terminus just about anywhere on your system. In this README, we'll use `/install/location` to stand in for your chosen installation location.
 
 ## Installation
+
+### Direct Installation
+
+Copy the following one-liner to your terminal:
+
+```
+curl -O https://github.com/pantheon-systems/terminus/blob/master/installer.php && php installer.php
+```
+
 ### Installing via the Terminus installer
 Run this in your Terminal client:
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
       "cbf": "phpcbf --standard=PSR2 -n tests/unit_tests/* bin/terminus src/*",
       "clover": "phpunit -c tests/config/phpunit.xml.dist --coverage-clover tests/logs/clover.xml",
       "coveralls": "php vendor/bin/php-coveralls -v -c tests/config/coveralls.yml",
-      "cs": "phpcs --standard=PSR2 --severity=1 -n tests/unit_tests bin/terminus src",
+      "cs": "phpcs --standard=PSR2 --severity=1 -n tests/unit_tests bin/terminus src installer.php",
       "docs": "php scripts/make-docs.php",
       "lint": "@cs",
       "phpunit": "SHELL_INTERACTIVE=true phpunit --colors=always  -c tests/config/phpunit.xml.dist --debug",

--- a/installer.php
+++ b/installer.php
@@ -58,11 +58,7 @@ function ammendPath($rcfile, $installdir, &$pathUpdated)
 function checkpath($paths, $installdir)
 {
 
-    if (in_array($installdir, $paths)) {
-        return true;
-    } else {
-        return false;
-    }
+    return in_array($installdir, $paths);
 }
 
 // BEGIN ACUTAL DOING OF THINGS!
@@ -77,8 +73,7 @@ if (!file_exists($installdir)) {
 if (downloadTerminus($installdir, $package)) {
     echo("Downloaded to " . $installdir . "\n\n");
 } else {
-    echo("Download unsuccessful.\n\n");
-    exit();
+    exit("Download unsuccessful.\n\n");
 }
 
 // Make Terminus executable

--- a/installer.php
+++ b/installer.php
@@ -1,0 +1,97 @@
+<?php
+
+// Terminus Installer Script
+$pathcommand = false;
+$paths = explode(":", getenv('PATH'));             // Creates an array with all paths in $PATH
+$installdir = (getenv('HOME') . "/.terminus/bin"); // Creates a string with the desired installation path
+$rcfiles = array(                                  // Array of common .rc files to look for.
+  ".bashrc",
+  ".zshrc",
+  ".config/fish/config.fish",
+);
+
+
+if (!in_array($installdir, $paths)) {              // Searches for ~/.terminus/bin within the existing $PATH
+    $pathcommand = true;                           // If it isn't there, we'll execute commands later to add it.
+    print_r("Creating " . $installdir . "/\n");
+    mkdir($installdir, 0700, true);                // Makes the directory
+}
+
+
+// Build $url from which to download terminus
+$opts = [
+        'http' => [
+          'method' => 'GET',
+          'header' => [
+            'User-Agent: PHP'
+          ]
+        ]
+];
+$context  = stream_context_create($opts);
+$package  = "updatinate"; // Temporarily set to another Repo for testing
+$releases = file_get_contents("https://api.github.com/repos/pantheon-systems/" . $package . "/releases", false, $context);
+$releases = json_decode($releases);
+$version  = $releases[0]->tag_name;
+$url      = $releases[0]->assets[0]->browser_download_url; //  Currently broken, awaiting release phar to point to.
+
+
+// Download Terminus
+print_r("\nDownloading Terminus " . $version . " from " . $url . "\n");
+// Defines a function to download Terminus, which throws an exception on failure.
+function downloadterminus()
+{
+    global $installdir;
+    global $url;
+    global $package;
+
+    if (false === file_put_contents($installdir . "/" . $package . ".phar", file_get_contents($url))) {
+        throw new Exception('Unable to download Terminus.');
+    }
+}
+// Call the function, and handle the exception.
+try{
+    echo downloadterminus() . "\n";
+} catch (Exception $e){
+    echo "\n \n";
+    echo $e->getMessage(), "\n \n";
+    exit(1);
+}
+
+
+// Make Terminus executable
+print_r("Making Terminus executable... \n\n");
+chmod($installdir . "/" . $package . ".phar", 0755)
+  or exit("\nUnable to set Terminus as executable.\n");
+
+// If the installation directory wasn't found in $PATH earlier, define a function to add it to common shell conf files.
+if ($pathcommand == true) {
+    function ammendpath($rcfile)
+    {
+        global $installdir;
+        if (false === file_put_contents(getenv('HOME') . "/$rcfile", "# Adds Terminus to \$PATH\nPATH=\$PATH:" . $installdir . "\n\n", FILE_APPEND | LOCK_EX)) {
+            throw new Exception($rcfile . " found, but unable to write to it.");
+        }
+    }
+
+
+    foreach ($rcfiles as $rcfile){
+        if (file_exists(getenv('HOME') . "/$rcfile")) {
+            try{
+                ammendpath($rcfile);
+                print_r("Found " . $rcfile . " and added " . $installdir . " to your \$PATH.\nIn order to run Terminus, you must first run:\n\nsource ~/" . $rcfile . "\n");
+            }
+            catch (Exception $e){
+                echo "\n \n" . $e->getMessage(), "\n \n";
+            }
+        }
+    }
+}
+// If the installation directory was found in $PATH, exit with this message.
+else{
+    print_r("Terminus successfully installed.\n");
+}
+exit();
+?>
+
+
+

--- a/installer.php
+++ b/installer.php
@@ -2,12 +2,14 @@
 
 // Terminus Installer Script
 $pathcommand = false;
+$pathupdate = false;
 $paths = explode(":", getenv('PATH'));             // Creates an array with all paths in $PATH
 $installdir = (getenv('HOME') . "/.terminus/bin"); // Creates a string with the desired installation path
 $rcfiles = array(                                  // Array of common .rc files to look for.
   ".bashrc",
   ".zshrc",
   ".config/fish/config.fish",
+  ".profile",
 );
 
 
@@ -68,12 +70,14 @@ if ($pathcommand == true) {
     function ammendpath($rcfile)
     {
         global $installdir;
-        if (false === file_put_contents(getenv('HOME') . "/$rcfile", "# Adds Terminus to \$PATH\nPATH=\$PATH:" . $installdir . "\n\n", FILE_APPEND | LOCK_EX)) {
+        global $pathupdate;
+        $pathupdate = file_put_contents(getenv('HOME') . "/$rcfile", "# Adds Terminus to \$PATH\nPATH=\$PATH:" . $installdir . "\n\n", FILE_APPEND | LOCK_EX)
+        if (!$pathupdate) {
             throw new Exception($rcfile . " found, but unable to write to it.");
         }
     }
 
-
+    // Iterates through common shell configuration file possibilities to write to.
     foreach ($rcfiles as $rcfile){
         if (file_exists(getenv('HOME') . "/$rcfile")) {
             try{
@@ -85,6 +89,11 @@ if ($pathcommand == true) {
             }
         }
     }
+    // If no configuration file was updated to amend $PATH, this lets the user know.
+    if (!$pathcommand){
+        print_r("Terminus has been installed to " . $installdir . " But no suitable configuration file was found to update \$PATH.\n\nYou must manually add " . $installdir . " to your PATH, or execute Terminus from the full path.");
+    }
+
 }
 // If the installation directory was found in $PATH, exit with this message.
 else{

--- a/installer.php
+++ b/installer.php
@@ -7,7 +7,7 @@ Created by Alex Fornuto - alex@fornuto.com
 // Define environemnt variables.
 $pathUpdated = false;
 $paths = explode(":", getenv('PATH'));             // Creates an array with all paths in $PATH
-$installdir = (getenv('HOME') . "/.terminus/bin"); // Creates a string with the desired installation path
+$installdir = ("/usr/local/bin");                  // Creates a string with the desired installation path
 $rcfiles = array(                                  // Array of common .rc files to look for.
   ".bashrc",
   ".zshrc",
@@ -35,9 +35,14 @@ function downloadTerminus($installdir, $package)
     $version  = $releases[0]->tag_name;
     $url      = $releases[0]->assets[0]->browser_download_url;
     // Do the needful
-    echo("\nDownloading Terminus " . $version . " from " . $url . "\n");
-    $couldDownload = file_put_contents($installdir . "/" . $package . ".phar", file_get_contents($url));
-
+    echo("\nDownloading Terminus " . $version . " from " . $url . "to /tmp \n");
+    $couldDownload = file_put_contents("/tmp/" . $package . ".phar", file_get_contents($url));
+    echo("Moving to " . $installdir . "...\n");
+    if(!rename("/tmp/" . $package . ".phar", $installdir . "/" . $package . ".phar")){
+        echo("\n" . $installdir . " requires admin rights to write to...\n");
+        exec("sudo mv /tmp/" . $package . ".phar " . $installdir . "/" . $package . ".phar"); 
+        echo("\n");
+    }
     // Return true if successful
     return $couldDownload;
 }
@@ -71,7 +76,7 @@ if (!file_exists($installdir)) {
 
 //Download terminus.phar
 if (downloadTerminus($installdir, $package)) {
-    echo("Downloaded to " . $installdir . "\n\n");
+    echo("Installed to " . $installdir . "\n\n");
 } else {
     exit("Download unsuccessful.\n\n");
 }

--- a/installer.php
+++ b/installer.php
@@ -21,7 +21,7 @@ $package = "updatinate";                           // This _should_ be "terminus
 // prompts for sudo if required.
 function downloadTerminus($installdir, $package)
 {
-    // $opts defines values required by the GitHub API to respond correclty. $context formats them for use.
+    // $opts defines values required by the GitHub API to respond correctly. $context formats them for use.
     $opts = [
             'http' => [
               'method' => 'GET',


### PR DESCRIPTION
## Summary of Changes

 - Adds a new installer script, to be used as a one-line installation method for Terminus .phar files.
 - Updates the README with instructions on how to use it.
 - Updates the CircleCI configuration to test the installer script.

## Remaining Work

- [ ] Point `$package` to `terminus` once a release phar is in place.
- [ ] Improve the one-liner provided in the README to avoid leaving the install script in the working directory.
- [ ] Include more checks in the script for things like existing instances of terminus.
- [ ] Squash the commits, hiding the shameful mistakes I made.