### PR TITLE
Add getReferences() method to include product_id

### DIFF
--- a/src/Models/SiteUpstream.php
+++ b/src/Models/SiteUpstream.php
@@ -63,5 +63,4 @@ class SiteUpstream extends TerminusModel implements SiteInterface
     {
         return [$this->id, $this->get('product_id'), $this->get('label'), $this->get('machine_name'),];
     }
-
 }

--- a/src/Models/SiteUpstream.php
+++ b/src/Models/SiteUpstream.php
@@ -55,4 +55,13 @@ class SiteUpstream extends TerminusModel implements SiteInterface
         }
         return $data;
     }
+    
+     /**
+     * @return string[]
+     */
+    public function getReferences()
+    {
+        return [$this->id, $this->get('product_id'), $this->get('label'), $this->get('machine_name'),];
+    }
+
 }


### PR DESCRIPTION
In certain cases, an upstream ID and product_id won't be the same, and this leads to failures when trying to list sites by upstream ID, which is the `product_id`, rather than the `id`. It fails because we aren't overriding `TerminusModel` default method, which only returns the ID, in `SiteUpstream` class.

When running `terminus site:list --upstream=foo`, the logic here invokes the getUpstream() method:

```
    /**
     * Filters sites list by upstream
     *
     * @param string $upstream_id An upstream to filter by
     * @return Sites
     */
    public function filterByUpstream($upstream_id)
    {
        $upstream_id = strtolower($upstream_id);
        return $this->filter(function ($model) use ($upstream_id) {
            return in_array($upstream_id, $model->getUpstream()->getReferences());
        });
    }
```
The `getUpstream()` method creates a `SiteUpstream` object:

```

    /**
     * @return Upstream
     */
    public function getUpstream()
    {
        $upstream_data = (object)array_merge((array)$this->get('upstream'), (array)$this->get('product'));
        if (empty((array)$upstream_data)
            && !is_null($settings = $this->get('settings'))
            && isset($settings->upstream)
        ) {
            $upstream_data = $settings->upstream;
        }
        return $this->getContainer()->get(SiteUpstream::class, [$upstream_data, ['site' => $this,],]);
    }
```

And ultimately, the `in_array($upstream_id, $model->getUpstream()->getReferences());` evaluates to false erroneously, as the ID is the only thing returned, and so a valid upstream `product_id` is not properly caught.

This patch simply adds the method found in `Upstream` model `getReferences()` override
