### PR TITLE
Update README for Installation methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,29 @@ Once you have at least the requirements installed, you can install Terminus via 
 You can install Terminus just about anywhere on your system. In this README, we'll use `/install/location` to stand in for your chosen installation location.
 
 ## Installation
+
+There are several ways to install Terminus, depending on your use case:
+
+- For a composer-managed version of Terminus that is _not_ part of your other composer-managed project(s) and doesn't utilize global composer installations, use the [Terminus installer](#installing-via-the-terminus-installer).
+- If you want to contribute to the Terminus project, [download and install](#installing-with-git) from the git repository.
+- To add Terminus as a dependency of your composer-based project, [install with Composer](#installing-with-composer).
+- For a self-contained Terminus executable, [install terminus.phar](#install-self-contained-terminus).
+
 ### Install Self-Contained Terminus
 
 1. Download the latest `terminus.phar` from the [Releases](https://github.com/pantheon-systems/terminus/releases) page. In the example below, we're directing the file to `$HOME/bin/` and renaming the file to `terminus`:
 
-  ```bash
-  wget https://github.com/pantheon-systems/terminus/releases/download/2.3.0/terminus.phar -O ~/.bin/terminus
-  ```
+    ```bash
+    wget https://github.com/pantheon-systems/terminus/releases/download/2.3.0/terminus.phar -O ~/.bin/terminus
+    ```
 
-  Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above vermatim.
+    Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above vermatim.
 
 1. Make the Terminus file exectable. The example below assumes the same installation path as above:
 
-  ```bash
-  chmod +X ~/.bin/terminus
-  ```
+    ```bash
+    chmod +X ~/.bin/terminus
+    ```
 
 **Note:** Your installation directory must be in or added to your `$PATH` environment variable in order to call `terminus` from any working directory.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/ma
 ```
 For more information on installation options or to report an issue with this method, please see the [Terminus Installer README.md file](https://github.com/pantheon-systems/terminus-installer).
 
+**Note:** Terminus installed this way cannot use `terminus update` to self-update versions.
+
 ### Installing with Composer
 
 Run this in your terminal client:
@@ -71,6 +73,8 @@ composer remove pantheon-systems/terminus
 before requiring it.
 
 Do not install Terminus via `composer global require`. [`composer global require` should not be used to install php applications](https://pantheon.io/blog/fixing-composer-global-command). If you need to globally install something using `composer`, use the [`cgr` utility](https://github.com/consolidation/cgr) as a replacement instead.
+
+**Note:** Terminus installed this way cannot use `terminus update` to self-update versions.
 
 ### Installing with Git
 To install with Git and use Terminus HEAD, you should clone this repository and run Terminus directly. If you would
@@ -89,6 +93,8 @@ You can now run the bleeding-edge version of Terminus via:
 ```bash
 bin/terminus
 ```
+
+**Note:** Terminus installed this way cannot use `terminus update` to self-update versions.
 
 ## Updating
 ### Updating via the Terminus installer

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ Once you have at least the requirements installed, you can install Terminus via 
 You can install Terminus just about anywhere on your system. In this README, we'll use `/install/location` to stand in for your chosen installation location.
 
 ## Installation
+### Install Self-Contained Terminus
+
+1. Download the latest `terminus.phar` from the [Releases](https://github.com/pantheon-systems/terminus/releases) page. In the example below, we're directing the file to `$HOME/bin/` and renaming the file to `terminus`:
+
+  ```bash
+  wget https://github.com/pantheon-systems/terminus/releases/download/2.3.0/terminus.phar -O ~/.bin/terminus
+  ```
+
+  Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above vermatim.
+
+1. Make the Terminus file exectable. The example below assumes the same installation path as above:
+
+  ```bash
+  chmod +X ~/.bin/terminus
+  ```
+
+**Note:** Your installation directory must be in or added to your `$PATH` environment variable in order to call `terminus` from any working directory.
+
 ### Installing via the Terminus installer
 Run this in your Terminal client:
 ```bash


### PR DESCRIPTION
Closes #2057 

Each commit represents one part of the three-step solution outlined in #2057  

- Documents installing `terminus.phar`
- Document the lack of `terminus update` in other methods
- Describe when one might use each installation method.