### PR TITLE
v3.0 phpcs config changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           path: /home/runner/work/terminus/terminus
       - name: Full Composer Install
         run: composer install
+      - name: Validate Code
+        run: composer code:lint
       - name: Phar Build
         run: composer phar:build
       - name: permissions

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
       "vendor/bin/robo coverage ./docs/TestCoverage.md"
     ],
     "cs": [
-      "phpcs --standard=tests/config/linting_ruleset.xml bin/t3 src"
+      "vendor/bin/phpcs --standard=tests/config/linting_ruleset.xml bin/t3 src tests/Functional"
     ],
     "docs": [
       "vendor/bin/robo doc ./README.md",

--- a/tests/Functional/TagCommandsTest.php
+++ b/tests/Functional/TagCommandsTest.php
@@ -28,7 +28,7 @@ class TagCommandsTest extends TestCase
      * @group short
      */
     public function testTagAddListRemove()
-    {   
+    {
         $siteName = getenv('TERMINUS_SITE');
         $orgId = getenv('TERMINUS_ORG');
         $newTag = uniqid("tag-");


### PR DESCRIPTION
1. Changed composer "cs" script to execute `vendor/bin/phpcs` instead of `phpcs`
2. Changed composer "cs" script to run on `tests/Functional` directory
3.  Added "Validate Code" step to CI's "Checkout & build Phar" phase