### PR TITLE
[CMS-228] Allow self:plugin:install to install from a path

### DIFF
--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -57,6 +57,9 @@ class InstallCommand extends PluginBaseCommand
         }
     }
 
+    /**
+     * Convert given projects into an array indexed by project name and path (if exists) as value.
+     */
     protected function convertPathProjects($projects)
     {
         $resultList = [];

--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -125,17 +125,20 @@ class InstallCommand extends PluginBaseCommand
         $dependencies_dir = $folders['dependencies_dir'];
         try {
             if (!empty($instalation_path)) {
-                $command = str_replace(
-                    ['{dir}', '{name}', '{path}',],
-                    [$plugins_dir, $project_name_without_version, realpath($instalation_path),],
-                    self::CONFIGURE_PATH_REPO_COMMAND
-                );
-                $results = $this->runCommand($command);
-                if ($results['exit_code'] !== 0) {
-                    throw new TerminusException(
-                        'Error requiring package in terminus-plugins.',
-                        []
+                // Update path repository in plugins dir and dependencies dir.
+                foreach ([$plugins_dir, $dependencies_dir] as $dir) {
+                    $command = str_replace(
+                        ['{dir}', '{name}', '{path}',],
+                        [$dir, $project_name_without_version, realpath($instalation_path),],
+                        self::CONFIGURE_PATH_REPO_COMMAND
                     );
+                    $results = $this->runCommand($command);
+                    if ($results['exit_code'] !== 0) {
+                        throw new TerminusException(
+                            'Error configuring path repository in ' . basename($dir),
+                            []
+                        );
+                    }
                 }
             }
 

--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -14,6 +14,8 @@ use Pantheon\Terminus\Plugins\PluginInfo;
 class InstallCommand extends PluginBaseCommand
 {
     const ALREADY_INSTALLED_MESSAGE = '{project} is already installed.';
+    const CONFIGURE_PATH_REPO_COMMAND =
+        'composer config -d {dir} repositories.{name} path {path}';
     const INSTALL_COMMAND =
         'composer require -d {dir} {project} --no-update';
     const INVALID_PROJECT_MESSAGE = '{project} is not a valid Packagist project.';
@@ -31,9 +33,10 @@ class InstallCommand extends PluginBaseCommand
      */
     public function install(array $projects)
     {
-        foreach ($projects as $project_name) {
+        $projects = $this->convertPathProjects($projects);
+        foreach ($projects as $project_name => $instalation_path) {
             if ($this->validateProject($project_name)) {
-                $results = $this->doInstallation($project_name);
+                $results = $this->doInstallation($project_name, $instalation_path);
                 // TODO Improve messaging
                 $this->log()->notice($results['output']);
             }
@@ -54,11 +57,57 @@ class InstallCommand extends PluginBaseCommand
         }
     }
 
+    protected function convertPathProjects($projects)
+    {
+        $resultList = [];
+
+        foreach ($projects as $project_or_path) {
+            if (!$this->hasProjectAtPath($project_or_path)) {
+                // No project was found, presume the parameter is a project and it has no path
+                $resultList[$project_or_path] = '';
+            }
+            else {
+                $project_name = $this->getProjectNameFromPath($project_or_path);
+                // A project name was found at the path, so record the name and its path
+                $resultList[$project_name] = $project_or_path;
+            }
+        }
+
+        return $resultList;
+    }
+
+    protected function hasProjectAtPath($project_or_path)
+    {
+        // If the specified path does not exist or does not have a composer.json file, presume it is a project.
+        $composerJson = $project_or_path . '/composer.json';
+        return is_dir($project_or_path) && file_exists($composerJson);
+    }
+
+    protected function getProjectNameFromPath($project_or_path)
+    {
+        $composerJson = $project_or_path . '/composer.json';
+        $composerContents = file_get_contents($composerJson);
+        // If the specified dir does not contain a terminus plugin, throw an error
+        $composerData = json_decode($composerContents, true);
+        if (!isset($composerData['type']) || ($composerData['type'] != 'terminus-plugin')) {
+            throw new TerminusException('Cannot install from path {path} because the project there is not of type "terminus-plugin"' . $composerJson, ['path' => $project_or_path]);
+        }
+
+        // If the specified dir does not have a name in the composer.json, throw an error
+        if (empty($composerData['name'])) {
+            throw new TerminusException('Cannot install from path {path} because the project there does not have a name', ['path' => $project_or_path]);
+        }
+
+        // Finally, return the project name and let install command install it as normal.
+        return $composerData['name'];
+    }
+
     /**
      * @param string $project_name Name of project to be installed
+     * @param string $instalation_path If not empty, install as a path repository
      * @return array Results from the install command
      */
-    private function doInstallation($project_name)
+    private function doInstallation($project_name, $instalation_path = '')
     {
         $plugin_name = PluginInfo::getPluginNameFromProjectName($project_name);
         $project_name_parts = explode(':', $project_name);
@@ -70,6 +119,21 @@ class InstallCommand extends PluginBaseCommand
         $plugins_dir = $folders['plugins_dir'];
         $dependencies_dir = $folders['dependencies_dir'];
         try {
+            if (!empty($instalation_path)) {
+                $command = str_replace(
+                    ['{dir}', '{name}', '{path}',],
+                    [$plugins_dir, $project_name_without_version, realpath($instalation_path),],
+                    self::CONFIGURE_PATH_REPO_COMMAND
+                );
+                $results = $this->runCommand($command);
+                if ($results['exit_code'] !== 0) {
+                    throw new TerminusException(
+                        'Error requiring package in terminus-plugins.',
+                        []
+                    );
+                }
+            }
+
             $command = str_replace(
                 ['{dir}', '{project}',],
                 [$plugins_dir, $project_name,],

--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -65,8 +65,7 @@ class InstallCommand extends PluginBaseCommand
             if (!$this->hasProjectAtPath($project_or_path)) {
                 // No project was found, presume the parameter is a project and it has no path
                 $resultList[$project_or_path] = '';
-            }
-            else {
+            } else {
                 $project_name = $this->getProjectNameFromPath($project_or_path);
                 // A project name was found at the path, so record the name and its path
                 $resultList[$project_name] = $project_or_path;
@@ -90,12 +89,18 @@ class InstallCommand extends PluginBaseCommand
         // If the specified dir does not contain a terminus plugin, throw an error
         $composerData = json_decode($composerContents, true);
         if (!isset($composerData['type']) || ($composerData['type'] != 'terminus-plugin')) {
-            throw new TerminusException('Cannot install from path {path} because the project there is not of type "terminus-plugin"' . $composerJson, ['path' => $project_or_path]);
+            throw new TerminusException(
+                'Cannot install from path {path} because the project there is not of type "terminus-plugin"',
+                ['path' => $project_or_path]
+            );
         }
 
         // If the specified dir does not have a name in the composer.json, throw an error
         if (empty($composerData['name'])) {
-            throw new TerminusException('Cannot install from path {path} because the project there does not have a name', ['path' => $project_or_path]);
+            throw new TerminusException(
+                'Cannot install from path {path} because the project there does not have a name',
+                ['path' => $project_or_path]
+            );
         }
 
         // Finally, return the project name and let install command install it as normal.

--- a/src/Commands/Self/Plugin/InstallCommand.php
+++ b/src/Commands/Self/Plugin/InstallCommand.php
@@ -75,6 +75,9 @@ class InstallCommand extends PluginBaseCommand
         return $resultList;
     }
 
+    /**
+     * Determines whether the given path contains a composer project.
+     */
     protected function hasProjectAtPath($project_or_path)
     {
         // If the specified path does not exist or does not have a composer.json file, presume it is a project.
@@ -82,13 +85,16 @@ class InstallCommand extends PluginBaseCommand
         return is_dir($project_or_path) && file_exists($composerJson);
     }
 
+    /**
+     * Gets project name from given path.
+     */
     protected function getProjectNameFromPath($project_or_path)
     {
         $composerJson = $project_or_path . '/composer.json';
         $composerContents = file_get_contents($composerJson);
         // If the specified dir does not contain a terminus plugin, throw an error
         $composerData = json_decode($composerContents, true);
-        if (!isset($composerData['type']) || ($composerData['type'] != 'terminus-plugin')) {
+        if (!isset($composerData['type']) || ($composerData['type'] !== 'terminus-plugin')) {
             throw new TerminusException(
                 'Cannot install from path {path} because the project there is not of type "terminus-plugin"',
                 ['path' => $project_or_path]

--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -253,6 +253,9 @@ abstract class PluginBaseCommand extends TerminusCommand
         }
     }
 
+    /**
+     * Return existing path repositories in given dir.
+     */
     protected function getPathRepositories($plugins_dir)
     {
         $path_repositories = [];

--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -266,8 +266,7 @@ abstract class PluginBaseCommand extends TerminusCommand
         if ($results['exit_code'] === 0) {
             $json = json_decode($results['output'], true);
             foreach ($json as $key => $repository) {
-                if (
-                    isset($repository['type']) &&
+                if (isset($repository['type']) &&
                     ($repository['type'] == 'path') &&
                     isset($repository['url']) &&
                     !empty($repository['url'])

--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -22,6 +22,7 @@ abstract class PluginBaseCommand extends TerminusCommand
     const PROJECT_NOT_FOUND_MESSAGE = 'No project or plugin named {project} found.';
     const DEPENDENCIES_REQUIRE_COMMAND = 'composer require -d {dir} {packages}';
     const COMPOSER_ADD_REPOSITORY = 'composer config -d {dir} repositories.{repo_name} path {path}';
+    const COMPOSER_GET_REPOSITORIES = 'composer config -d {dir} repositories';
     const BACKUP_COMMAND =
         "mkdir -p {backup_dir} && tar czvf {backup_dir}"
         . DIRECTORY_SEPARATOR . "backup.tar.gz \"{dir}\"";
@@ -178,6 +179,9 @@ abstract class PluginBaseCommand extends TerminusCommand
         }
         $this->ensureComposerJsonExists($plugins_dir, 'pantheon-systems/terminus-plugins');
         $this->ensureComposerJsonExists($dependencies_dir, 'pantheon-systems/terminus-dependencies');
+        // Get our path repositories and add the default entry
+        $path_repositories = $this->getPathRepositories($plugins_dir);
+        $path_repositories['pantheon-systems/terminus-plugins'] = '../' . $plugins_dir_basename;
         if (file_exists($this->getConfig()->get('root') . '/composer.lock')) {
             $terminus_composer_lock = json_decode(
                 file_get_contents($this->getConfig()->get('root') . '/composer.lock'),
@@ -194,30 +198,37 @@ abstract class PluginBaseCommand extends TerminusCommand
             $results = $this->runCommand($command);
             if ($results['exit_code'] === 0) {
                 // Second: Add path repositories.
-                $plugins_dir_basename = $this->getConfig()->get('plugins_dir_basename');
+                foreach ($path_repositories as $repo_name => $path) {
+                    $plugins_dir_basename = $this->getConfig()->get('plugins_dir_basename');
+                    $command = str_replace(
+                        ['{dir}', '{repo_name}', '{path}',],
+                        [$dependencies_dir, $repo_name, $path,],
+                        self::COMPOSER_ADD_REPOSITORY
+                    );
+                    $results = $this->runCommand($command);
+                    if ($results['exit_code'] !== 0) {
+                        throw new TerminusException(
+                            'Error configuring composer.json terminus-dependencies.',
+                            []
+                        );
+                    }
+                }
+
+                // Third: Require packages.
                 $command = str_replace(
-                    ['{dir}', '{repo_name}', '{path}',],
-                    [$dependencies_dir, 'pantheon-systems/terminus-plugins', '../' . $plugins_dir_basename,],
-                    self::COMPOSER_ADD_REPOSITORY
+                    ['{dir}', '{packages}',],
+                    [$dependencies_dir, 'pantheon-systems/terminus-plugins:*',],
+                    self::DEPENDENCIES_REQUIRE_COMMAND
                 );
                 $results = $this->runCommand($command);
                 if ($results['exit_code'] === 0) {
-                    // Third: Require packages.
-                    $command = str_replace(
-                        ['{dir}', '{packages}',],
-                        [$dependencies_dir, 'pantheon-systems/terminus-plugins:*',],
-                        self::DEPENDENCIES_REQUIRE_COMMAND
-                    );
-                    $results = $this->runCommand($command);
+                    // Finally: Update packages.
+                    $results = $this->runComposerUpdate($dependencies_dir);
                     if ($results['exit_code'] === 0) {
-                        // Finally: Update packages.
-                        $results = $this->runComposerUpdate($dependencies_dir);
-                        if ($results['exit_code'] === 0) {
-                            return [
-                                'plugins_dir' => $plugins_dir,
-                                'dependencies_dir' => $dependencies_dir,
-                            ];
-                        }
+                        return [
+                            'plugins_dir' => $plugins_dir,
+                            'dependencies_dir' => $dependencies_dir,
+                        ];
                     }
                 }
             }
@@ -240,6 +251,32 @@ abstract class PluginBaseCommand extends TerminusCommand
             $this->runCommand("composer --working-dir=${path} config minimum-stability dev");
             $this->runCommand("composer --working-dir=${path} config prefer-stable true");
         }
+    }
+
+    protected function getPathRepositories($plugins_dir)
+    {
+        $path_repositories = [];
+
+        $command = str_replace(
+            ['{dir}',],
+            [$plugins_dir],
+            self::COMPOSER_GET_REPOSITORIES
+        );
+        $results = $this->runCommand($command);
+        if ($results['exit_code'] === 0) {
+            $json = json_decode($results['output'], true);
+            foreach ($json as $key => $repository) {
+                if (
+                    isset($repository['type']) &&
+                    ($repository['type'] == 'path') &&
+                    isset($repository['url']) &&
+                    !empty($repository['url'])
+                ) {
+                    $path_repositories[$key] = $repository['url'];
+                }
+            }
+        }
+        return $path_repositories;
     }
 
     /**

--- a/src/Commands/Self/Plugin/UninstallCommand.php
+++ b/src/Commands/Self/Plugin/UninstallCommand.php
@@ -20,6 +20,8 @@ class UninstallCommand extends PluginBaseCommand
     const USAGE_MESSAGE = 'terminus self:plugin:<uninstall|remove> <project> [project 2] ...';
     const UNINSTALL_COMMAND =
     'composer remove -d {dir} {project} --no-update';
+    const REMOVE_PATH_REPO_COMMAND =
+        'composer config -d {dir} --unset repositories.{name}';
 
     /**
      * Remove one or more Terminus plugins.
@@ -93,6 +95,22 @@ class UninstallCommand extends PluginBaseCommand
                     'Error running composer update in terminus-dependencies.',
                     []
                 );
+            }
+
+            // Cleanup path repositories if they exist.
+            foreach ([$plugins_dir, $dependencies_dir] as $dir) {
+                $command = str_replace(
+                    ['{dir}', '{name}',],
+                    [$dir, $project_name,],
+                    self::REMOVE_PATH_REPO_COMMAND
+                );
+                $results = $this->runCommand($command);
+                if ($results['exit_code'] !== 0) {
+                    throw new TerminusException(
+                        'Error removing path repository in ' . basename($dir),
+                        []
+                    );
+                }
             }
 
             $this->replaceFolder($plugins_dir, $original_plugins_dir);

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -499,8 +499,6 @@ class Terminus implements
         $this->commands = $commands;
     }
 
-
-
     public static function factory($dependencies_version = null): Terminus
     {
         $input = new ArgvInput($_SERVER['argv']);
@@ -512,7 +510,7 @@ class Terminus implements
         $config->extend(new EnvConfig());
         if ($dependencies_version) {
             $dependenciesBaseDir = $config->get('dependencies_base_dir');
-            $terminusDependenciesDir = $dependenciesBaseDir . '/' . $dependencies_version;
+            $terminusDependenciesDir = $dependenciesBaseDir . '-' . $dependencies_version;
             $config->set('terminus_dependencies_dir', $terminusDependenciesDir);
             if (file_exists($terminusDependenciesDir . '/vendor/autoload.php')) {
                 include_once("$terminusDependenciesDir/vendor/autoload.php");


### PR DESCRIPTION
To use:

`t3 self:plugin:install <folder_path>`

Uninstall as you'd normally do and it will cleanup the added path repositories.