### PR TITLE
Allow sites to be filtered by upstream - closes #1860

### DIFF
--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -141,6 +141,19 @@ class Sites extends APICollection implements SessionAwareInterface
     }
 
     /**
+     * Filters sites list by upstream
+     *
+     * @param string $upstream An upstream to filter by
+     * @return Sites
+     */
+    public function filterByUpstream($upstream_uuid)
+    {
+        return $this->filter(function ($model) use ($upstream_uuid) {
+            return ($model->getUpstream()->get('product_id') == $upstream_uuid);
+        });
+    }
+
+    /**
      * Retrieves the site of the given UUID or name
      *
      * If the site list has already been fetched then this function will search for the site in the fetched list.

--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -143,7 +143,7 @@ class Sites extends APICollection implements SessionAwareInterface
     /**
      * Filters sites list by upstream
      *
-     * @param string $upstream An upstream to filter by
+     * @param string $upstream_id An upstream to filter by
      * @return Sites
      */
     public function filterByUpstream($upstream_id)

--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -146,10 +146,10 @@ class Sites extends APICollection implements SessionAwareInterface
      * @param string $upstream An upstream to filter by
      * @return Sites
      */
-    public function filterByUpstream($upstream_uuid)
+    public function filterByUpstream($upstream_id)
     {
-        return $this->filter(function ($model) use ($upstream_uuid) {
-            return ($model->getUpstream()->get('product_id') == $upstream_uuid);
+        return $this->filter(function ($model) use ($upstream_id) {
+            return in_array($upstream_id, $model->getUpstream()->getReferences());
         });
     }
 

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -39,16 +39,21 @@ class ListCommand extends TerminusCommand implements RowsOfFieldsInterface, Site
      *
      * @param string $organization Organization name, label, or ID
      * @option string $tag Tag name to filter
+     * @option string $upstream Upstream name to filter
      *
      * @usage <organization> Displays the list of sites associated with <organization>.
      * @usage <organization> --tag=<tag> Displays the list of sites associated with <organization> that have the <tag> tag.
+     * @usage <organization> --upstream=<upstream_uuid> Displays the list of sites associated with <organization> on the upstream with id <upstream_uuid>.
      */
-    public function listSites($organization, $options = ['tag' => null,])
+    public function listSites($organization, $options = ['tag' => null, 'upstream' => null])
     {
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
         if (!is_null($tag = $options['tag'])) {
             $this->sites->filterByTag($tag);
+        }
+        if (!is_null($upstream = $options['upstream'])) {
+            $this->sites->filterByUpstream($upstream);
         }
         return $this->getRowsOfFields(
             $this->sites,

--- a/src/Models/Upstream.php
+++ b/src/Models/Upstream.php
@@ -32,7 +32,7 @@ class Upstream extends TerminusModel implements OrganizationInterface
      */
     public function getReferences()
     {
-        return [$this->id, $this->get('label'), $this->get('machine_name'),];
+        return [$this->id, $this->get('product_id'), $this->get('label'), $this->get('machine_name'),];
     }
 
     /**


### PR DESCRIPTION
This adds the `--upstream` option to `terminus org:site:list` which behaves similarly to how the `--tag` option works but filters by upstream. Currently you must pass the uuid of the upstream, not the label or machine name. This closes #1860  

I still need to add tests but am opening the PR so I don't forget :)