### PR TITLE
[AL-1686] Remove deprecated/unused functionality in Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ All notable changes to this project will be documented in this file. This projec
 - Removed `TerminusConfig::fromArray()`. Use the inherited `TerminusConfig::combine()`. (#1923)
 - Removed `TerminusConfig::toArray()`. Use the inherited `TerminusConfig::export()`. (#1923)
 - Removed `Pantheon\Terminus\Friends\RowsOfFieldsInterface` (#1923)
+- Removed deprecated `Workflow::wait` (#1937)
+- Removed const `Workflow::POLLING_PERIOD`. Please use `TERMINUS_HTTP_RETRY_DELAY_MS` (#1937)
 
 ## 1.9.0 - 2018-09-11
 ### Added

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -33,9 +33,6 @@ class Workflow extends TerminusModel implements ContainerAwareInterface, Session
      */
     private $workflow_operations;
 
-    // @TODO: Make this configurable.
-    const POLLING_PERIOD = 3;
-
     /**
      * Object constructor
      *
@@ -250,44 +247,6 @@ class Workflow extends TerminusModel implements ContainerAwareInterface, Session
             'started_at' => $this->get('started_at'),
             'operations' => $this->getOperations()->serialize(),
         ];
-    }
-
-    /**
-     * Waits on this workflow to finish
-     *
-     * @deprecated 1.0.0 Use while($workflow->checkProgress) instead
-     *
-     * @return Workflow|void
-     * @throws TerminusException
-     *
-     * @deprecated 1.0.1 Use checkProgress to wait on workflows
-     */
-    public function wait()
-    {
-        while (!$this->isFinished()) {
-            $this->fetch();
-            sleep(self::POLLING_PERIOD);
-            /**
-             * TODO: Output this to stdout so that it doesn't get mixed with any
-             *   actual output. We can't use the logger here because that might be
-             *   redirected to a log file where each line is timestamped.
-             */
-            fwrite(STDERR, '.');
-        }
-        echo "\n";
-        if ($this->isSuccessful()) {
-            return $this;
-        } else {
-            $final_task = $this->get('final_task');
-            if (($final_task != null) && !empty($final_task->messages)) {
-                foreach ($final_task->messages as $data => $message) {
-                    if (!is_string($message->message)) {
-                        $message->message = print_r($message->message, true);
-                    }
-                    throw new TerminusException((string)$message->message);
-                }
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Removed the deprecated `Workflow::wait` function and unused const `Workflow::POLLING_PERIOD` property