### PR TITLE
[AL-1847] - Fixed issue wherein any list command using datetime filters' first it em was a formatted Unix datetime 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fixed `site:org:list` so that it no longer ends without returning anything. (#1964)
 - Fixed `env:deploy` so the `--note` option is used when initializing the test or live environments. (#1965)
 - "Deploy from Terminus" is the default message used by `env:deploy` when initializing the test or live environments. (#1965)
+- Fixed issue wherein any list command using datetime filters' first item was a formatted Unix datetime 0. (#1970)
 
 ## 2.0.0 - 2019-02-20
 ### Added

--- a/src/Commands/StructuredListTrait.php
+++ b/src/Commands/StructuredListTrait.php
@@ -92,7 +92,7 @@ trait StructuredListTrait
 
         $list->addRendererFunction(
             function ($key, $cell_data) use ($config, $date_attributes) {
-                if (array_search($key, $date_attributes)) {
+                if (!is_numeric($key) && in_array($key, $date_attributes)) {
                     return $config->formatDatetime($cell_data);
                 }
                 return $cell_data;

--- a/src/Commands/StructuredListTrait.php
+++ b/src/Commands/StructuredListTrait.php
@@ -92,7 +92,7 @@ trait StructuredListTrait
 
         $list->addRendererFunction(
             function ($key, $cell_data) use ($config, $date_attributes) {
-                if (in_array($key, $date_attributes)) {
+                if (array_search($key, $date_attributes)) {
                     return $config->formatDatetime($cell_data);
                 }
                 return $cell_data;


### PR DESCRIPTION
What's happening here is that when the `--format=list` is used, the list becomes unidimensional and all the keys are dropped. Using `in_array` will match either the value or the key of the needle so it would try to format the first N objects in the list. (N is the number of attributes which the model recognizes as so typed.) Switching to `array_search` will restrict the search to only values.