### PR TITLE
Add -S param to env command.

### DIFF
--- a/bin/t3
+++ b/bin/t3
@@ -1,4 +1,4 @@
-#!/usr/bin/env php -d memory_limit=2048M
+#!/usr/bin/env -S php -d memory_limit=2048M
 <?php
 
 /**


### PR DESCRIPTION
@stovak I just noticed I forgot to push this change to make the linux binary work.

The issue was that by default env treats everything as a single argument. -S makes it treat them as multiple arguments and therefore we can pass arguments to php.

This will make the tests in Linux run as expected and also will enable the deb package to work once created.