### PR TITLE
[BUGS-3082] Bugfix for plan:info command, the site object was not set resulting i…

### DIFF
--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -28,6 +28,9 @@ class Plan extends TerminusModel implements SiteInterface
             $attributes = (object)$attributes->attributes;
         }
         parent::__construct($attributes, $options);
+        if (isset($options['site'])) {
+            $this->setSite($options['site']);
+        }
     }
 
     /**

--- a/tests/unit_tests/Commands/Plan/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Plan/ListCommandTest.php
@@ -23,7 +23,7 @@ class ListCommandTest extends CommandTestCase
             ['id' => 'master', 'sku' => 'xxx'],
             ['id' => 'another', 'sku' => 'yyy'],
         ];
-        
+
         $plans_collection = $this->getMockBuilder(Plans::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/unit_tests/Models/PlanTest.php
+++ b/tests/unit_tests/Models/PlanTest.php
@@ -3,6 +3,7 @@
 namespace Pantheon\Terminus\UnitTests\Models;
 
 use Pantheon\Terminus\Collections\Plans;
+use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\Plan;
 
 /**
@@ -28,6 +29,9 @@ class PlanTest extends ModelTestCase
     {
         parent::setUp();
         $this->plans = $this->getMockBuilder(Plans::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->site = $this->getMockBuilder(Site::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->data = [
@@ -203,7 +207,7 @@ class PlanTest extends ModelTestCase
      */
     protected function makePlan(array $attributes = [])
     {
-        $model = new Plan((object)$attributes, ['collection' => $this->plans,]);
+        $model = new Plan((object)$attributes, ['collection' => $this->plans,'site' => $this->site,]);
         $model->setConfig($this->config);
         $model->setRequest($this->request);
         return $model;


### PR DESCRIPTION
…n a bad URL being formed

Before:
```
Notice: Trying to get property 'id' of non-object in /Users/mark/Pantheon/terminus/src/Friends/SiteTrait.php on line 45
 [error]  Client error: `GET https://terminus.pantheon.io/api/sites//plan` resulted in a `404 Not Found` response:
Not found.
```

