### PR TITLE
Include composer.json and composer.lock in terminus.phar.

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,7 +3,7 @@
   "chmod": "0755",
   "compactors": [],
   "directories": ["assets", "bin", "config", "src", "templates"],
-  "files": ["README.md"],
+  "files": ["README.md","composer.lock","composer.json"],
   "finder": [
     {
       "exclude": [


### PR DESCRIPTION
This will allow us to evaluate our dependencies when loading plugins with terminus.phar.

The existing code has a short-circuit for Terminus plugins that do not have dependencies; it checks for the existence of a composer.lock file, which historically was not written by Composer 1 for projects with no dependencies. Composer 2 writes this file, though, so we are getting more folks who find it impossible to use Terminus plugins with terminus.phar when using Composer 2 to install them.

This PR fixes that problem.