### PR TITLE
Clean up functional test groups

### DIFF
--- a/tests/Functional/AliasesCommandTest.php
+++ b/tests/Functional/AliasesCommandTest.php
@@ -22,8 +22,7 @@ class AliasesCommandTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\AliasesCommand
      *
-     * @group auth
-     * @group long
+     * @group todo
      */
     public function testGetAliases()
     {

--- a/tests/Functional/AuthCommandsTest.php
+++ b/tests/Functional/AuthCommandsTest.php
@@ -34,8 +34,10 @@ class AuthCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Auth\WhoamiCommand
+     *
      * @group auth
-     * @group auth
+     * @group short
+     *
      * @throws \JsonException
      */
     public function testAuthWhoAmI()

--- a/tests/Functional/ConnectionCommandsTest.php
+++ b/tests/Functional/ConnectionCommandsTest.php
@@ -23,8 +23,10 @@ class ConnectionCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Connection\InfoCommand
      * @covers \Pantheon\Terminus\Commands\Connection\SetCommand
      * @covers \Pantheon\Terminus\Commands\Env\InfoCommand
+     *
      * @group connection
      * @group long
+     *
      * @throws \JsonException
      */
     public function testConnection()

--- a/tests/Functional/D9ifyCommandsTest.php
+++ b/tests/Functional/D9ifyCommandsTest.php
@@ -23,7 +23,7 @@ class D9ifyCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\D9ify\ProcessCommand
      *
      * @group d9ify
-     * @group long
+     * @group todo
      */
     public function testBranchList()
     {

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -24,8 +24,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\ClearCacheCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testClearCacheCommand()
@@ -37,8 +39,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\DeployCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testDeployCommand()
@@ -50,8 +54,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\CloneContentCommand
+     *
      * @group env
      * @group long
+     *
      * @throws \JsonException
      */
     public function testCloneContentCommand()
@@ -63,8 +69,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\CodeLogCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testCodelogCommand()
@@ -100,8 +108,10 @@ class EnvCommandsTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\DiffStatCommand
      * @covers \Pantheon\Terminus\Commands\Env\CommitCommand
+     *
      * @group env
-     * @group long
+     * @group todo
+     *
      * @throws \JsonException
      */
     public function testCommitCommand()
@@ -113,8 +123,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\InfoCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testInfoCommand()
@@ -147,8 +159,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\MetricsCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testMetricsCommand()
@@ -180,8 +194,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\ListCommand
+     *
      * @group env
      * @group short
+     *
      * @throws \JsonException
      */
     public function testListCommand()
@@ -211,8 +227,10 @@ class EnvCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Env\ViewCommand
+     *
      * @group env
      * @group long
+     *
      * @throws \JsonException
      */
     public function testViewCommand()

--- a/tests/Functional/HTTPSCommandsTest.php
+++ b/tests/Functional/HTTPSCommandsTest.php
@@ -24,8 +24,8 @@ class HTTPSCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\HTTPS\RemoveCommand
      * @covers \Pantheon\Terminus\Commands\HTTPS\SetCommand
      *
-     * @group branch
-     * @group long
+     * @group https
+     * @group todo
      */
     public function testHTTPS()
     {

--- a/tests/Functional/ImportCommandsTest.php
+++ b/tests/Functional/ImportCommandsTest.php
@@ -61,6 +61,7 @@ class ImportCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Import\SiteCommand
      *
      * @group import
+     * @group todo
      */
     public function testImportSite()
     {

--- a/tests/Functional/LockCommandsTest.php
+++ b/tests/Functional/LockCommandsTest.php
@@ -23,7 +23,7 @@ class LockCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Lock\InfoCommand
      *
      * @group lock
-     * @group todo
+     * @group short
      *
      * @throws \Exception
      */

--- a/tests/Functional/LockCommandsTest.php
+++ b/tests/Functional/LockCommandsTest.php
@@ -23,7 +23,7 @@ class LockCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Lock\InfoCommand
      *
      * @group lock
-     * @group short
+     * @group todo
      *
      * @throws \Exception
      */

--- a/tests/Functional/MultiDevTest.php
+++ b/tests/Functional/MultiDevTest.php
@@ -18,6 +18,7 @@ class MultiDevTest extends TestCase
      * @covers Pantheon\Terminus\Commands\Multidev\CreateCommand
      * @covers Pantheon\Terminus\Commands\Multidev\ListCommand
      * @covers Pantheon\Terminus\Commands\Multidev\DeleteCommand
+     *
      * @group multidev
      * @group long
      */

--- a/tests/Functional/OrgCommandsTest.php
+++ b/tests/Functional/OrgCommandsTest.php
@@ -17,6 +17,7 @@ class OrgCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Org\ListCommand
+     *
      * @group org
      * @group short
      */
@@ -40,6 +41,7 @@ class OrgCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Org\People\ListCommand
+     *
      * @group org
      * @group short
      */
@@ -71,6 +73,7 @@ class OrgCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Org\Site\ListCommand
+     *
      * @group org
      * @group short
      */
@@ -94,6 +97,7 @@ class OrgCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Org\Upstream\ListCommand
+     *
      * @group org
      * @group short
      */

--- a/tests/Functional/OwnerCommandsTest.php
+++ b/tests/Functional/OwnerCommandsTest.php
@@ -22,8 +22,7 @@ class OwnerCommandsTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\Owner\SetCommand
      *
-     * @group branch
-     * @group long
+     * @group todo
      */
     public function testConnection()
     {

--- a/tests/Functional/PaymentMethodCommandsTest.php
+++ b/tests/Functional/PaymentMethodCommandsTest.php
@@ -24,8 +24,7 @@ class PaymentMethodCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\PaymentMethod\ListCommand
      * @covers \Pantheon\Terminus\Commands\PaymentMethod\RemoveCommand
      *
-     * @group branch
-     * @group long
+     * @group todo
      */
     public function testConnection()
     {

--- a/tests/Functional/PlanCommandsTest.php
+++ b/tests/Functional/PlanCommandsTest.php
@@ -24,8 +24,7 @@ class PlanCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Plan\ListCommand
      * @covers \Pantheon\Terminus\Commands\Plan\SetCommand
      *
-     * @group branch
-     * @group long
+     * @group todo
      */
     public function testConnection()
     {

--- a/tests/Functional/RemoteCommandsTest.php
+++ b/tests/Functional/RemoteCommandsTest.php
@@ -24,7 +24,7 @@ class RemoteCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\Remote\WPCommand
      *
      * @group remote
-     * @group long
+     * @group todo
      */
     public function testConnection()
     {

--- a/tests/Functional/SSHKeyCommandsTest.php
+++ b/tests/Functional/SSHKeyCommandsTest.php
@@ -25,7 +25,7 @@ class SSHKeyCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\SSHKey\RemoveCommand
      *
      * @group sshkey
-     * @group long
+     * @group todo
      */
     public function testSSHKeyCommand()
     {

--- a/tests/Functional/ServiceLevelCommandsTest.php
+++ b/tests/Functional/ServiceLevelCommandsTest.php
@@ -23,7 +23,7 @@ class ServiceLevelCommandsTest extends TestCase
      * @covers \Pantheon\Terminus\Commands\ServiceLevel\SetCommand
      *
      * @group service-level
-     * @group long
+     * @group todo
      */
     public function testConnection()
     {

--- a/tests/Functional/SiteCommandsTest.php
+++ b/tests/Functional/SiteCommandsTest.php
@@ -19,6 +19,7 @@ class SiteCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Site\ListCommand
+     *
      * @group site
      * @group short
      */
@@ -56,9 +57,11 @@ class SiteCommandsTest extends TestCase
      *
      * @test
      * @covers \Pantheon\Terminus\Commands\Site\Org\ListCommand
-     * @throws \JsonException
+     *
      * @group site
      * @group short
+     *
+     * @throws \JsonException
      */
     public function testSiteOrgListCommand()
     {
@@ -80,9 +83,11 @@ class SiteCommandsTest extends TestCase
      *
      * @test
      * @covers \Pantheon\Terminus\Commands\Site\Org\ListCommand
-     * @throws \JsonException
+     *
      * @group site
      * @group short
+     *
+     * @throws \JsonException
      */
     public function testSiteOrgsCommand()
     {
@@ -105,8 +110,10 @@ class SiteCommandsTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\Site\CreateCommand
      * @covers \Pantheon\Terminus\Commands\Site\InfoCommand
+     *
      * @group site
      * @group long
+     *
      * @throws \JsonException
      */
     public function testSiteCreateInfoDeleteCommand()

--- a/tests/Functional/UpstreamCommandsTest.php
+++ b/tests/Functional/UpstreamCommandsTest.php
@@ -23,6 +23,7 @@ class UpstreamCommandsTest extends TestCase
      *
      * @test
      * @covers \Pantheon\Terminus\Commands\Upstream\ListCommand
+     *
      * @group upstream
      * @group short
      */
@@ -44,8 +45,10 @@ class UpstreamCommandsTest extends TestCase
     /**
      * @test
      * @covers \Pantheon\Terminus\Commands\Upstream\InfoCommand
+     *
      * @group upstream
      * @group short
+     *
      * @throws \JsonException
      */
     public function testUpstreamInfoCommand()
@@ -67,8 +70,10 @@ class UpstreamCommandsTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\Upstream\Updates\ListCommand
      * @covers \Pantheon\Terminus\Commands\Upstream\Updates\StatusCommand
+     *
      * @group upstream
      * @group short
+     *
      * @throws \JsonException
      */
     public function testUpstreamUpdatesListStatus()

--- a/tests/Functional/WorkflowCommandsTest.php
+++ b/tests/Functional/WorkflowCommandsTest.php
@@ -21,12 +21,12 @@ class WorkflowCommandsTest extends TestCase
      * @test
      * @covers \Pantheon\Terminus\Commands\Workflow\WatchCommand
      * @covers \Pantheon\Terminus\Commands\Workflow\ListCommand
-     * @group long
-     * @group workflow
      *
+     * @group workflow
+     * @group todo
      */
     public function testWorkflowCRUD()
     {
-            $this->fail("Figure out how to test.");
+        $this->fail("Figure out how to test.");
     }
 }


### PR DESCRIPTION
- Moved un-implemented tests to 'todo' test group
- Made function comment formatting more consistent
