### PR TITLE
Display site name on notice or warning messages when there is nothing to deploy.

### DIFF
--- a/src/Commands/Env/DeployCommand.php
+++ b/src/Commands/Env/DeployCommand.php
@@ -51,7 +51,7 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
         $annotation = $options['note'];
         if ($env->isInitialized()) {
             if (!$env->hasDeployableCode()) {
-                $this->log()->notice('There is nothing to deploy.');
+                $this->log()->notice('There is nothing to deploy on ' . $site_env . '.');
                 return;
             }
 

--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -66,7 +66,7 @@ class ApplyCommand extends UpdatesCommand
             $this->processWorkflow($workflow);
             $this->log()->notice($workflow->getMessage());
         } else {
-            $this->log()->warning('There are no available updates for this site.');
+            $this->log()->warning('There are no available updates for the site ' . $site_env . '.');
         }
     }
 }

--- a/src/Commands/Upstream/Updates/ListCommand.php
+++ b/src/Commands/Upstream/Updates/ListCommand.php
@@ -55,7 +55,7 @@ class ListCommand extends UpdatesCommand
         );
 
         if (empty($data)) {
-            $this->log()->warning('There are no available updates for this site.');
+            $this->log()->warning('There are no available updates for the site ' . $site_env . '.');
         }
 
         // Return the output data.

--- a/tests/features/env-deploy.feature
+++ b/tests/features/env-deploy.feature
@@ -26,7 +26,7 @@ Feature: Site Deployment
   @vcr env-deploy-no-changes.yml
   Scenario: Failing to deploy dev to test because there are no changes to deploy
     When I run "terminus env:deploy [[test_site_name]].test --note='Deploy test' --sync-content"
-    Then I should get: "There is nothing to deploy."
+    Then I should get: "There is nothing to deploy on [[test_site_name]].test."
 
   @vcr env-deploy-init-with-message.yml
   Scenario: Initializing test when it has not been previously initialized

--- a/tests/features/upstream-updates-list.feature
+++ b/tests/features/upstream-updates-list.feature
@@ -11,7 +11,7 @@ Feature: Update a site with all its upstream's updates
   @vcr upstream-updates.yml
   Scenario: Check for upstream updates and there aren't any
     When I run "terminus upstream:updates:list [[test_site_name]].dev"
-    Then I should get: "There are no available updates for this site."
+    Then I should get: "There are no available updates for the site [[test_site_name]].dev."
     And I should get: "----------- ----------- --------- --------"
     And I should get: "Commit ID   Timestamp   Message   Author"
     And I should get: "----------- ----------- --------- --------"

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -52,7 +52,7 @@ class ApplyCommandTest extends UpdatesCommandTest
             ->method('log')
             ->with(
                 $this->equalTo('warning'),
-                $this->equalTo('There are no available updates for this site.')
+                $this->equalTo('There are no available updates for the site 123')
             );
 
         $this->environment->expects($this->never())

--- a/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ApplyCommandTest.php
@@ -52,7 +52,7 @@ class ApplyCommandTest extends UpdatesCommandTest
             ->method('log')
             ->with(
                 $this->equalTo('warning'),
-                $this->equalTo('There are no available updates for the site 123')
+                $this->equalTo('There are no available updates for the site 123.')
             );
 
         $this->environment->expects($this->never())

--- a/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
@@ -43,7 +43,7 @@ class ListCommandTest extends UpdatesCommandTest
             ->method('log')
             ->with(
                 $this->equalTo('warning'),
-                $this->equalTo('There are no available updates for the site 123')
+                $this->equalTo('There are no available updates for the site 123.')
             );
 
         $out = $this->command->listUpstreamUpdates('123');

--- a/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
+++ b/tests/unit_tests/Commands/Upstream/Updates/ListCommandTest.php
@@ -43,7 +43,7 @@ class ListCommandTest extends UpdatesCommandTest
             ->method('log')
             ->with(
                 $this->equalTo('warning'),
-                $this->equalTo('There are no available updates for this site.')
+                $this->equalTo('There are no available updates for the site 123')
             );
 
         $out = $this->command->listUpstreamUpdates('123');


### PR DESCRIPTION
Hi, I'd like to propose these changes because when running scripts that run the terminus upstream:apply or terminus env:deploy on multiple sites we would like to see which sites have not been synchronized yet with the CI tool.