### PR TITLE
Add connection:get command

### DIFF
--- a/src/Commands/Connection/GetCommand.php
+++ b/src/Commands/Connection/GetCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Connection;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+/**
+ * Class GetCommand
+ * @package Pantheon\Terminus\Commands\Connection
+ */
+class GetCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+    use WorkflowProcessingTrait;
+
+    /**
+     * Gets Git or SFTP connection mode on a development environment (excludes Test and Live).
+     *
+     * @authorize
+     *
+     * @command connection:get
+     *
+     * @param string $site_env Site & development environment (excludes Test and Live) in the format `site-name.env`
+     *
+     * @throws TerminusException
+     *
+     * @usage <site>.<env> gets the connection mode of <site>'s <env> environment.
+     */
+    public function connectionGet($site_env)
+    {
+        list(, $env) = $this->getSiteEnv($site_env);
+
+        if (in_array($env->id, ['test', 'live',])) {
+            throw new TerminusException(
+                'Connection mode cannot be get on the {env} environment',
+                ['env' => $env->id,]
+            );
+        }
+        
+        return $env->get('connection_mode');
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -139,6 +139,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
             'Pantheon\\Terminus\\Commands\\Backup\\RestoreCommand',
             'Pantheon\\Terminus\\Commands\\Backup\\SingleBackupCommand',
             'Pantheon\\Terminus\\Commands\\Branch\\ListCommand',
+            'Pantheon\\Terminus\\Commands\\Connection\\GetCommand',
             'Pantheon\\Terminus\\Commands\\Connection\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Connection\\SetCommand',
             'Pantheon\\Terminus\\Commands\\Dashboard\\ViewCommand',


### PR DESCRIPTION
`connection:set` throws an exception if the desired `mode` is already set for the environment. 

This is problematic when using Terminus in a script as the script will fail. The addition of a `connection:get` command will allow the connection mode to be determined so `connection:set` can be conditionally run only if it is needed.