### PR TITLE
CMS-166 - backup:automatic:enable --keep-for parameter fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## MASTER
 
-- Translate `backup:automatic:enable` `keep-for` option to `weekly-ttl` expected by schedule backup workflow
+- Fix `backup:automatic:enable --keep-for` parameter not being respected (#2166)
 
 ## 2.6.0 - 2021-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## MASTER
 
+- Translate `backup:automatic:enable` `keep-for` option to `weekly-ttl` expected by schedule backup workflow
+
 ## 2.6.0 - 2021-06-04
 
 ### Added

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -33,6 +33,12 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
     public function enableSchedule($site_env, $options = ['day' => null, 'keep-for' => null,])
     {
         list(, $env) = $this->getSiteEnv($site_env);
+
+        // ygg expects 'weekly-ttl', not 'keep-for'
+        if(isset($options['keep-for']) && !is_null($options['keep-for'])) {
+            $options['weekly-ttl'] = $options['keep-for'];
+        }
+
         $env->getBackups()->setBackupSchedule($options);
         $this->log()->notice('Backup schedule successfully set.');
     }

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -34,7 +34,7 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
     {
         list(, $env) = $this->getSiteEnv($site_env);
 
-        // ygg expects 'weekly-ttl', not 'keep-for'
+        // Schedule Backup workflow expects 'weekly-ttl' as input option.
         if(isset($options['keep-for']) && !is_null($options['keep-for'])) {
             $options['weekly-ttl'] = $options['keep-for'];
         }

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -35,7 +35,7 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
         list(, $env) = $this->getSiteEnv($site_env);
 
         // Schedule Backup workflow expects 'weekly-ttl' as input option.
-        if(isset($options['keep-for']) && !is_null($options['keep-for'])) {
+        if (isset($options['keep-for'])) {
             $options['weekly-ttl'] = $options['keep-for'];
         }
 

--- a/tests/fixtures/backup-schedule-set-ttl.yml
+++ b/tests/fixtures/backup-schedule-set-ttl.yml
@@ -168,7 +168,7 @@
             Content-type: application/json
             Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:64461ccc-9666-11e6-ae7a-bc764e10d7c2:MDSxnCT7RyKhDzs43QKK5'
             Accept: null
-        body: '{"type":"change_backup_schedule","params":{"backup_schedule":{"0":{"hour":null,"ttl":691200},"1":{"hour":null,"ttl":691200},"2":{"hour":null,"ttl":2764800},"3":{"hour":null,"ttl":691200},"4":{"hour":null,"ttl":691200},"5":{"hour":null,"ttl":691200},"6":{"hour":null,"ttl":691200}}}}'
+        body: '{"type":"change_backup_schedule","params":{"backup_schedule":{"0":{"hour":null,"ttl":691200},"1":{"hour":null,"ttl":691200},"2":{"hour":null,"ttl":15552000},"3":{"hour":null,"ttl":691200},"4":{"hour":null,"ttl":691200},"5":{"hour":null,"ttl":691200},"6":{"hour":null,"ttl":691200}}}}'
     response:
         status:
             http_version: '1.1'
@@ -250,3 +250,4 @@
             Vary: Accept-Encoding
             Strict-Transport-Security: max-age=31536000
         body: '{"0": {"hour": 16, "ttl": 691200}, "1": {"hour": 16, "ttl": 691200}, "2": {"hour": 16, "ttl": 15552000}, "3": {"hour": 16, "ttl": 691200}, "4": {"hour": 16, "ttl": 691200}, "5": {"hour": 16, "ttl": 691200}, "6": {"hour": 16, "ttl": 691200}}'
+ 


### PR DESCRIPTION
Still need to confirm that this fixes [the issue](https://getpantheon.atlassian.net/browse/CMS-166).

Included a line in CHANGELOG.md.

Propose squashing the 3 commits when merging.