### PR TITLE
Plugin info

### DIFF
--- a/src/Commands/Plugin/InfoCommand.php
+++ b/src/Commands/Plugin/InfoCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Plugin;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Plugins\PluginDiscovery;
+
+/**
+ * Class InfoCommand
+ * @package Pantheon\Terminus\Commands\Plugin
+ */
+class InfoCommand extends TerminusCommand
+{
+    /**
+     * Displays info about currently installed plugins.
+     *
+     * @command plugin:info
+     *
+     * @field-labels
+     *     name: name
+     *     description: description
+     * @return RowsOfFields
+     *
+     * @usage Displays info about currently installed plugins.
+     */
+    public function info()
+    {
+        $discovery = $this->getContainer()->get(PluginDiscovery::class);
+        $plugins = $discovery->discover();
+
+        $result = [];
+        foreach ($plugins as $plugin) {
+            $item = $plugin->getInfo();
+            $fields_to_show = ['name', 'description'];
+            foreach ($fields_to_show as $k) {
+                if (!in_array($k, array_keys($item))){
+                    unset($item[$k]);
+                }
+            }
+            array_push($result, $item);
+        }
+        return new RowsOfFields($result);
+    }
+}

--- a/src/Commands/Plugin/InfoCommand.php
+++ b/src/Commands/Plugin/InfoCommand.php
@@ -13,7 +13,7 @@ use Pantheon\Terminus\Plugins\PluginDiscovery;
 class InfoCommand extends TerminusCommand
 {
     /**
-     * Displays info about currently installed plugins.
+     * Displays info about currently installed Terminus plugins.
      *
      * @command plugin:info
      *

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -198,6 +198,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
             'Pantheon\\Terminus\\Commands\\Plan\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Plan\\ListCommand',
             'Pantheon\\Terminus\\Commands\\Plan\\SetCommand',
+            'Pantheon\\Terminus\\Commands\\Plugin\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\Redis\\DisableCommand',
             'Pantheon\\Terminus\\Commands\\Redis\\EnableCommand',
             'Pantheon\\Terminus\\Commands\\Remote\\DrushCommand',

--- a/tests/unit_tests/Commands/Plugin/InfoCommandTest.php
+++ b/tests/unit_tests/Commands/Plugin/InfoCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Commands\Plugin;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Pantheon\Terminus\Commands\Plugin\InfoCommand;
+use Pantheon\Terminus\Config\TerminusConfig;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+
+/**
+ * Class InfoCommandTest
+ * Testing class for Pantheon\Terminus\Commands\Plugin\InfoCommand
+ * @package Pantheon\Terminus\UnitTests\Commands\Plugin
+ */
+class InfoCommandTest extends CommandTestCase
+{
+    /**
+     * Tests the plugin:info command
+     */
+    public function testInfo()
+    {
+        $output_data = [
+            'name' => '*NAME*',
+            'description' => '*DESCRIPTION*',
+        ];
+
+        $this->config = $this->getMockBuilder(TerminusConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->config->expects($this->once())
+            ->method('serialize')
+            ->with()
+            ->willReturn($output_data);
+
+        $command = new InfoCommand();
+        $command->setConfig($this->config);
+        $info = $command->info();
+
+        $this->assertInstanceOf(RowsOfFields::class, $info);
+        $this->assertEquals($output_data, $info->getArrayCopy());
+    }
+}


### PR DESCRIPTION
Here's an optional way to solve #2021 - I opted for a whole new namespace for "Plugin" rather than adding it to `self:info` or `terminus --version`. I have some other ideas for this namespace like `plugin:install` and possibly `plugin:search` so I think `plugin:info` makes sense. If I'm totally off base here let me know and I can move it into `self:info`