### PR TITLE
Ci yml cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
           name: CoverageReport
           path: docs/TestCoverage.md
 
+
+  # # NOT CURRENTLY USED
   # behat_tests:
   #   runs-on: ubuntu-latest
   #   name: Behat Tests
@@ -136,6 +138,7 @@ jobs:
   #       run: composer test:behat
 
 
+  # # NOT CURRENTLY USED
   # package_macos:
   #   runs-on: macos-latest
   #   name: Package a Homebrew release
@@ -148,6 +151,7 @@ jobs:
   #       run: brew bump-formula-pr --url=${{ steps.tagged.outputs.url }} --no-browse --no-audit --commit stovak/t3/terminus
 
 
+  # # NOT CURRENTLY USED
   # package_linux:
   #   runs-on: ubuntu-latest
   #   name: Package .deb Release
@@ -177,6 +181,7 @@ jobs:
   #         path: ./*.deb
   #         if-no-files-found: error
 
+  # # NOT CURRENTLY USED
   # publish_linux:
   #   runs-on: ubuntu-latest
   #   name: Publish .deb Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
           if-no-files-found: error
 
 
-  commit:
+  functional:
     runs-on: ${{ matrix.operating-system }}
-    name: Commit testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
+    name: Functional testing matrix - PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     if: ${{ ! startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,109 +99,109 @@ jobs:
           name: CoverageReport
           path: docs/TestCoverage.md
 
-  behat_tests:
-    runs-on: ubuntu-latest
-    name: Behat Tests
-    needs: [ checkout_build ]
-    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-    strategy:
-      matrix:
-        php-versions: [ '7.4', '8.0' ]
-      fail-fast: false
-    env:
-      TERMINUS_VERBOSITY: 22
-      TERMINUS_EXECUTABLE: t3
-      TERMINUS_TEST_MODE: 1
-      TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
-    steps:
-      - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: gd, mbstring, zip
-          coverage: pcov
-      - name: Download repo content from artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: full-workspace
-      - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: t3-phar
-      - name: Install Composer Dependencies
-        run: composer install --no-interaction --prefer-dist
-      - name: Fix permissions
-        run: chmod +x ./bin/t3
-      - name: Behat Tests
-        run: composer test:behat
+  # behat_tests:
+  #   runs-on: ubuntu-latest
+  #   name: Behat Tests
+  #   needs: [ checkout_build ]
+  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+  #   strategy:
+  #     matrix:
+  #       php-versions: [ '7.4', '8.0' ]
+  #     fail-fast: false
+  #   env:
+  #     TERMINUS_VERBOSITY: 22
+  #     TERMINUS_EXECUTABLE: t3
+  #     TERMINUS_TEST_MODE: 1
+  #     TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+  #   steps:
+  #     - name: Setup PHP with PECL extension
+  #       uses: shivammathur/setup-php@v2
+  #       with:
+  #         php-version: ${{ matrix.php-versions }}
+  #         extensions: gd, mbstring, zip
+  #         coverage: pcov
+  #     - name: Download repo content from artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: full-workspace
+  #     - name: Download terminus.phar as artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: t3-phar
+  #     - name: Install Composer Dependencies
+  #       run: composer install --no-interaction --prefer-dist
+  #     - name: Fix permissions
+  #       run: chmod +x ./bin/t3
+  #     - name: Behat Tests
+  #       run: composer test:behat
 
 
-  package_macos:
-    runs-on: macos-latest
-    name: Package a Homebrew release
-    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-    needs: [ 'functional_tests', 'behat_tests' ]
-    steps:
-      - name: Brew Tap Terminus
-        run: brew install stovak/t3/terminus
-      - name: Update tap with new release
-        run: brew bump-formula-pr --url=${{ steps.tagged.outputs.url }} --no-browse --no-audit --commit stovak/t3/terminus
+  # package_macos:
+  #   runs-on: macos-latest
+  #   name: Package a Homebrew release
+  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+  #   needs: [ 'functional_tests', 'behat_tests' ]
+  #   steps:
+  #     - name: Brew Tap Terminus
+  #       run: brew install stovak/t3/terminus
+  #     - name: Update tap with new release
+  #       run: brew bump-formula-pr --url=${{ steps.tagged.outputs.url }} --no-browse --no-audit --commit stovak/t3/terminus
 
 
-  package_linux:
-    runs-on: ubuntu-latest
-    name: Package .deb Release
-    container:
-      image: quay.io/pantheon-public/php-ci:v7.4
-    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-    needs: [ 'functional_tests', 'behat_tests' ]
-    steps:
-      - name: Download repo content from artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: full-workspace
-      - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: t3-phar
-      - name: Full Composer Install
-        run: composer install
-      - name: Prepare needed folder and fix permissions
-        run: mkdir -p ~/.terminus/cache/tokens && chmod +x ./t3
-      - name: Passegers, gather ye packages
-        run: composer bundle:linux
-      - name: Save t3 deb as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: t3-deb
-          path: ./*.deb
-          if-no-files-found: error
+  # package_linux:
+  #   runs-on: ubuntu-latest
+  #   name: Package .deb Release
+  #   container:
+  #     image: quay.io/pantheon-public/php-ci:v7.4
+  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+  #   needs: [ 'functional_tests', 'behat_tests' ]
+  #   steps:
+  #     - name: Download repo content from artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: full-workspace
+  #     - name: Download terminus.phar as artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: t3-phar
+  #     - name: Full Composer Install
+  #       run: composer install
+  #     - name: Prepare needed folder and fix permissions
+  #       run: mkdir -p ~/.terminus/cache/tokens && chmod +x ./t3
+  #     - name: Passegers, gather ye packages
+  #       run: composer bundle:linux
+  #     - name: Save t3 deb as artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: t3-deb
+  #         path: ./*.deb
+  #         if-no-files-found: error
 
-  publish_linux:
-    runs-on: ubuntu-latest
-    name: Publish .deb Release
-    strategy:
-      matrix:
-        # Add needed repositories in the form of <package_name>/<distro>/<version>.
-        repository:
-          - 'terminus/debian/buster'
-          - 'terminus/debian/bullseye'
-          - 'terminus/ubuntu/bionic'
-          - 'terminus/ubuntu/focal'
-          - 'terminus/ubuntu/groovy'
-          - 'terminus/ubuntu/hirsute'
-    if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
-    needs: [ 'package_linux' ]
-    steps:
-      - name: Download terminus deb as artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: t3-deb
-      - uses: docker://lpenz/ghaction-packagecloud:v0.2
-        with:
-          user: stovak
-          repository: ${{ matrix.repository }}
-          files: |
-            *.deb
-        env:
-          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+  # publish_linux:
+  #   runs-on: ubuntu-latest
+  #   name: Publish .deb Release
+  #   strategy:
+  #     matrix:
+  #       # Add needed repositories in the form of <package_name>/<distro>/<version>.
+  #       repository:
+  #         - 'terminus/debian/buster'
+  #         - 'terminus/debian/bullseye'
+  #         - 'terminus/ubuntu/bionic'
+  #         - 'terminus/ubuntu/focal'
+  #         - 'terminus/ubuntu/groovy'
+  #         - 'terminus/ubuntu/hirsute'
+  #   if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository_owner == 'pantheon-systems' }}
+  #   needs: [ 'package_linux' ]
+  #   steps:
+  #     - name: Download terminus deb as artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: t3-deb
+  #     - uses: docker://lpenz/ghaction-packagecloud:v0.2
+  #       with:
+  #         user: stovak
+  #         repository: ${{ matrix.repository }}
+  #         files: |
+  #           *.deb
+  #       env:
+  #         PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,54 +136,6 @@ jobs:
         run: composer test:behat
 
 
-  functional_tests:
-    runs-on: ubuntu-latest
-    name: Tagged Release Functional Tests
-    needs: [ checkout_build ]
-    strategy:
-      matrix:
-        # TODO: test on Win10/WSL+Ubunutu
-        operating-system: [ 'macos-latest', 'ubuntu-latest' ]
-        php-versions: [ '7.4', '8.0' ]
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'pantheon-systems' }}
-    steps:
-      - name: Download repo content from artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: full-workspace
-      - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: t3-phar
-      - name: Setup PHP with PECL extension
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: gd, mbstring, zip
-          coverage: pcov
-      - name: Install
-        run: composer install --no-interaction --prefer-dist
-      - name: Full testing scheme
-        run: composer functional:all
-      - name: Coverage Report
-        run: composer coverage
-      - name: Save coverage as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: CoverageReport
-          path: docs/TestCoverage.md
-      # If you've gotten this far, tag it as a release
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            t3
-          prerelease: true
-          # TODO: add a changelog to the release process
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
   package_macos:
     runs-on: macos-latest
     name: Package a Homebrew release

--- a/composer.json
+++ b/composer.json
@@ -126,8 +126,8 @@
       "@coverage"
     ],
     "test:functional": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --colors=always -c ./phpunit.xml --debug --do-not-cache-result",
-      "@coverage"
+      "@test:short",
+      "@test:long"
     ],
     "test:all": [
       "@test:functional",


### PR DESCRIPTION
Removed duplicate 'functional_tests' job.  Commented out jobs which currently aren't used: behat_tests, package_macos, package_linux, publish_linux 