### PR TITLE
CORE-344: Remove 'alpha' prefix from 'metrics' command.

### DIFF
--- a/src/Commands/Env/MetricsCommand.php
+++ b/src/Commands/Env/MetricsCommand.php
@@ -33,8 +33,8 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @authorize
      *
-     * @command alpha:env:metrics
-     * @aliases alpha:metrics
+     * @command env:metrics
+     * @aliases metrics,alpha:env:metrics,alpha:metrics
      *
      * @field-labels
      *     datetime: Period
@@ -126,7 +126,7 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
     /**
      * Ensure that the user did not supply an invalid value for 'period'.
      *
-     * @hook validate alpha:env:metrics
+     * @hook validate env:metrics
      * @param CommandData $commandData
      */
     public function validateOptions(CommandData $commandData)

--- a/tests/features/metrics.feature
+++ b/tests/features/metrics.feature
@@ -9,14 +9,14 @@ Feature: Checking metrics for an environment
 
   @vcr metrics.yml
   Scenario: Checking aggregated metrics
-    When I run "terminus alpha:env:metrics [[test_site_name]] --datapoints=2"
+    When I run "terminus env:metrics [[test_site_name]] --datapoints=2"
     Then I should get: "Period       Visits   Pages Served"
     And I should get: "2018-04-10    7,357         14,606"
     And I should get: "2018-04-11    5,569         10,981"
 
   @vcr metrics.yml
   Scenario: Checking metrics for live env
-    When I run "terminus alpha:env:metrics [[test_site_name]].live --datapoints=2"
+    When I run "terminus env:metrics [[test_site_name]].live --datapoints=2"
     Then I should get: "Period       Visits   Pages Served"
     And I should get: "2018-04-10    7,353         14,431"
     And I should get: "2018-04-11    5,565         10,845"


### PR DESCRIPTION
See also the [updated metrics documentation](https://github.com/pantheon-systems/documentation/pull/4721).