### PR TITLE
Ensure FileStore directory is created if it does not exist.

### DIFF
--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -19,7 +19,7 @@ class FileStore extends \DirectoryIterator implements DataStoreInterface
      */
     public function __construct(string $directory)
     {
-        if (!file_exists($directory)) {
+        if (!is_dir($directory)) {
             mkdir($directory, 0755, true);
         }
         parent::__construct($directory);

--- a/src/DataStore/FileStore.php
+++ b/src/DataStore/FileStore.php
@@ -13,6 +13,19 @@ class FileStore extends \DirectoryIterator implements DataStoreInterface
 {
 
     /**
+     * Creates FileStore instance.
+     *
+     * Creates directory if it doesn't exist before invoking DirectoryIterator constructor.
+     */
+    public function __construct(string $directory)
+    {
+        if (!file_exists($directory)) {
+            mkdir($directory, 0755, true);
+        }
+        parent::__construct($directory);
+    }
+
+    /**
      * Reads retrieves data from the store
      *
      * @param string $key A key


### PR DESCRIPTION
Previously this class wasn't a \DirectoryIterator and whenever it needed to write/read it ensured that the directory exists.

Now, it's a \DirectoryIterator so, before creating it, we should ensure that it exists.

This issue hadn't probably popped up before because we already had the folders created by t2 installation and they are the same folders for t3, I found the issue while trying to make terminus-build-tools run on t3.