### PR TITLE
[AI-81/AL-2210] Automatically validate all role parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 - Terminus will now load plugin files ending in `Hook.php` in addition to those ending with `Command.php` (#2025)
+- The role parameter in `org:people:add` is now being validated before sending the request. (#2033)
+- The role parameter in `org:people:role` is now being validated before attempting the change. (#2033)
+- The role parameter in `site:team:add` is now being validated before attempting the change. (#2033)
+- The role parameter in `site:team:role` is now being validated before attempting the change. (#2033)
 
 ### Deprecated
 - Deprecated the `--cc` option on `env:deploy`. Please use `env:clear-cache` instead. (#2022)

--- a/src/Hooks/RoleValidator.php
+++ b/src/Hooks/RoleValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Pantheon\Terminus\Hooks;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+class RoleValidator
+{
+    const ORG_ROLES = 'admin|developer|team_member|unprivileged';
+    const PARAM_NAME = 'role';
+    const ROLE_SEPARATOR = '|';
+    const SITE_ROLES = 'developer|team_member';
+
+    /**
+     * @hook validate *
+     *
+     * @param CommandData $command_data
+     * @throws TerminusException If the input role is invalid
+     */
+    public function validateRole(CommandData $command_data)
+    {
+        $input = $command_data->input();
+        if (!$input->hasArgument(self::PARAM_NAME)) {
+            return;
+        }
+
+        $acceptable_roles = self::getRoles($command_data->annotationData()->get('command'));
+        $role = $input->getArgument(self::PARAM_NAME);
+
+        if (!in_array($role, $acceptable_roles)) {
+            $replacements = [
+                'role' => $role,
+                'roles' => self::prettifyList($acceptable_roles)
+            ];
+            throw new TerminusException('{role} is not a valid role selection. Please enter {roles}.', $replacements);
+        }
+    }
+
+    /**
+     * Gives the roles available for a given command
+     *
+     * @param string $command_name The name of the command being validated
+     * @return array Roles permitted for this type of command
+     * @throws TerminusException if a command name is given for which there is no role list
+     */
+    protected static function getRoles($command_name)
+    {
+        $command_name_array = explode(':', $command_name);
+        $command_namespace = array_shift($command_name_array);
+        $const_name = 'self::' . strtoupper($command_namespace) . '_ROLES';
+        if (!defined($const_name)) {
+            throw new TerminusException(
+                'The available roles for {command_name} are unknown.',
+                compact('command_name')
+            );
+        }
+        return explode(self::ROLE_SEPARATOR, constant($const_name));
+    }
+
+    /**
+     * Turns an array into a list string using an Oxford comma
+     *
+     * @param array $list Array to turn into a list
+     * @param string $connector Connector to use before the last item in the sentence
+     * @return string
+     */
+    protected static function prettifyList(array $list, $connector = 'or')
+    {
+        $last_item = array_pop($list);
+        array_push($list, "$connector $last_item");
+        $glue = (count($list) > 2) ? ', ' : ' ';
+        return implode($glue, $list);
+    }
+}

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -123,6 +123,7 @@ class Terminus implements ConfigAwareInterface, ContainerAwareInterface, LoggerA
         $this->commands = [
             'Consolidation\\Filter\\Hooks\\FilterHooks',
             'Pantheon\\Terminus\\Hooks\\Authorizer',
+            'Pantheon\\Terminus\\Hooks\\RoleValidator',
             'Pantheon\\Terminus\\Hooks\\SiteEnvLookup',
             'Pantheon\\Terminus\\Commands\\AliasesCommand',
             'Pantheon\\Terminus\\Commands\\ArtCommand',

--- a/tests/features/org-people.feature
+++ b/tests/features/org-people.feature
@@ -29,6 +29,11 @@ Feature: Organizational users
     When I run "terminus org:people:add '[[organization_name]]' [[other_user]] team_member"
     Then I should get: "[[other_user]] has been added to the [[organization_name]] organization as a(n) team_member."
 
+  @vcr org-people-add.yml
+  Scenario: Failing to add an org member role because the given role is invalid
+    When I run "terminus org:people:add '[[organization_name]]' [[other_user]] invalid"
+    Then I should get: "invalid is not a valid role selection. Please enter admin, developer, team_member, or unprivileged."
+
   @vcr org-people-remove.yml
   Scenario: Removing a member from an organization
     When I run "terminus org:people:remove '[[organization_name]]' [[other_user]]"
@@ -38,3 +43,8 @@ Feature: Organizational users
   Scenario: Changing a org member's role
     When I run "terminus org:people:role '[[organization_name]]' [[other_user]] developer"
     Then I should get: "Dev User's role has been changed to developer in the [[organization_name]] organization."
+
+  @vcr org-people-role.yml
+  Scenario: Failing to change a org member's role because the given role is invalid
+    When I run "terminus org:people:role '[[organization_name]]' [[other_user]] invalid"
+    Then I should get: "invalid is not a valid role selection. Please enter admin, developer, team_member, or unprivileged."

--- a/tests/features/site-team.feature
+++ b/tests/features/site-team.feature
@@ -18,6 +18,11 @@ Feature: Managing a site's team
     And I should get: "[[other_user]]   developer     3a1d2042-cca3-432e-94c4-12a8f2b6a950   false"
     And I should get: "----------------------- ------------- -------------------------------------- -----------"
 
+  @vcr site-team-add.yml
+  Scenario: Failing to add a team member because the given role is invalid
+    When I run "terminus site:team:add [[test_site_name]] [[other_user]] admin"
+    Then I should get: "admin is not a valid role selection. Please enter developer or team_member."
+
   @vcr site-team-add-no-change-mgmt.yml
   Scenario: Adding a team member without change management enabled
     When I run "terminus site:team:add [[test_site_name]] [[other_user]] developer"
@@ -32,8 +37,13 @@ Feature: Managing a site's team
 
   @vcr site-team-role.yml
   Scenario: Changing a team member's role
-    When I run "terminus site:team:role [[test_site_name]] [[other_user]] admin"
+    When I run "terminus site:team:role [[test_site_name]] [[other_user]] developer"
     Then I should get one of the following: "This site does not have its change-management option enabled., Changed a user role"
+
+  @vcr site-team-role.yml
+  Scenario: Failing to change a team member's role because it's invalid
+    When I run "terminus site:team:add [[test_site_name]] [[other_user]] admin"
+    Then I should get: "admin is not a valid role selection. Please enter developer or team_member."
 
   @vcr site-team-list.yml
   Scenario: Listing team members

--- a/tests/unit_tests/Hooks/RoleValidatorTest.php
+++ b/tests/unit_tests/Hooks/RoleValidatorTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Hooks;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Pantheon\Terminus\Config\TerminusConfig;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Hooks\RoleValidator;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Class RoleValidatorTest
+ * Testing class for Pantheon\Terminus\Hooks\RoleValidator
+ * @package Pantheon\Terminus\UnitTests\Hooks
+ */
+class RoleValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    const ORG_ROLES = 'admin, developer, team_member, or unprivileged';
+    const PARAM_NAME = 'role';
+    const SITE_ROLES = 'developer or team_member';
+    /**
+     * @var AnnotationData
+     */
+    protected $annotation_data;
+    /**
+     * @var CommandData
+     */
+    protected $command_data;
+    /**
+     * @var TerminusException
+     */
+    protected $exception;
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+    /**
+     * @var RoleValidator
+     */
+    protected $role_validator;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp()
+    {
+        $this->config = new TerminusConfig();
+
+        $this->annotation_data = $this->getMockBuilder(AnnotationData::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->command_data = $this->getMockBuilder(CommandData::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->exception = $this->getMockBuilder(TerminusException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->input = $this->getMockBuilder(InputInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->command_data->expects($this->once())
+            ->method('input')
+            ->with()
+            ->willReturn($this->input);
+
+        $this->role_validator = new RoleValidator();
+    }
+
+    /**
+     * Tests validateRole for a command without a role parameter
+     */
+    public function testValidateRoleNoRole()
+    {
+        $this->expectHasArgument(false);
+        $this->expectCommandName("doesn't matter", false);
+        $this->expectGetArgument("doesn't matter", false);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Tests validateRole for an org command with an invalid role parameter
+     */
+    public function testValidateRoleOrgInvalid()
+    {
+        $invalid_role = 'invalid';
+
+        $this->expectHasArgument();
+        $this->expectCommandName('org:whatever:idk');
+        $this->expectGetArgument($invalid_role);
+        $this->expectInvalidRoleException($invalid_role, self::ORG_ROLES);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Tests validateRole for an org command with a valid role parameter
+     */
+    public function testValidateRoleOrgValid()
+    {
+        $valid_role = 'admin';
+
+        $this->expectHasArgument();
+        $this->expectCommandName('org:whatever:idk');
+        $this->expectGetArgument($valid_role);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Tests validateRole for a site command with an invalid role parameter
+     */
+    public function testValidateRoleSiteInvalid()
+    {
+        $invalid_role = 'admin'; // This one is valid for org commands but not site ones
+
+        $this->expectHasArgument();
+        $this->expectCommandName('site:omg:wth');
+        $this->expectGetArgument($invalid_role);
+        $this->expectInvalidRoleException($invalid_role, self::SITE_ROLES);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Tests validateRole for a site command with a valid role parameter
+     */
+    public function testValidateRoleSiteValid()
+    {
+        $valid_role = 'team_member';
+
+        $this->expectHasArgument();
+        $this->expectCommandName('site:omg:wth');
+        $this->expectGetArgument($valid_role);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Tests validateRole for a command that doesn't have a role list
+     */
+    public function testValidateRoleWrongCommand()
+    {
+        $invalid_command = 'user:wrong:cmd';
+
+        $this->expectHasArgument();
+        $this->expectCommandName($invalid_command);
+        $this->expectGetArgument("doesn't matter", false);
+        $this->expectInvalidCommandNameException($invalid_command);
+
+        $this->role_validator->validateRole($this->command_data);
+    }
+
+    /**
+     * Sets up the test to expect the input to have the argument or not
+     *
+     * @param bool $expect
+     */
+    protected function expectHasArgument($expect = true)
+    {
+        $this->input->expects($this->once())
+            ->method('hasArgument')
+            ->with(self::PARAM_NAME)
+            ->willReturn($expect);
+    }
+
+    /**
+     * Sets up the test to expect the input to have the argument or not
+     *
+     * @param bool $expect
+     */
+    protected function expectCommandName($command_name, $expect = true)
+    {
+        $expectation = $expect ? $this->once() : $this->any();
+
+        $this->command_data->expects($expectation)
+            ->method('annotationData')
+            ->with()
+            ->willReturn($this->annotation_data);
+        $this->annotation_data->method('get')
+            ->with('command')
+            ->willReturn($command_name);
+    }
+
+    /**
+     * Sets up the test to expect the input to have the argument or not
+     *
+     * @param bool $expect
+     */
+    protected function expectGetArgument($value, $expect = true)
+    {
+        $expectation = $expect ? $this->once() : $this->never();
+
+        $this->input->expects($expectation)
+            ->method('getArgument')
+            ->with(self::PARAM_NAME)
+            ->willReturn($value);
+    }
+
+    /**
+     * Expects an invalid-command exception to be thrown
+     *
+     * @param $command_name Name of the command whose parameter is being validated
+     */
+    protected function expectInvalidCommandNameException($command_name)
+    {
+        $expected_exception = new TerminusException(
+            'The available roles for {command_name} are unknown.',
+            compact('command_name')
+        );
+        $this->setExpectedException(get_class($expected_exception), $expected_exception->getMessage());
+    }
+
+    /**
+     * Expects an invalid-role exception to be thrown
+     *
+     * @param $role
+     * @param $roles
+     */
+    protected function expectInvalidRoleException($role, $roles)
+    {
+        $expected_exception = new TerminusException(
+            '{role} is not a valid role selection. Please enter {roles}.',
+            compact('role', 'roles')
+        );
+        $this->setExpectedException(get_class($expected_exception), $expected_exception->getMessage());
+    }
+}


### PR DESCRIPTION
Added role parameter validation for `org:people:add`, `org:people:role`, `site:team:add`,  and `site:team:role`