### PR TITLE
[CORE-2239] Add stderr to strings returned from exec

### DIFF
--- a/src/Helpers/LocalMachineHelper.php
+++ b/src/Helpers/LocalMachineHelper.php
@@ -39,7 +39,11 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
     {
         $process = $this->getProcess($cmd);
         $process->run($callback);
-        return ['output' => $process->getOutput(), 'exit_code' => $process->getExitCode(),];
+        return [
+            'output' => $process->getOutput(),
+            'stderr' => $process->getErrorOutput(),
+            'exit_code' => $process->getExitCode(),
+        ];
     }
 
     /**
@@ -71,7 +75,11 @@ class LocalMachineHelper implements ConfigAwareInterface, ContainerAwareInterfac
             $process->start();
             $process->wait($callback);
         }
-        return ['output' => $process->getOutput(), 'exit_code' => $process->getExitCode(),];
+        return [
+            'output' => $process->getOutput(),
+            'stderr' => $process->getErrorOutput(),
+            'exit_code' => $process->getExitCode(),
+        ];
     }
 
     /**


### PR DESCRIPTION
If you execute a command using the existing library in Terminus, you can get what the command sent to stdout but not stderr.
This solves that.