### PR TITLE
PHPUnit testing improvements

### DIFF
--- a/tests/unit_tests/Collections/CollectionTestCase.php
+++ b/tests/unit_tests/Collections/CollectionTestCase.php
@@ -5,12 +5,13 @@ namespace Pantheon\Terminus\UnitTests\Collections;
 use League\Container\Container;
 use Robo\Config;
 use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class CollectionTestCase
  * @package Pantheon\Terminus\UnitTests\Collections
  */
-abstract class CollectionTestCase extends \PHPUnit_Framework_TestCase
+abstract class CollectionTestCase extends TerminusTestCase
 {
     /**
      * @var TerminusCollection

--- a/tests/unit_tests/Collections/DomainsTest.php
+++ b/tests/unit_tests/Collections/DomainsTest.php
@@ -4,7 +4,6 @@ namespace Pantheon\Terminus\UnitTests\Collections;
 
 use Pantheon\Terminus\Collections\Domains;
 use Pantheon\Terminus\Collections\Workflows;
-use Pantheon\Terminus\Models\Domain;
 use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\Workflow;

--- a/tests/unit_tests/Collections/SiteOrganizationMembershipsTest.php
+++ b/tests/unit_tests/Collections/SiteOrganizationMembershipsTest.php
@@ -7,13 +7,14 @@ use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SiteOrganizationMembershipsTest
  * Testing class for Pantheon\Terminus\Collections\SiteOrganizationMemberships
  * @package Pantheon\Terminus\UnitTests\Collections
  */
-class SiteOrganizationMembershipsTest extends \PHPUnit_Framework_TestCase
+class SiteOrganizationMembershipsTest extends TerminusTestCase
 {
     /**
      * @var SiteOrganizationMemberships

--- a/tests/unit_tests/Collections/SiteUserMembershipsTest.php
+++ b/tests/unit_tests/Collections/SiteUserMembershipsTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Collections;
 use Pantheon\Terminus\Collections\SiteUserMemberships;
 use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SiteUserMembershipsTest
  * Testing class for Pantheon\Terminus\Collections\SiteUserMemberships
  * @package Pantheon\Terminus\UnitTests\Collections
  */
-class SiteUserMembershipsTest extends \PHPUnit_Framework_TestCase
+class SiteUserMembershipsTest extends TerminusTestCase
 {
     public function testCreate()
     {

--- a/tests/unit_tests/Collections/SitesTest.php
+++ b/tests/unit_tests/Collections/SitesTest.php
@@ -5,7 +5,6 @@ namespace Pantheon\Terminus\UnitTests\Collections;
 use League\Container\Container;
 use Pantheon\Terminus\Collections\SiteOrganizationMemberships;
 use Pantheon\Terminus\Collections\Sites;
-use Pantheon\Terminus\Collections\SiteUserMemberships;
 use Pantheon\Terminus\Collections\Tags;
 use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Exceptions\TerminusException;

--- a/tests/unit_tests/Collections/TagsTest.php
+++ b/tests/unit_tests/Collections/TagsTest.php
@@ -7,7 +7,6 @@ use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\OrganizationSiteMembership;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Collections\Tags;
-use Pantheon\Terminus\Models\Tag;
 
 /**
  * Class TagsTest

--- a/tests/unit_tests/Commands/AliasesCommandTest.php
+++ b/tests/unit_tests/Commands/AliasesCommandTest.php
@@ -4,9 +4,7 @@ namespace Pantheon\Terminus\UnitTests\Commands;
 
 use League\Container\Container;
 use Pantheon\Terminus\Commands\AliasesCommand;
-use Pantheon\Terminus\Helpers\LocalMachineHelper;
 use Robo\Config;
-use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\UnitTests\Helpers\AliasFixtures;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -38,7 +36,6 @@ class AliasesCommandTest extends CommandTestCase
      * @var BufferedOutput
      */
     protected $output;
-
 
     /**
      * @inheritdoc

--- a/tests/unit_tests/Commands/Backup/BackupCommandTest.php
+++ b/tests/unit_tests/Commands/Backup/BackupCommandTest.php
@@ -3,7 +3,6 @@
 namespace Pantheon\Terminus\UnitTests\Commands\Backup;
 
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
-
 use Pantheon\Terminus\Collections\Backups;
 use Pantheon\Terminus\Models\Backup;
 use Pantheon\Terminus\Models\Workflow;

--- a/tests/unit_tests/Commands/CommandTestCase.php
+++ b/tests/unit_tests/Commands/CommandTestCase.php
@@ -4,21 +4,22 @@ namespace Pantheon\Terminus\UnitTests\Commands;
 
 use League\Container\Container;
 use Pantheon\Terminus\Config\TerminusConfig;
-use Pantheon\Terminus\Style\TerminusStyle;
-use Psr\Log\NullLogger;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\Input;
-use Symfony\Component\Console\Output\OutputInterface;
 use Pantheon\Terminus\Collections\Environments;
 use Pantheon\Terminus\Collections\Sites;
 use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\Style\TerminusStyle;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class CommandTestCase
  * @package Pantheon\Terminus\UnitTests\Commands
  */
-abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
+abstract class CommandTestCase extends TerminusTestCase
 {
     /**
      * @var TerminusConfig

--- a/tests/unit_tests/Commands/Domain/Primary/AddCommandTest.php
+++ b/tests/unit_tests/Commands/Domain/Primary/AddCommandTest.php
@@ -1,10 +1,8 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Domain\Primary;
 
 use Pantheon\Terminus\Commands\Domain\Primary\AddCommand;
-use Pantheon\Terminus\UnitTests\Commands\Domain\Primary\PrimaryDomainCommandsTestBase;
 
 /**
  * Class AddCommandTest

--- a/tests/unit_tests/Commands/Domain/Primary/PrimaryDomainCommandsTestBase.php
+++ b/tests/unit_tests/Commands/Domain/Primary/PrimaryDomainCommandsTestBase.php
@@ -1,10 +1,8 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Domain\Primary;
 
 use Pantheon\Terminus\Commands\Domain\SetCommand;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Models\PrimaryDomain;
 use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\Session\Session;

--- a/tests/unit_tests/Commands/Domain/Primary/RemoveCommandTest.php
+++ b/tests/unit_tests/Commands/Domain/Primary/RemoveCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Domain\Primary;
 
 use Pantheon\Terminus\Commands\Domain\Primary\RemoveCommand;

--- a/tests/unit_tests/Commands/Env/ClearCacheCommandTest.php
+++ b/tests/unit_tests/Commands/Env/ClearCacheCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Env;
 
 use Pantheon\Terminus\Commands\Env\ClearCacheCommand;

--- a/tests/unit_tests/Commands/Env/CodeLogCommandTest.php
+++ b/tests/unit_tests/Commands/Env/CodeLogCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pantheon\Terminus\UnitTests\Commands\Env;
 
 use Pantheon\Terminus\Commands\Env\CodeLogCommand;

--- a/tests/unit_tests/Commands/Env/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Env/ListCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Env;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;

--- a/tests/unit_tests/Commands/Env/MetricsCommandTest.php
+++ b/tests/unit_tests/Commands/Env/MetricsCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pantheon\Terminus\UnitTests\Commands\Env;
 
 use Pantheon\Terminus\Commands\Env\MetricsCommand;

--- a/tests/unit_tests/Commands/Env/MockCloneCommand.php
+++ b/tests/unit_tests/Commands/Env/MockCloneCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pantheon\Terminus\UnitTests\Commands\Env;
 
 use Pantheon\Terminus\Commands\CloneCommand;

--- a/tests/unit_tests/Commands/Lock/DisableCommandTest.php
+++ b/tests/unit_tests/Commands/Lock/DisableCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Lock;
 
 use Pantheon\Terminus\Commands\Lock\DisableCommand;

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteAllCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteAllCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Collections\SavedTokens;

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensDeleteCommandTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Commands\MachineToken\DeleteCommand;
 use Robo\Config;
 use Pantheon\Terminus\Models\MachineToken;
 use Pantheon\Terminus\Exceptions\TerminusException;
-use Symfony\Component\Console\Input\Input;
 
 /**
  * Class MachineTokenDeleteCommandTest

--- a/tests/unit_tests/Commands/MachineToken/MachineTokensListCommandTest.php
+++ b/tests/unit_tests/Commands/MachineToken/MachineTokensListCommandTest.php
@@ -4,7 +4,6 @@ namespace Pantheon\Terminus\UnitTests\Commands\MachineToken;
 
 use Pantheon\Terminus\Commands\MachineToken\ListCommand;
 use Robo\Config;
-use Pantheon\Terminus\Collections\MachineTokens;
 use Pantheon\Terminus\Models\MachineToken;
 
 /**

--- a/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Multidev/DeleteCommandTest.php
@@ -5,7 +5,6 @@ namespace Pantheon\Terminus\UnitTests\Commands\Multidev;
 use Pantheon\Terminus\Commands\Multidev\DeleteCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\UnitTests\Commands\WorkflowProgressTrait;
-use Symfony\Component\Console\Input\Input;
 
 /**
  * Class DeleteCommandTest

--- a/tests/unit_tests/Commands/Plan/InfoCommandTest.php
+++ b/tests/unit_tests/Commands/Plan/InfoCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests\Commands\Plan;
+
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
+use Pantheon\Terminus\Commands\Plan\InfoCommand;
+use Pantheon\Terminus\Models\Plan;
+use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
+
+/**
+ * Class InfoCommandTest
+ * Test suite class for Pantheon\Terminus\Commands\Plan\InfoCommand
+ * @package Pantheon\Terminus\UnitTests\Commands\Plan
+ */
+class InfoCommandTest extends CommandTestCase
+{
+    /**
+     * @var Plan
+     */
+    protected $plan;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setup()
+    {
+        parent::setUp();
+
+        $this->plan = $this->getMockBuilder(Plan::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->command = new InfoCommand($this->getConfig());
+        $this->command->setSites($this->sites);
+        $this->command->setLogger($this->logger);
+    }
+
+    /**
+     * Exercises plan:info
+     */
+    public function testInfo()
+    {
+        $data = [
+            'billing_cycle' => 'monthly',
+            'id' => 'plan id',
+            'name' => 'Plan A',
+            'price' => 2599,
+            'monthly_price' => 2599,
+            'sku' => 'Plan.sku',
+            'storage' => 1234,
+            'support_plan' => 'silver',
+        ];
+
+        $this->site->expects($this->once())
+            ->method('getPlan')
+            ->with()
+            ->willReturn($this->plan);
+        $this->plan->expects($this->once())
+            ->method('fetch')
+            ->with()
+            ->willReturn($this->plan);
+        $this->plan->expects($this->once())
+            ->method('serialize')
+            ->willReturn($data);
+        $this->logger->expects($this->never())
+            ->method('log');
+
+        $out = $this->command->info('my-site');
+        $this->assertInstanceOf(PropertyList::class, $out);
+    }
+}

--- a/tests/unit_tests/Commands/Remote/DummyCommand.php
+++ b/tests/unit_tests/Commands/Remote/DummyCommand.php
@@ -3,7 +3,6 @@
 namespace Pantheon\Terminus\UnitTests\Commands\Remote;
 
 use Pantheon\Terminus\Commands\Remote\SSHBaseCommand;
-use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class DummyCommand

--- a/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
+++ b/tests/unit_tests/Commands/Remote/SSHBaseCommandTest.php
@@ -6,8 +6,6 @@ use League\Container\Container;
 use Pantheon\Terminus\Exceptions\TerminusProcessException;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Process\ProcessUtils;
 
 /**
  * SSHBaseCommand Test Suite

--- a/tests/unit_tests/Commands/Self/ConsoleCommandTest.php
+++ b/tests/unit_tests/Commands/Self/ConsoleCommandTest.php
@@ -5,7 +5,6 @@ namespace Pantheon\Terminus\UnitTests\Commands\Console;
 use Pantheon\Terminus\Commands\Self\ConsoleCommand;
 use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\UnitTests\Commands\Env\EnvCommandTest;
-use Psr\Log\LoggerInterface;
 
 /**
  * Class ConsoleCommandTest

--- a/tests/unit_tests/Commands/Site/CreateCommandTest.php
+++ b/tests/unit_tests/Commands/Site/CreateCommandTest.php
@@ -5,7 +5,6 @@ namespace Pantheon\Terminus\UnitTests\Commands\Site;
 use Pantheon\Terminus\Collections\Upstreams;
 use Pantheon\Terminus\Collections\UserOrganizationMemberships;
 use Pantheon\Terminus\Commands\Site\CreateCommand;
-use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\Upstream;

--- a/tests/unit_tests/Commands/Site/DeleteCommandTest.php
+++ b/tests/unit_tests/Commands/Site/DeleteCommandTest.php
@@ -3,7 +3,6 @@
 namespace Pantheon\Terminus\UnitTests\Commands\Site;
 
 use Pantheon\Terminus\Commands\Site\DeleteCommand;
-use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 use Pantheon\Terminus\UnitTests\Commands\WorkflowProgressTrait;

--- a/tests/unit_tests/Commands/Site/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Site/ListCommandTest.php
@@ -6,7 +6,6 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Collections\UserOrganizationMemberships;
 use Pantheon\Terminus\Commands\Site\ListCommand;
 use Pantheon\Terminus\Models\Organization;
-use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\UserOrganizationMembership;
 use Pantheon\Terminus\Session\Session;

--- a/tests/unit_tests/Commands/Site/LookupCommandTest.php
+++ b/tests/unit_tests/Commands/Site/LookupCommandTest.php
@@ -4,7 +4,6 @@ namespace Pantheon\Terminus\UnitTests\Commands\Site;
 
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Pantheon\Terminus\Commands\Site\LookupCommand;
-use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
 /**

--- a/tests/unit_tests/Commands/Site/Team/RemoveCommandTest.php
+++ b/tests/unit_tests/Commands/Site/Team/RemoveCommandTest.php
@@ -2,9 +2,6 @@
 
 namespace Pantheon\Terminus\UnitTests\Commands\Site\Team;
 
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use Pantheon\Terminus\Commands\Site\Team\RemoveCommand;
 use Pantheon\Terminus\UnitTests\Commands\WorkflowProgressTrait;
 

--- a/tests/unit_tests/Commands/Site/Upstream/ClearCacheCommandTest.php
+++ b/tests/unit_tests/Commands/Site/Upstream/ClearCacheCommandTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Commands\Site\Upstream;
 
 use Pantheon\Terminus\Commands\Site\Upstream\ClearCacheCommand;

--- a/tests/unit_tests/Config/DefaultsConfigTest.php
+++ b/tests/unit_tests/Config/DefaultsConfigTest.php
@@ -4,13 +4,14 @@ namespace Pantheon\Terminus\UnitTests\Config;
 
 use Pantheon\Terminus\Config\DefaultsConfig;
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class DefaultsConfigTest
  * Testing class for Pantheon\Terminus\Config\DefaultsConfig
  * @package Pantheon\Terminus\UnitTests\Config
  */
-class DefaultsConfigTest extends \PHPUnit_Framework_TestCase
+class DefaultsConfigTest extends TerminusTestCase
 {
     /**
      * @var Config

--- a/tests/unit_tests/Config/DotEnvConfigTest.php
+++ b/tests/unit_tests/Config/DotEnvConfigTest.php
@@ -3,8 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Config;
 
 use Pantheon\Terminus\Config\DotEnvConfig;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class DotEnvConfigTest extends \PHPUnit_Framework_TestCase
+class DotEnvConfigTest extends TerminusTestCase
 {
     public function testReadDotEnv()
     {

--- a/tests/unit_tests/Config/EnvConfigTest.php
+++ b/tests/unit_tests/Config/EnvConfigTest.php
@@ -3,8 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Config;
 
 use Pantheon\Terminus\Config\EnvConfig;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class EnvConfigTest extends \PHPUnit_Framework_TestCase
+class EnvConfigTest extends TerminusTestCase
 {
     public function testReadEnv()
     {

--- a/tests/unit_tests/Config/TerminusConfigTest.php
+++ b/tests/unit_tests/Config/TerminusConfigTest.php
@@ -3,8 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Config;
 
 use Pantheon\Terminus\Config\TerminusConfig;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class TerminusConfigTest extends \PHPUnit_Framework_TestCase
+class TerminusConfigTest extends TerminusTestCase
 {
     protected $config;
 

--- a/tests/unit_tests/Config/YamlConfigTest.php
+++ b/tests/unit_tests/Config/YamlConfigTest.php
@@ -3,8 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Config;
 
 use Pantheon\Terminus\Config\YamlConfig;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class YamlConfigTest extends \PHPUnit_Framework_TestCase
+class YamlConfigTest extends TerminusTestCase
 {
     protected $config;
 

--- a/tests/unit_tests/DataStore/FileStoreTest.php
+++ b/tests/unit_tests/DataStore/FileStoreTest.php
@@ -3,8 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\DataStore;
 
 use Pantheon\Terminus\DataStore\FileStore;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class FileStoreTest extends \PHPUnit_Framework_TestCase
+class FileStoreTest extends TerminusTestCase
 {
     public function setUp()
     {

--- a/tests/unit_tests/Exceptions/TerminusExceptionTest.php
+++ b/tests/unit_tests/Exceptions/TerminusExceptionTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Exceptions;
 
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class TerminusExceptionTest
  * Testing class for Pantheon\Terminus\Exceptions\TerminusException
  * @package Pantheon\Terminus\UnitTests\Exceptions
  */
-class TerminusExceptionTest extends \PHPUnit_Framework_TestCase
+class TerminusExceptionTest extends TerminusTestCase
 {
     /**
      * Tests the getReplacements function

--- a/tests/unit_tests/Friends/Domain/SingularTest.php
+++ b/tests/unit_tests/Friends/Domain/SingularTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Domain;
 
 use Pantheon\Terminus\Models\Domain;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SingularTest
  * Testing class for Pantheon\Terminus\Friends\DomainTrait & Pantheon\Terminus\Friends\DomainInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Domain
  */
-class SingularTest extends \PHPUnit_Framework_TestCase
+class SingularTest extends TerminusTestCase
 {
     /**
      * @var Domain

--- a/tests/unit_tests/Friends/Environment/SingularTest.php
+++ b/tests/unit_tests/Friends/Environment/SingularTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Environment;
 
 use Pantheon\Terminus\Models\Environment;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SingularTest
  * Testing class for Pantheon\Terminus\Friends\EnvironmentTrait & Pantheon\Terminus\Friends\EnvironmentInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Environment
  */
-class SingularTest extends \PHPUnit_Framework_TestCase
+class SingularTest extends TerminusTestCase
 {
     /**
      * @var SingularDummyClass

--- a/tests/unit_tests/Friends/Organization/JoinTest.php
+++ b/tests/unit_tests/Friends/Organization/JoinTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Organization;
 
 use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class JoinTest
  * Testing class for Pantheon\Terminus\Friends\OrganizationJoinTrait & Pantheon\Terminus\Friends\OrganizationJoinInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Organization
  */
-class JoinTest extends \PHPUnit_Framework_TestCase
+class JoinTest extends TerminusTestCase
 {
     /**
      * @var JoinDummyClass

--- a/tests/unit_tests/Friends/Organization/PluralTest.php
+++ b/tests/unit_tests/Friends/Organization/PluralTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Friends\Organization;
 use Pantheon\Terminus\Collections\SiteOrganizationMemberships;
 use Pantheon\Terminus\Models\SiteOrganizationMembership;
 use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class PluralTest
  * Testing class for Pantheon\Terminus\Friends\OrganizationsTrait & Pantheon\Terminus\Friends\OrganizationsInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Organization
  */
-class PluralTest extends \PHPUnit_Framework_TestCase
+class PluralTest extends TerminusTestCase
 {
     /**
      * @var SiteOrganizationMemberships

--- a/tests/unit_tests/Friends/Organization/SingularTest.php
+++ b/tests/unit_tests/Friends/Organization/SingularTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Organization;
 
 use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SingularTest
  * Testing class for Pantheon\Terminus\Friends\OrganizationTrait & Pantheon\Terminus\Friends\OrganizationInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Organization
  */
-class SingularTest extends \PHPUnit_Framework_TestCase
+class SingularTest extends TerminusTestCase
 {
     /**
      * @var SingularDummyClass

--- a/tests/unit_tests/Friends/Profile/TraitTest.php
+++ b/tests/unit_tests/Friends/Profile/TraitTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Profile;
 
 use Pantheon\Terminus\Models\Profile;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class TraitTest
  * Testing class for Pantheon\Terminus\Friends\ProfileTrait & Pantheon\Terminus\Friends\UserInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Profile
  */
-class TraitTest extends \PHPUnit_Framework_TestCase
+class TraitTest extends TerminusTestCase
 {
     /**
      * @var DummyClass

--- a/tests/unit_tests/Friends/Site/JoinTest.php
+++ b/tests/unit_tests/Friends/Site/JoinTest.php
@@ -4,13 +4,14 @@ namespace Pantheon\Terminus\UnitTests\Friends\Site;
 
 use League\Container\Container;
 use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class JoinTest
  * Testing class for Pantheon\Terminus\Friends\SiteJoinTrait & Pantheon\Terminus\Friends\SiteJoinInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Site
  */
-class JoinTest extends \PHPUnit_Framework_TestCase
+class JoinTest extends TerminusTestCase
 {
     /**
      * @var Container

--- a/tests/unit_tests/Friends/Site/PluralTest.php
+++ b/tests/unit_tests/Friends/Site/PluralTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Friends\Site;
 use Pantheon\Terminus\Collections\UserSiteMemberships;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\UserSiteMembership;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class PluralTest
  * Testing class for Pantheon\Terminus\Friends\SitesTrait & Pantheon\Terminus\Friends\SitesInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Site
  */
-class PluralTest extends \PHPUnit_Framework_TestCase
+class PluralTest extends TerminusTestCase
 {
     /**
      * @var UserSiteMemberships

--- a/tests/unit_tests/Friends/Site/SingularTest.php
+++ b/tests/unit_tests/Friends/Site/SingularTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\Site;
 
 use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SingularTest
  * Testing class for Pantheon\Terminus\Friends\SiteTrait & Pantheon\Terminus\Friends\SiteInterface
  * @package Pantheon\Terminus\UnitTests\Friends\Site
  */
-class SingularTest extends \PHPUnit_Framework_TestCase
+class SingularTest extends TerminusTestCase
 {
     /**
      * @var SingularDummyClass

--- a/tests/unit_tests/Friends/User/JoinTest.php
+++ b/tests/unit_tests/Friends/User/JoinTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\User;
 
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class JoinTest
  * Testing class for Pantheon\Terminus\Friends\UserJoinTrait & Pantheon\Terminus\Friends\UserJoinInterface
  * @package Pantheon\Terminus\UnitTests\Friends\User
  */
-class JoinTest extends \PHPUnit_Framework_TestCase
+class JoinTest extends TerminusTestCase
 {
     /**
      * @var JoinDummyClass

--- a/tests/unit_tests/Friends/User/PluralTest.php
+++ b/tests/unit_tests/Friends/User/PluralTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Friends\User;
 use Pantheon\Terminus\Collections\SiteUserMemberships;
 use Pantheon\Terminus\Models\SiteUserMembership;
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class PluralTest
  * Testing class for Pantheon\Terminus\Friends\UsersTrait & Pantheon\Terminus\Friends\UsersInterface
  * @package Pantheon\Terminus\UnitTests\Friends\User
  */
-class PluralTest extends \PHPUnit_Framework_TestCase
+class PluralTest extends TerminusTestCase
 {
     /**
      * @var SiteUserMemberships

--- a/tests/unit_tests/Friends/User/SingularTest.php
+++ b/tests/unit_tests/Friends/User/SingularTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Friends\User;
 
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SingularTest
  * Testing class for Pantheon\Terminus\Friends\UserTrait & Pantheon\Terminus\Friends\UserInterface
  * @package Pantheon\Terminus\UnitTests\Friends\User
  */
-class SingularTest extends \PHPUnit_Framework_TestCase
+class SingularTest extends TerminusTestCase
 {
     /**
      * @var SingularDummyClass

--- a/tests/unit_tests/Helpers/DrushRcEmitterTest.php
+++ b/tests/unit_tests/Helpers/DrushRcEmitterTest.php
@@ -3,10 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Helpers;
 
 use Pantheon\Terminus\Helpers\AliasEmitters\AliasesDrushRcEmitter;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class DrushRcEmitterTest extends TestCase
+class DrushRcEmitterTest extends TerminusTestCase
 {
     /**
      * testDrushrcEmitter confirms that the alias collection sorts

--- a/tests/unit_tests/Helpers/LocalMachineHelperTest.php
+++ b/tests/unit_tests/Helpers/LocalMachineHelperTest.php
@@ -6,10 +6,11 @@ use League\Container\Container;
 use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
 use Pantheon\Terminus\ProgressBars\ProcessProgressBar;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-class LocalMachineHelperTest extends \PHPUnit_Framework_TestCase
+class LocalMachineHelperTest extends TerminusTestCase
 {
     /**
      * @var TerminusConfig

--- a/tests/unit_tests/Helpers/PrintingEmitterTest.php
+++ b/tests/unit_tests/Helpers/PrintingEmitterTest.php
@@ -3,10 +3,10 @@
 namespace Pantheon\Terminus\UnitTests\Helpers;
 
 use Pantheon\Terminus\Helpers\AliasEmitters\PrintingEmitter;
-use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-class PrintingEmitterTest extends TestCase
+class PrintingEmitterTest extends TerminusTestCase
 {
     /**
      * testPrintingEmitter confirms that the alias collection sorts

--- a/tests/unit_tests/Helpers/SitesYmlEmitterTest.php
+++ b/tests/unit_tests/Helpers/SitesYmlEmitterTest.php
@@ -3,10 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Helpers;
 
 use Pantheon\Terminus\Helpers\AliasEmitters\DrushSitesYmlEmitter;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\BufferedOutput;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class SitesYmlEmitterTest extends TestCase
+class SitesYmlEmitterTest extends TerminusTestCase
 {
     /**
      * Test Drush 9 alias emitter

--- a/tests/unit_tests/Helpers/TemplateTest.php
+++ b/tests/unit_tests/Helpers/TemplateTest.php
@@ -3,9 +3,9 @@
 namespace Pantheon\Terminus\UnitTests\Helpers;
 
 use Pantheon\Terminus\Helpers\AliasEmitters\Template;
-use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class TemplateTest extends TestCase
+class TemplateTest extends TerminusTestCase
 {
     /**
      * processTestValues provides the expected results and inputs for testProcess

--- a/tests/unit_tests/Hooks/AuthorizerTest.php
+++ b/tests/unit_tests/Hooks/AuthorizerTest.php
@@ -8,13 +8,14 @@ use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Hooks\Authorizer;
 use Pantheon\Terminus\Models\SavedToken;
 use Pantheon\Terminus\Session\Session;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class AuthorizerTest
  * Testing class for Pantheon\Terminus\Hooks\Authorizer
  * @package Pantheon\Terminus\UnitTests\Hooks
  */
-class AuthorizerTest extends \PHPUnit_Framework_TestCase
+class AuthorizerTest extends TerminusTestCase
 {
     /**
      * @var Authorizer

--- a/tests/unit_tests/Hooks/SiteEnvLookupTest.php
+++ b/tests/unit_tests/Hooks/SiteEnvLookupTest.php
@@ -5,9 +5,9 @@ namespace Pantheon\Terminus\UnitTests\Hooks;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Pantheon\Terminus\Collections\Sites;
 use Pantheon\Terminus\Config\TerminusConfig;
-use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Hooks\SiteEnvLookup;
 use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -15,7 +15,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * Testing class for Pantheon\Terminus\Hooks\SiteEnvLookup
  * @package Pantheon\Terminus\UnitTests\Hooks
  */
-class SiteEnvLookupTest extends \PHPUnit_Framework_TestCase
+class SiteEnvLookupTest extends TerminusTestCase
 {
     const SITE_ID_FIXTURE = 'abc';
 

--- a/tests/unit_tests/Models/CommitTest.php
+++ b/tests/unit_tests/Models/CommitTest.php
@@ -1,11 +1,11 @@
 <?php
 
-
 namespace Pantheon\Terminus\UnitTests\Models;
 
 use Pantheon\Terminus\Models\Commit;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
-class CommitTest extends \PHPUnit_Framework_TestCase
+class CommitTest extends TerminusTestCase
 {
     public function testSerialize()
     {

--- a/tests/unit_tests/Models/DNSRecordTest.php
+++ b/tests/unit_tests/Models/DNSRecordTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Models;
 use Pantheon\Terminus\Collections\DNSRecords;
 use Pantheon\Terminus\Models\DNSRecord;
 use Pantheon\Terminus\Models\Domain;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class DNSRecordTest
  * Testing class for Pantheon\Terminus\Models\DNSRecord
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class DNSRecordTest extends \PHPUnit_Framework_TestCase
+class DNSRecordTest extends TerminusTestCase
 {
     /**
      * @var DNSRecord

--- a/tests/unit_tests/Models/EnvironmentTest.php
+++ b/tests/unit_tests/Models/EnvironmentTest.php
@@ -19,8 +19,6 @@ use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\Collections\Commits;
 use Pantheon\Terminus\Models\Commit;
 use Pantheon\Terminus\Exceptions\TerminusException;
-use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Process\ProcessUtils;
 
 /**
  * Class EnvironmentTest

--- a/tests/unit_tests/Models/ModelTestCase.php
+++ b/tests/unit_tests/Models/ModelTestCase.php
@@ -4,12 +4,13 @@ namespace Pantheon\Terminus\UnitTests\Models;
 
 use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class ModelTestCase
  * @package Pantheon\Terminus\UnitTests\Models
  */
-abstract class ModelTestCase extends \PHPUnit_Framework_TestCase
+abstract class ModelTestCase extends TerminusTestCase
 {
     /**
      * @var TerminusCollection

--- a/tests/unit_tests/Models/OrganizationUpstreamTest.php
+++ b/tests/unit_tests/Models/OrganizationUpstreamTest.php
@@ -5,13 +5,14 @@ namespace Pantheon\Terminus\UnitTests\Models;
 use Pantheon\Terminus\Collections\OrganizationUpstreams;
 use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\OrganizationUpstream;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class OrganizationUpstreamTest
  * Tests the Pantheon\Terminus\Models\OrganizationUpstream class
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class OrganizationUpstreamTest extends \PHPUnit_Framework_TestCase
+class OrganizationUpstreamTest extends TerminusTestCase
 {
     /**
      * @var OrganizationUpstreams

--- a/tests/unit_tests/Models/OrganizationUserMembershipTest.php
+++ b/tests/unit_tests/Models/OrganizationUserMembershipTest.php
@@ -9,13 +9,14 @@ use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\OrganizationUserMembership;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class OrganizationUserMembershipTest
  * Testing class for Pantheon\Terminus\Models\OrganizationUserMembership
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class OrganizationUserMembershipTest extends \PHPUnit_Framework_TestCase
+class OrganizationUserMembershipTest extends TerminusTestCase
 {
     /**
      * @var OrganizationUserMemberships

--- a/tests/unit_tests/Models/PaymentMethodTest.php
+++ b/tests/unit_tests/Models/PaymentMethodTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Models;
 
 use Pantheon\Terminus\Models\PaymentMethod;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class PaymentMethodTest
  * Testing class for Pantheon\Terminus\Models\PaymentMethod
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class PaymentMethodTest extends \PHPUnit_Framework_TestCase
+class PaymentMethodTest extends TerminusTestCase
 {
     /**
      * Tests the PaymentMethod::serialize() function

--- a/tests/unit_tests/Models/SiteOrganizationMembershipTest.php
+++ b/tests/unit_tests/Models/SiteOrganizationMembershipTest.php
@@ -9,13 +9,14 @@ use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\SiteOrganizationMembership;
 use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SiteOrganizationMembershipTest
  * Testing class for Pantheon\Terminus\Models\SiteOrganizationMembership
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class SiteOrganizationMembershipTest extends \PHPUnit_Framework_TestCase
+class SiteOrganizationMembershipTest extends TerminusTestCase
 {
     /**
      * @var SiteOrganizationMemberships

--- a/tests/unit_tests/Models/SiteUpstreamTest.php
+++ b/tests/unit_tests/Models/SiteUpstreamTest.php
@@ -6,13 +6,14 @@ use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\SiteUpstream;
 use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SiteUpstreamTest
  * Tests the Pantheon\Terminus\Models\SiteUpstream class
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class SiteUpstreamTest extends \PHPUnit_Framework_TestCase
+class SiteUpstreamTest extends TerminusTestCase
 {
     /**
      * Tests the Upstream::clearCache() function

--- a/tests/unit_tests/Models/SiteUserMembershipTest.php
+++ b/tests/unit_tests/Models/SiteUserMembershipTest.php
@@ -9,13 +9,14 @@ use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\SiteUserMembership;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\Workflow;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SiteUserMembershipTest
  * Testing class for Pantheon\Terminus\Models\SiteUserMembership
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class SiteUserMembershipTest extends \PHPUnit_Framework_TestCase
+class SiteUserMembershipTest extends TerminusTestCase
 {
     /**
      * @var SiteUserMemberships

--- a/tests/unit_tests/Models/UpstreamTest.php
+++ b/tests/unit_tests/Models/UpstreamTest.php
@@ -3,13 +3,14 @@
 namespace Pantheon\Terminus\UnitTests\Models;
 
 use Pantheon\Terminus\Models\Upstream;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class UpstreamTest
  * Tests the Pantheon\Terminus\Models\Upstream class
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class UpstreamTest extends \PHPUnit_Framework_TestCase
+class UpstreamTest extends TerminusTestCase
 {
     /**
      * Tests the Upstream::getReferences() function

--- a/tests/unit_tests/Models/UserOrganizationMembershipTest.php
+++ b/tests/unit_tests/Models/UserOrganizationMembershipTest.php
@@ -7,13 +7,14 @@ use Pantheon\Terminus\Collections\UserOrganizationMemberships;
 use Pantheon\Terminus\Models\Organization;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\UserOrganizationMembership;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class UserOrganizationMembershipTest
  * Testing class for Pantheon\Terminus\Models\UserOrganizationMembership
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class UserOrganizationMembershipTest extends \PHPUnit_Framework_TestCase
+class UserOrganizationMembershipTest extends TerminusTestCase
 {
     /**
      * @var UserOrganizationMemberships

--- a/tests/unit_tests/Models/UserSiteMembershipTest.php
+++ b/tests/unit_tests/Models/UserSiteMembershipTest.php
@@ -7,13 +7,14 @@ use Pantheon\Terminus\Collections\UserSiteMemberships;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\UserSiteMembership;
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class UserSiteMembershipTest
  * Testing class for Pantheon\Terminus\Models\UserSiteMembership
  * @package Pantheon\Terminus\UnitTests\Models
  */
-class UserSiteMembershipTest extends \PHPUnit_Framework_TestCase
+class UserSiteMembershipTest extends TerminusTestCase
 {
     /**
      * @var UserSiteMemberships

--- a/tests/unit_tests/Models/WorkflowTest.php
+++ b/tests/unit_tests/Models/WorkflowTest.php
@@ -5,7 +5,6 @@ namespace Pantheon\Terminus\UnitTests\Models;
 use League\Container\Container;
 use Pantheon\Terminus\Collections\Environments;
 use Pantheon\Terminus\Collections\WorkflowOperations;
-use Pantheon\Terminus\Collections\Workflows;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\User;
 use Pantheon\Terminus\Models\Workflow;

--- a/tests/unit_tests/Plugins/PluginAutoloadTest.php
+++ b/tests/unit_tests/Plugins/PluginAutoloadTest.php
@@ -4,13 +4,10 @@ namespace Pantheon\Terminus\UnitTests\Plugins;
 
 use Pantheon\Terminus\Plugins\PluginAutoloadDependencies;
 
-use League\Container\Container;
-use Pantheon\Terminus\Exceptions\TerminusException;
-use Pantheon\Terminus\Plugins\PluginDiscovery;
-use Pantheon\Terminus\Plugins\PluginInfo;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Psr\Log\NullLogger;
 
-class PluginAutoloadTest extends \PHPUnit_Framework_TestCase
+class PluginAutoloadTest extends TerminusTestCase
 {
     /**
      * @var PluginAutoloadDependencies

--- a/tests/unit_tests/Plugins/PluginDiscoveryTest.php
+++ b/tests/unit_tests/Plugins/PluginDiscoveryTest.php
@@ -3,12 +3,11 @@
 namespace Pantheon\Terminus\UnitTests\Plugins;
 
 use League\Container\Container;
-use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Plugins\PluginDiscovery;
-use Pantheon\Terminus\Plugins\PluginInfo;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Psr\Log\NullLogger;
 
-class PluginDiscoveryTest extends \PHPUnit_Framework_TestCase
+class PluginDiscoveryTest extends TerminusTestCase
 {
     /**
      * @var Container

--- a/tests/unit_tests/Plugins/PluginInfoTest.php
+++ b/tests/unit_tests/Plugins/PluginInfoTest.php
@@ -4,13 +4,14 @@ namespace Pantheon\Terminus\UnitTests\Plugins;
 
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Plugins\PluginInfo;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class PluginInfoTest
  * Testing class for Pantheon\Terminus\Plugins\PluginInfo
  * @package Pantheon\Terminus\UnitTests\Plugins
  */
-class PluginInfoTest extends \PHPUnit_Framework_TestCase
+class PluginInfoTest extends TerminusTestCase
 {
     /**
      * @inheritdoc

--- a/tests/unit_tests/Request/RequestTest.php
+++ b/tests/unit_tests/Request/RequestTest.php
@@ -13,10 +13,9 @@ use League\Container\Container;
 use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
-use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\Request\Request;
 use Pantheon\Terminus\Session\Session;
-use Pantheon\Terminus\Terminus;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -25,7 +24,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * Testing class for Pantheon\Terminus\Request\Request
  * @package Pantheon\Terminus\UnitTests\Request
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TerminusTestCase
 {
     /**
      * @var Client

--- a/tests/unit_tests/Session/SessionTest.php
+++ b/tests/unit_tests/Session/SessionTest.php
@@ -2,21 +2,20 @@
 
 namespace Pantheon\Terminus\UnitTests\Session;
 
-use Behat\Gherkin\Cache\FileCache;
 use League\Container\Container;
 use Pantheon\Terminus\Collections\SavedTokens;
-use Pantheon\Terminus\Models\SavedToken;
 use Robo\Config;
 use Pantheon\Terminus\DataStore\FileStore;
 use Pantheon\Terminus\Session\Session;
 use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 
 /**
  * Class SessionTest
  * Testing class for Pantheon\Terminus\Session\Session
  * @package Pantheon\Terminus\UnitTests\Session
  */
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends TerminusTestCase
 {
     /**
      * @var Config

--- a/tests/unit_tests/TerminusTest.php
+++ b/tests/unit_tests/TerminusTest.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Pantheon\Terminus;
+namespace Pantheon\Terminus\UnitTests;
 
-use Consolidation\OutputFormatters\Formatters\FormatterInterface;
 use League\Container\ContainerInterface;
 use Robo\Config;
 use Symfony\Component\Console\Input\InputInterface;

--- a/tests/unit_tests/TerminusTest.php
+++ b/tests/unit_tests/TerminusTest.php
@@ -6,9 +6,8 @@ use League\Container\ContainerInterface;
 use Robo\Config;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use PHPUnit\Framework\TestCase;
 
-class TerminusTest extends TestCase
+class TerminusTest extends TerminusTestCase
 {
     /**
      * @var Robo\Config

--- a/tests/unit_tests/TerminusTestCase.php
+++ b/tests/unit_tests/TerminusTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pantheon\Terminus\UnitTests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TerminusTestCase
+ * @package Pantheon\Terminus\UnitTests
+ */
+abstract class TerminusTestCase extends TestCase
+{
+}

--- a/tests/unit_tests/Update/LatestReleaseTest.php
+++ b/tests/unit_tests/Update/LatestReleaseTest.php
@@ -4,14 +4,13 @@ namespace Pantheon\Terminus\UnitTests\Update;
 
 use Consolidation\Log\Logger;
 use League\Container\Container;
-use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\DataStore\DataStoreInterface;
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Request\Request;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Pantheon\Terminus\Update\LatestRelease;
-use Pantheon\Terminus\Update\UpdateChecker;
 
-class LatestReleaseTest extends \PHPUnit_Framework_TestCase
+class LatestReleaseTest extends TerminusTestCase
 {
     /**
      * @var Container

--- a/tests/unit_tests/Update/UpdateCheckerTest.php
+++ b/tests/unit_tests/Update/UpdateCheckerTest.php
@@ -7,6 +7,7 @@ use League\Container\Container;
 use Pantheon\Terminus\Config\TerminusConfig;
 use Pantheon\Terminus\DataStore\DataStoreInterface;
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
+use Pantheon\Terminus\UnitTests\TerminusTestCase;
 use Pantheon\Terminus\Update\LatestRelease;
 use Pantheon\Terminus\Update\UpdateChecker;
 
@@ -15,7 +16,7 @@ use Pantheon\Terminus\Update\UpdateChecker;
  * Testing class for Pantheon\Terminus\Update\UpdateChecker
  * @package Pantheon\Terminus\UnitTests\Update
  */
-class UpdateCheckerTest extends \PHPUnit_Framework_TestCase
+class UpdateCheckerTest extends TerminusTestCase
 {
     /**
      * @var TerminusConfig


### PR DESCRIPTION
What this is doing:
- Adds `Pantheon\Terminus\UnitTests\Commands\Plan\InfoCommandTest`
- Fixes the namespace in `Pantheon\Terminus\UnitTests\TerminusTest`
- Adds `Pantheon\Terminus\UnitTests\TerminusTestCase` which extends the PHPUnit test case. Its purpose is to update all the references to  the outdated `\PHPUnit_Framework_TestCase` and to make it easier to change all these in the future as it becomes necessary.
- Removes all the unused `use` statements in the unit tests, as identified by my IDE.
- Standardizes the number of line breaks. Some places needed them, others had too many.