### PR TITLE
Add validation for empty tag

### DIFF
--- a/src/Commands/Tag/AddCommand.php
+++ b/src/Commands/Tag/AddCommand.php
@@ -2,6 +2,8 @@
 
 namespace Pantheon\Terminus\Commands\Tag;
 
+use Pantheon\Terminus\Exceptions\TerminusException;
+
 /**
  * Class AddCommand
  * @package Pantheon\Terminus\Commands\Tag
@@ -23,6 +25,9 @@ class AddCommand extends TagCommand
      */
     public function add($site_name, $organization, $tag)
     {
+        if (empty($tag)) {
+            throw new TerminusException("Tag cannot be null");
+        }
         list($org, $site, $tags) = $this->getModels($site_name, $organization);
         $tags->create($tag);
         $this->log()->notice(

--- a/src/Commands/Tag/AddCommand.php
+++ b/src/Commands/Tag/AddCommand.php
@@ -26,7 +26,7 @@ class AddCommand extends TagCommand
     public function add($site_name, $organization, $tag)
     {
         if (empty($tag)) {
-            throw new TerminusException("Tag cannot be null");
+            throw new TerminusException("Tag cannot be empty");
         }
         list($org, $site, $tags) = $this->getModels($site_name, $organization);
         $tags->create($tag);


### PR DESCRIPTION
The tag command does not validate for empty tag being passed. This adds a simple check and throws an exception if empty tag is provided.