### PR TITLE
Fix org:list command to display org name and label info.

### DIFF
--- a/src/Friends/ProfileTrait.php
+++ b/src/Friends/ProfileTrait.php
@@ -25,8 +25,7 @@ trait ProfileTrait
             if (!empty($this->attributes->profile)) {
                 $this->getContainer()->add($nickname, new Profile($this->attributes->profile))
                     ->addArgument([$this->get('profile')]);
-            }
-            else {
+            } else {
                 $this->getContainer()->add($nickname, Profile::class)
                     ->addArgument([$this->get('profile')]);
             }

--- a/src/Friends/ProfileTrait.php
+++ b/src/Friends/ProfileTrait.php
@@ -22,8 +22,14 @@ trait ProfileTrait
     {
         if (empty($this->profile)) {
             $nickname = \uniqid(__FUNCTION__ . "-");
-            $this->getContainer()->add($nickname, Profile::class)
-                ->addArgument([$this->get('profile')]);
+            if (!empty($this->attributes->profile)) {
+                $this->getContainer()->add($nickname, new Profile($this->attributes->profile))
+                    ->addArgument([$this->get('profile')]);
+            }
+            else {
+                $this->getContainer()->add($nickname, Profile::class)
+                    ->addArgument([$this->get('profile')]);
+            }
             $profile = $this->getContainer()->get($nickname);
             $this->setProfile($profile);
         }

--- a/src/Friends/ProfileTrait.php
+++ b/src/Friends/ProfileTrait.php
@@ -22,13 +22,8 @@ trait ProfileTrait
     {
         if (empty($this->profile)) {
             $nickname = \uniqid(__FUNCTION__ . "-");
-            if (!empty($this->attributes->profile)) {
-                $this->getContainer()->add($nickname, new Profile($this->attributes->profile))
-                    ->addArgument([$this->get('profile')]);
-            } else {
-                $this->getContainer()->add($nickname, Profile::class)
-                    ->addArgument([$this->get('profile')]);
-            }
+            $this->getContainer()->add($nickname, Profile::class)
+                ->addArgument($this->get('profile'));
             $profile = $this->getContainer()->get($nickname);
             $this->setProfile($profile);
         }

--- a/tests/Functional/OrgCommandsTest.php
+++ b/tests/Functional/OrgCommandsTest.php
@@ -30,7 +30,13 @@ class OrgCommandsTest extends TestCase
             "row from org list array of orgs should be an org item"
         );
         $this->assertArrayHasKey('id', $org, "Orgs from org list should have an id property");
+        $this->assertNotEmpty($org['id'], 'Orgs ID should not be empty');
+
         $this->assertArrayHasKey('name', $org, "Orgs from org list should have a name property");
+        $this->assertNotEmpty($org['name'], 'Orgs Name should not be empty');
+
+        $this->assertArrayHasKey('label', $org, "Orgs from org list should have a label property");
+        $this->assertNotEmpty($org['label'], 'Orgs Label should not be empty');
     }
 
     /**


### PR DESCRIPTION
Previously name and label were empty because the Profile was never getting that information.

This PR fixes that.

## Previously:

```
 -------------------------------------- ------ -------
  ID                                     Name   Label
 -------------------------------------- ------ -------
  XXXX-XXXXXXX
 -------------------------------------- ------ -------
```

## Now:

```
 -------------------------------------- -------------------------- --------------------------
  ID                                     Name                       Label
 -------------------------------------- -------------------------- --------------------------
  XXXX-XXXXXXX   ci-xxxxxxxxxxx            CI XXXXXXXX
 -------------------------------------- -------------------------- --------------------------
```