### PR TITLE
[FEAT-596] Add multiple tag filter support

### DIFF
--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -150,7 +150,7 @@ class Sites extends APICollection implements SessionAwareInterface
     public function filterByTag($tag)
     {
         return $this->filter(function ($site) use ($tag) {
-            return (empty($tag)) ? $site->tags->contains_none() : $site->tags->contains_any($this->splitString($tag));
+            return (empty($tag)) ? $site->tags->containsNone() : $site->tags->containsAny($this->splitString($tag));
         });
     }
 
@@ -163,7 +163,7 @@ class Sites extends APICollection implements SessionAwareInterface
     public function filterByTags($tags)
     {
         return $this->filter(function ($site) use ($tags) {
-            return (empty($tags)) ? $site->tags->contains_none() : $site->tags->contains_all($this->splitString($tags));
+            return (empty($tags)) ? $site->tags->containsNone() : $site->tags->containsAll($this->splitString($tags));
         });
     }
 

--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -142,15 +142,28 @@ class Sites extends APICollection implements SessionAwareInterface
     }
 
     /**
-     * Filters sites list by tag
+     * Filters sites list by tags separated by a comma (ANY).
      *
-     * @param string $tag A tag to filter by
+     * @param string $tag Comma-separated list of tags to filter by
      * @return Sites
      */
     public function filterByTag($tag)
     {
         return $this->filter(function ($site) use ($tag) {
-            return $site->tags->has($tag);
+            return (empty($tag)) ? $site->tags->contains_none() : $site->tags->contains_any($this->splitString($tag));
+        });
+    }
+
+    /**
+     * Filters sites list by tags separated by a comma (ALL).
+     *
+     * @param string $tags Comma-separated list of tags to filter by
+     * @return Sites
+     */
+    public function filterByTags($tags)
+    {
+        return $this->filter(function ($site) use ($tags) {
+            return (empty($tags)) ? $site->tags->contains_none() : $site->tags->contains_all($this->splitString($tags));
         });
     }
 

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -171,6 +171,40 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     }
 
     /**
+     * Determines whether the models contain any object provided a list of IDs
+     *
+     * @param array $ids UUIDs of object to seek
+     * @return boolean True if object is found, false if it is not
+     */
+    public function contains_any($ids)
+    {
+        $ids = array_flip($ids);
+        return !is_null($models = $this->all()) && !empty(array_intersect_key($ids, $models));
+    }
+
+    /**
+     * Determines whether the models contain all objects provided a list of IDs
+     *
+     * @param array $ids UUIDs of object to seek
+     * @return boolean True if object is found, false if it is not
+     */
+    public function contains_all($ids)
+    {
+        $ids = array_flip($ids);
+        return !is_null($models = $this->all()) && empty(array_diff(array_keys($ids), array_keys($models)));
+    }
+
+    /**
+     * Determines whether the models contain no objects.
+     *
+     * @return boolean False if object is found, True if it is not
+     */
+    public function contains_none()
+    {
+        return !is_null($models = $this->all()) && empty($models);
+    }
+
+    /**
      * List Model IDs
      *
      * @return string[] Array of all model IDs
@@ -211,5 +245,19 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     public function setData(array $data = [])
     {
         $this->data = $data;
+    }
+
+    /**
+     * Convert comma-separated string into an array.
+     * @param string $input
+     * @return array
+     */
+    public function splitString($input = "")
+    {
+        /**
+         * array_map to trim each item
+         * array_filter to always return an array, even if empty
+         */
+        return array_filter(array_map('trim', explode(',', $input)));
     }
 }

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -176,7 +176,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
      * @param array $ids UUIDs of object to seek
      * @return boolean True if object is found, false if it is not
      */
-    public function contains_any($ids)
+    public function containsAny($ids)
     {
         $ids = array_flip($ids);
         return !is_null($models = $this->all()) && !empty(array_intersect_key($ids, $models));
@@ -188,7 +188,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
      * @param array $ids UUIDs of object to seek
      * @return boolean True if object is found, false if it is not
      */
-    public function contains_all($ids)
+    public function containsAll($ids)
     {
         $ids = array_flip($ids);
         return !is_null($models = $this->all()) && empty(array_diff(array_keys($ids), array_keys($models)));
@@ -199,7 +199,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
      *
      * @return boolean False if object is found, True if it is not
      */
-    public function contains_none()
+    public function containsNone()
     {
         return !is_null($models = $this->all()) && empty($models);
     }

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -11,6 +11,7 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
  * Class ListCommand
+ *
  * @package Pantheon\Terminus\Commands\Org\Site
  */
 class ListCommand extends TerminusCommand implements SiteAwareInterface
@@ -36,9 +37,9 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     created: Created
      *     tags: Tags
      *     frozen: Is Frozen?
-     * @param string $organization Organization name, label, or ID
-     * @param null[] $options
-     * @return RowsOfFields
+     * @param        string $organization Organization name, label, or ID
+     * @param        null[] $options
+     * @return       RowsOfFields
      *
      * @throws TerminusNotFoundException
      * @option plan DEPRECATED Plan filter; filter by the plan's label
@@ -52,8 +53,10 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <organization> --tags=<tags> Displays the list of sites associated with <organization> that have ALL <tags> tags.
      * @usage <organization> --upstream=<upstream> Displays the list of sites associated with <organization> with the upstream having UUID <upstream>.
      */
-    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,])
-    {
+    public function listSites(
+        $organization,
+        $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,]
+    ) {
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
         if (isset($options['plan']) && !is_null($plan = $options['plan'])) {

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -5,6 +5,7 @@ namespace Pantheon\Terminus\Commands\Org\Site;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
@@ -35,19 +36,23 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     created: Created
      *     tags: Tags
      *     frozen: Is Frozen?
+     * @param string $organization Organization name, label, or ID
+     * @param null[] $options
      * @return RowsOfFields
      *
-     * @param string $organization Organization name, label, or ID
+     * @throws TerminusNotFoundException
      * @option plan DEPRECATED Plan filter; filter by the plan's label
-     * @option string $tag DEPRECATED Tag name to filter
+     * @option string $tag A comma-separated list of tags to filter by (ANY can match)
+     * @option string $tags A comma-separated list of tags to filter by (ALL must match)
      * @option string $upstream Upstream name to filter
      *
      * @usage <organization> Displays the list of sites associated with <organization>.
      * @usage <organization> --plan=<plan> Displays the list of sites associated with <organization> having the plan named <plan>.
-     * @usage <organization> --tag=<tag> Displays the list of sites associated with <organization> that have the <tag> tag.
+     * @usage <organization> --tag=<tag> Displays the list of sites associated with <organization> that have ANY <tag> tag.
+     * @usage <organization> --tags=<tags> Displays the list of sites associated with <organization> that have ALL <tags> tags.
      * @usage <organization> --upstream=<upstream> Displays the list of sites associated with <organization> with the upstream having UUID <upstream>.
      */
-    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'upstream' => null,])
+    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,])
     {
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
@@ -56,6 +61,9 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
         }
         if (!is_null($tag = $options['tag'])) {
             $this->sites->filterByTag($tag);
+        }
+        if (!is_null($tags = $options['tags'])) {
+            $this->sites->filterByTags($tags);
         }
         if (!is_null($upstream = $options['upstream'])) {
             $this->sites->filterByUpstream($upstream);


### PR DESCRIPTION
- Add the ability to provide a comma-separated list of tags to `--tag` that will return a list of sites that have ANY tag in the list. (fixes #1790)
- Add an additional `--tags` option which takes a comma-separated list of tags, but requires ALL tags to match.
- Now supports NO tags and will return only sites with no tags if the tag option value is empty (fixes #1845)

The summary of this PR is extending the functionality of the existing `--tag` option to support multiple tags as a comma-separated string, in addition to adding a `--tags` option which is more explicit. These also support single tag values as to not alter the previous behavior.

- `--tag` will return sites matching ANY tag
- `--tags` will return sites that match ALL tags
- Both options will return all sites with NO tags if the value is an empty string (`--tag ""`)

I added 3 methods to the `TerminusCollection` in addition to the binary `has()` method:

- `containsAny` - if any provided ID matches
- `containsAll` - if all provided IDs match
- `containsNone` - Match if an empty ID was provided with sites with no ID

**What about `--filter`?**
While the `--filter` option can work, it is more restrictive in terms of both functionality and results. The tag field is parsed as a single, combined string, which causes unexpected results.

1. Single tag (`--filter "tags=tagA"`)
This will only return a list of sites that have only this one tag. If the site has other tags, this fails.

2. More than one tag (`--filter "tags=tagA||tags=tagB"`)
Similar to a single tag, only shows a list of sites if they solely contain each tag, and it disregards other tags.

3. More than one tag, but listed alphabetically (`--filter "tags=tagA,tagB"`)
Will only list sites that have both tags (none others), and they must be listed in alphabetical order. If you were switch the order of the tags (tagB,tagA), then you will get no results.