### PR TITLE
AL-2260: Fixes #2036: Prevent failure of drush8 alias policy file.

### DIFF
--- a/templates/aliases/policy/drush8/pantheon_policy.drush.inc
+++ b/templates/aliases/policy/drush8/pantheon_policy.drush.inc
@@ -19,7 +19,7 @@ function pantheon_policy_drush_sitealias_alter(&$alias_record) {
   // alias record to a local alias.
   if (isset($alias_record['remote-host'])) {
     $host = $alias_record['remote-host'];
-    if (!(preg_match('#^appserver\..*\.drush\.in$#', $host))) {
+    if (!(preg_match('#^appserver\..*\.drush\.in$#', $host)) || (strpos($host, '{env-name}') !== FALSE)) {
       return;
     }
     $ip = gethostbyname($host);


### PR DESCRIPTION
Do not check to see if multidev exists when procesing raw alias templates, e.g. in the site:alias command.