### PR TITLE
[CORE-1032] refactor region field to use human-readable name and ignore region machine name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## MASTER
 ### Changed
-- `site:info`'s value of the `region` field has been changed to use human-readable region names. (#1982)
-- `site:list`'s value of the `region` field has been changed to use human-readable region names. (#1982)
+- `site:info`'s value of the `region` field has been changed to use human-readable region names. (#1985)
+- `site:list`'s value of the `region` field has been changed to use human-readable region names. (#1985)
 
 ## 2.0.1 - 2019-04-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,9 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
 ## MASTER
-### Added
-- Added `region_label` field to the output of `site:info`, labeled "Region". (#1982)
-- Added `region_label` field to the output of `site:list`, labeled "Region". (#1982)
-- Added `region_label` field to the output of `Site::serialize()`. (#1982)
-
 ### Changed
-- `site:info`'s label of the `region` field has been changed from "Region" to "Region Code". (#1982)
-- `site:list`'s label of the `region` field has been changed from "Region" to "Region Code". (#1982)
+- `site:info`'s value of the `region` field has been changed to use human-readable region names. (#1982)
+- `site:list`'s value of the `region` field has been changed to use human-readable region names. (#1982)
 
 ## 2.0.1 - 2019-04-28
 ### Fixed

--- a/src/Commands/Site/InfoCommand.php
+++ b/src/Commands/Site/InfoCommand.php
@@ -26,8 +26,7 @@ class InfoCommand extends SiteCommand
      *     label: Label
      *     created: Created
      *     framework: Framework
-     *     region: Region Code
-     *     region_label: Region
+     *     region: Region
      *     organization: Organization
      *     plan_name: Plan
      *     max_num_cdes: Max Multidevs
@@ -37,7 +36,6 @@ class InfoCommand extends SiteCommand
      *     owner: Owner
      *     frozen: Is Frozen?
      *     last_frozen_at: Date Last Frozen
-     * @default-table-fields id,name,label,created,framework,region_label,organization,plan_name,max_num_cdes,upstream,holder_type,holder_id,owner,frozen,last_frozen_at
      * @return PropertyList
      *
      * @param string $site The name or UUID of a site to retrieve information on

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -22,14 +22,13 @@ class ListCommand extends SiteCommand
      *     id: ID
      *     plan_name: Plan
      *     framework: Framework
-     *     region: Region Code
-     *     region_label: Region
+     *     region: Region
      *     owner: Owner
      *     created: Created
      *     memberships: Memberships
      *     frozen: Is Frozen?
      *     last_frozen_at: Date frozen
-     * @default-fields name,id,plan_name,framework,region_label,owner,created,memberships,frozen
+     * @default-fields name,id,plan_name,framework,region,owner,created,memberships,frozen
      * @return RowsOfFields
      *
      * @option name Name filter

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -383,8 +383,7 @@ class Site extends TerminusModel implements ContainerAwareInterface, Organizatio
             'holder_type' => $this->get('holder_type'),
             'holder_id' => $this->get('holder_id'),
             'owner' => $this->get('owner'),
-            'region' => $this->get('preferred_zone'),
-            'region_label' => $this->get('preferred_zone_label'),
+            'region' => $this->get('preferred_zone_label'),
             'frozen' => $this->isFrozen(),
             'last_frozen_at' => $this->get('last_frozen_at'),
         ];

--- a/tests/unit_tests/Models/SiteTest.php
+++ b/tests/unit_tests/Models/SiteTest.php
@@ -539,7 +539,6 @@ class SiteTest extends ModelTestCase
             'max_num_cdes' => 0,
             'last_frozen_at' => '1682641540',
             'region' => null,
-            'region_label' => null,
         ];
 
         $this->request->expects($this->once())


### PR DESCRIPTION
Revises #1982.