### PR TITLE
Add command alias 'alpha:aliases'

### DIFF
--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -27,7 +27,7 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
      * @authorize
      *
      * @command aliases
-     * @aliases drush:aliases
+     * @aliases drush:aliases,alpha:aliases
      *
      * @option boolean $print Print aliases only (Drush 8 format)
      * @option string $location Path and filename for php aliases.

--- a/src/Commands/AliasesCommand.php
+++ b/src/Commands/AliasesCommand.php
@@ -27,7 +27,7 @@ class AliasesCommand extends TerminusCommand implements SiteAwareInterface
      * @authorize
      *
      * @command aliases
-     * @aliases drush:aliases,alpha:aliases
+     * @aliases drush:aliases alpha:aliases
      *
      * @option boolean $print Print aliases only (Drush 8 format)
      * @option string $location Path and filename for php aliases.


### PR DESCRIPTION
I removed this alias when rolling the plugin into Terminus core, but I'm not sure why I thought that was a good idea. This alias is used by the Terminus Build Tools workflow, so let's keep this in for backwards compatibility.