### PR TITLE
Remove errant ' from Help data

### DIFF
--- a/src/Commands/Backup/Automatic/InfoCommand.php
+++ b/src/Commands/Backup/Automatic/InfoCommand.php
@@ -31,7 +31,7 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
-     * @usage <site>.<env> Displays the day when <site>'s <env> environment's weekly backup is created'.
+     * @usage <site>.<env> Displays the day when <site>'s <env> environment's weekly backup is created.
      * @usage <site>.<env> --format=table Displays the hour of <site>'s <env> environment's daily backups (retained for one week) and the day on which its weekly backups (retained for one month) are made.
      */
     public function getSchedule($site_env)


### PR DESCRIPTION
I found this while creating reference documentation for all Terminus commands.