### PR TITLE
[AL-2151] Replaces unhelpful automatically generated output with more useful formatting

### DIFF
--- a/bin/terminus
+++ b/bin/terminus
@@ -27,12 +27,12 @@ use Pantheon\Terminus\Config\DefaultsConfig;
 use Pantheon\Terminus\Config\DotEnvConfig;
 use Pantheon\Terminus\Config\EnvConfig;
 use Pantheon\Terminus\Config\YamlConfig;
+use Pantheon\Terminus\Output\TerminusOutput;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 // Create the input and output objects for Terminus to run against.
 $input = new ArgvInput($_SERVER['argv']);
-$output = new ConsoleOutput();
+$output = new TerminusOutput();
 
 // Create a config object.
 $config = new DefaultsConfig();

--- a/src/Commands/Env/ListCommand.php
+++ b/src/Commands/Env/ListCommand.php
@@ -37,8 +37,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_id Site name
      *
-     * @usage env:list <site>
-     *    Displays a list of <site>'s environments.
+     * @usage env:list <site> Displays a list of <site>'s environments.
      */
     public function listEnvs($site_id)
     {

--- a/src/Output/TerminusOutput.php
+++ b/src/Output/TerminusOutput.php
@@ -15,7 +15,6 @@ class TerminusOutput extends ConsoleOutput
         '<site_env>' => '<site>.<env>',
         '[<drush_command>]...' => '-- <command>',
         '[<wp_command>]...' => '-- <command>',
-        'site_env' => 'site.env',
     ];
 
     protected function doWrite($message, $newline)

--- a/src/Output/TerminusOutput.php
+++ b/src/Output/TerminusOutput.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pantheon\Terminus\Output;
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+/**
+ * Class TerminusOutput
+ * @package Pantheon\Terminus\Output
+ */
+class TerminusOutput extends ConsoleOutput
+{
+    const REPLACEMENTS = [
+        ' [--]' => '',
+        '<site_env>' => '<site>.<env>',
+        '[<drush_command>]...' => '-- <command>',
+        '[<wp_command>]...' => '-- <command>',
+        'site_env' => 'site.env',
+    ];
+
+    protected function doWrite($message, $newline)
+    {
+        return parent::doWrite(
+            self::replacePhrases($message),
+            $newline
+        );
+    }
+
+    protected static function replacePhrases($message)
+    {
+        return str_replace(array_keys(self::REPLACEMENTS), array_values(self::REPLACEMENTS), $message);
+    }
+}


### PR DESCRIPTION
This is from a spike to determine how/whether to improve on confusing automatically generated help usage options. This can be done in plain Symfony Console by providing an extended InputDefintion, but because Terminus permits Robo to create the commands and does not extend them itself the best path appears blocked. I am ambivalent about whether this should be merged - it helps the situation but it's p sloppy and would screw with anything named "site_env", which seems unlikely but is entirely possible.

This branch
![image](https://user-images.githubusercontent.com/868204/66789875-5afaa880-eea2-11e9-8e1d-84f2dfbf82bb.png)

master
![image](https://user-images.githubusercontent.com/868204/66789868-5635f480-eea2-11e9-951a-dfcb65b70573.png)