### PR TITLE
Small fixes to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,6 @@ jobs:
         run: composer install
       - name: permissions
         run: chmod +x ./t3
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Functional Tests
         run: composer functional:short
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
         run: composer install
       - name: permissions
         run: chmod +x ./t3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Functional Tests
         run: composer functional:short
         env:

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -64,7 +64,7 @@ chmod(TERMINUE_BIN_FILE, 0700);
 if ($token) {
     exec(
         sprintf(
-            "%s auth:login --token=%s",
+            "%s auth:login --machine-token=%s",
             TERMINUE_BIN_FILE,
             $token
         )

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -57,7 +57,7 @@ if (empty($token)) {
 }
 
 
-define("TERMINUE_BIN_FILE", "./t3");
+define("TERMINUE_BIN_FILE", "php ./t3");
 
 chmod(TERMINUE_BIN_FILE, 0700);
 


### PR DESCRIPTION
Hi @stovak 

The first change in this PR fixes an error in the logs about --token.
The second one makes the tests run in linux. It was stuck because somehow it's not being able to pick up the phar file without the php command in front of it.