### PR TITLE
Refactor SiteAwareTrait

### DIFF
--- a/src/Collections/Domains.php
+++ b/src/Collections/Domains.php
@@ -51,11 +51,13 @@ class Domains extends EnvironmentOwnedCollection
      * Fetches domain data hydrated with recommendations
      *
      * @param array $options Additional information for the request
-     * @return void
+     *
+     * @return \Pantheon\Terminus\Collections\TerminusCollection
      */
     public function fetchWithRecommendations($options = [])
     {
         $this->setFetchArgs(['query' => ['hydrate' => ['as_list', 'recommendations',],],]);
+
         return $this->fetch();
     }
 }

--- a/src/Collections/Environments.php
+++ b/src/Collections/Environments.php
@@ -3,9 +3,11 @@
 namespace Pantheon\Terminus\Collections;
 
 use Pantheon\Terminus\Models\Environment;
+use Pantheon\Terminus\Models\Workflow;
 
 /**
- * Class Environments
+ * Class Environments.
+ *
  * @package Pantheon\Terminus\Collections
  */
 class Environments extends SiteOwnedCollection
@@ -28,9 +30,12 @@ class Environments extends SiteOwnedCollection
      * @param array $options
      *     bool no-db Do not copy database from the source environment
      *     bool no-files Do not copy files from the source environment
-     * @return Workflow
+     *
+     * @return \Pantheon\Terminus\Models\Workflow
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    public function create($target_env_id, Environment $source_env, array $options = [])
+    public function create($target_env_id, Environment $source_env, array $options = []): Workflow
     {
         $params = [
             'clone_database' => ['from_environment' => $source_env->id,],
@@ -44,7 +49,7 @@ class Environments extends SiteOwnedCollection
             unset($params['clone_files']);
         }
 
-        $workflow = $this->getSite()->getWorkflows()->create(
+        return $this->getSite()->getWorkflows()->create(
             'create_cloud_development_environment',
             [
                 'params' => [
@@ -53,7 +58,6 @@ class Environments extends SiteOwnedCollection
                 ],
             ]
         );
-        return $workflow;
     }
 
     /**

--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -181,7 +181,7 @@ class Sites extends APICollection implements SessionAwareInterface
      * @return Site
      * @throws TerminusException
      */
-    public function get($id): ?TerminusModel
+    public function get($id): TerminusModel
     {
         try {
             $uuid = $this->findUUIDByNameOrUUID($id);

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -132,7 +132,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
      * @return TerminusModel $this->models[$id]
      * @throws TerminusNotFoundException
      */
-    public function get($id): ?TerminusModel
+    public function get($id): TerminusModel
     {
         foreach ($this->all() as $member) {
             if (in_array($id, $member->getReferences())) {

--- a/src/Collections/Workflows.php
+++ b/src/Collections/Workflows.php
@@ -89,7 +89,7 @@ class Workflows extends APICollection implements SessionAwareInterface
      *   - params: associative array of parameters for the request
      * @return Workflow $model
      */
-    public function create($type, array $options = [])
+    public function create($type, array $options = []): Workflow
     {
 
         $params = $options['params'] ?? [];

--- a/src/Commands/Auth/LoginCommand.php
+++ b/src/Commands/Auth/LoginCommand.php
@@ -36,8 +36,7 @@ class LoginCommand extends TerminusCommand
      * @usage Logs in a user with a previously saved machine token.
      * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
      *
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
-     * @throws TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function logIn(array $options = ['machine-token' => null, 'email' => null,]): void
     {

--- a/src/Commands/Backup/Automatic/DisableCommand.php
+++ b/src/Commands/Backup/Automatic/DisableCommand.php
@@ -27,7 +27,6 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Disables the regular backup schedule for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function disableSchedule($site_env)
     {

--- a/src/Commands/Backup/Automatic/DisableCommand.php
+++ b/src/Commands/Backup/Automatic/DisableCommand.php
@@ -7,7 +7,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class CancelCommand
+ * Class DisableCommand.
+ *
  * @package Pantheon\Terminus\Commands\Backup\Automatic
  */
 class DisableCommand extends TerminusCommand implements SiteAwareInterface
@@ -24,11 +25,13 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Disables the regular backup schedule for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function disableSchedule($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-        $env->getBackups()->cancelBackupSchedule();
+        $this->getEnv($site_env)->getBackups()->cancelBackupSchedule();
         $this->log()->notice('Backup schedule successfully canceled.');
     }
 }

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -33,7 +33,6 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> --keep-for=<days> Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups on <day> that are retained for <days>.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function enableSchedule($site_env, $options = ['day' => null, 'keep-for' => null,])
     {

--- a/src/Commands/Backup/Automatic/EnableCommand.php
+++ b/src/Commands/Backup/Automatic/EnableCommand.php
@@ -2,13 +2,13 @@
 
 namespace Pantheon\Terminus\Commands\Backup\Automatic;
 
-use Pantheon\Terminus\Collections\Backups;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class SetCommand
+ * Class EnableCommand.
+ *
  * @package Pantheon\Terminus\Commands\Backup\Automatic
  */
 class EnableCommand extends TerminusCommand implements SiteAwareInterface
@@ -23,23 +23,26 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
      * @command backup:automatic:enable
      *
      * @param string $site_env Site & environment in the format `site-name.env`
+     * @param null[] $options
+     *
      * @option string $day Day of the week to make the month-long backup in any format recognized by PHP strtotime
      * @option integer $keep-for Retention period, in days, to retain the weekly backup. The default is 32 days.
      *
      * @usage <site>.<env> Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups that are retained for one month.
      * @usage <site>.<env> --day=<day> Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups on <day> that are retained for one month.
      * @usage <site>.<env> --keep-for=<days> Enables automatic daily backups of <site>'s <env> environment that are retained for one week and weekly backups on <day> that are retained for <days>.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function enableSchedule($site_env, $options = ['day' => null, 'keep-for' => null,])
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-
         // Schedule Backup workflow expects 'weekly-ttl' as input option.
         if (isset($options['keep-for'])) {
             $options['weekly-ttl'] = $options['keep-for'];
         }
 
-        $env->getBackups()->setBackupSchedule($options);
+        $this->getEnv($site_env)->getBackups()->setBackupSchedule($options);
         $this->log()->notice('Backup schedule successfully set.');
     }
 }

--- a/src/Commands/Backup/Automatic/InfoCommand.php
+++ b/src/Commands/Backup/Automatic/InfoCommand.php
@@ -35,7 +35,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @return PropertyList
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function getSchedule($site_env)
     {

--- a/src/Commands/Backup/Automatic/InfoCommand.php
+++ b/src/Commands/Backup/Automatic/InfoCommand.php
@@ -18,7 +18,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
     /**
      * Displays the hour when daily backups are created and the day of the week when weekly backups are created.
      *
-     *
      * @authorize
      *
      * @command backup:automatic:info
@@ -28,17 +27,19 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     weekly_backup_day: Weekly Backup Day
      *     expiry: Weekly Backup Expiry
      * @default-string-field weekly_backup_day
-     * @return PropertyList
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Displays the day when <site>'s <env> environment's weekly backup is created.
      * @usage <site>.<env> --format=table Displays the hour of <site>'s <env> environment's daily backups (retained for one week), day on which its weekly backups (retained for one month) are made, and how long it is kept for.
+     *
+     * @return PropertyList
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function getSchedule($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-        $schedule = $env->getBackups()->getBackupSchedule();
+        $schedule = $this->getEnv($site_env)->getBackups()->getBackupSchedule();
         if (is_null($schedule['daily_backup_hour'])) {
             $this->log()->notice('Backups are not currently scheduled to be run.');
         }

--- a/src/Commands/Backup/CreateCommand.php
+++ b/src/Commands/Backup/CreateCommand.php
@@ -32,7 +32,6 @@ class CreateCommand extends BackupCommand
      * @usage <site>.<env> --keep-for=<days> Creates a backup of <site>'s <env> environment's <element> and retains it for <days> days.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function create($site_env, $options = ['element' => 'all', 'keep-for' => null,])
     {

--- a/src/Commands/Backup/CreateCommand.php
+++ b/src/Commands/Backup/CreateCommand.php
@@ -6,7 +6,8 @@ use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
 use Pantheon\Terminus\Models\Backup;
 
 /**
- * Class CreateCommand
+ * Class CreateCommand.
+ *
  * @package Pantheon\Terminus\Commands\Backup
  */
 class CreateCommand extends BackupCommand
@@ -21,6 +22,7 @@ class CreateCommand extends BackupCommand
      * @command backup:create
      *
      * @param string $site_env Site & environment in the format `site-name.env`
+     * @param array $options
      * @option string $element [all|code|files|database|db] Element to be backed up
      * @option integer $keep-for Retention period, in days, to retain backup. It defaults to 365 days.
      *
@@ -28,15 +30,23 @@ class CreateCommand extends BackupCommand
      * @usage <site>.<env> --element=<element> Creates a backup of <site>'s <env> environment's <element>.
      * @usage <site>.<env> --keep-for=<days> Creates a backup of <site>'s <env> environment and retains it for <days> days.
      * @usage <site>.<env> --keep-for=<days> Creates a backup of <site>'s <env> environment's <element> and retains it for <days> days.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function create($site_env, $options = ['element' => 'all', 'keep-for' => null,])
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env);
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
+
         $options['keep-for'] = (isset($options['keep-for']) && !is_null($options['keep-for']))
             ? $options['keep-for']
             : Backup::DEFAULT_TTL;
         $options['element'] = isset($options['element']) ? $this->getElement($options['element']) : null;
         $this->processWorkflow($env->getBackups()->create($options));
-        $this->log()->notice('Created a backup of the {env} environment.', ['env' => $env->id,]);
+        $this->log()->notice(
+            'Created a backup of the {env} environment.',
+            ['env' => $env->getName()]
+        );
     }
 }

--- a/src/Commands/Backup/ListCommand.php
+++ b/src/Commands/Backup/ListCommand.php
@@ -39,7 +39,6 @@ class ListCommand extends BackupCommand
      * @usage <site>.<env> --element=<element> Lists all <element> backups made of <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function listBackups($site_env, array $options = ['element' => 'all',])
     {

--- a/src/Commands/Backup/ListCommand.php
+++ b/src/Commands/Backup/ListCommand.php
@@ -6,7 +6,8 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Commands\StructuredListTrait;
 
 /**
- * Class ListCommand
+ * Class ListCommand.
+ *
  * @package Pantheon\Terminus\Commands\Backup
  */
 class ListCommand extends BackupCommand
@@ -28,17 +29,22 @@ class ListCommand extends BackupCommand
      *     date: Date
      *     expiry: Expiry
      *     initiator: Initiator
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @param array $options
      * @return RowsOfFields
      *
-     * @param string $site_env Site & environment in the format `site-name.env`
      * @option string $element [all|code|files|database|db] DEPRECATED Backup element filter
      *
      * @usage <site>.<env> Lists all backups made of <site>'s <env> environment.
      * @usage <site>.<env> --element=<element> Lists all <element> backups made of <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function listBackups($site_env, array $options = ['element' => 'all',])
     {
-        list(, $env) = $this->getSiteEnv($site_env, 'dev');
+        $env = $this->getEnv($site_env);
+
         $backups = $env->getBackups()->filterForFinished();
         $element = $this->getElement($options['element']);
         if ($element !== null) {

--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -31,11 +31,15 @@ class RestoreCommand extends SingleBackupCommand
      */
     public function restoreBackup($site_env, array $options = ['file' => null, 'element' => 'all',])
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
+
         $backup = $this->getBackup($site_env, $options);
 
-        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
-        if (!$this->confirm('Are you sure you want to restore to {env} on {site}?', $tr)) {
+        if (!$this->confirm(
+            'Are you sure you want to restore to {env} on {site}?',
+            ['site' => $site->getName(), 'env' => $env->getName()]
+        )) {
             return;
         }
 

--- a/src/Commands/Backup/SingleBackupCommand.php
+++ b/src/Commands/Backup/SingleBackupCommand.php
@@ -3,19 +3,22 @@
 namespace Pantheon\Terminus\Commands\Backup;
 
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
+use Pantheon\Terminus\Models\Backup;
 
 abstract class SingleBackupCommand extends BackupCommand
 {
-
     /**
      * @param $site_env
      * @param array $options
+     *
      * @return Backup
-     * @throws TerminusNotFoundException
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    protected function getBackup($site_env, array $options = ['file' => null, 'element' => 'all',])
+    protected function getBackup($site_env, array $options = ['file' => null, 'element' => 'all',]): Backup
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
 
         if (isset($options['file']) && !is_null($file_name = $options['file'])) {
             $backup = $env->getBackups()->getBackupByFileName($file_name);
@@ -25,7 +28,10 @@ abstract class SingleBackupCommand extends BackupCommand
             if (empty($backups)) {
                 throw new TerminusNotFoundException(
                     'No backups available. Create one with `terminus backup:create {site}.{env}`',
-                    ['site' => $site->get('name'), 'env' => $env->id,]
+                    [
+                        'site' => $this->getSite($site_env)->getName(),
+                        'env' => $env->getName(),
+                    ]
                 );
             }
             $backup = array_shift($backups);

--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -5,13 +5,12 @@ namespace Pantheon\Terminus\Commands\Connection;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
-use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class InfoCommand
+ * Class InfoCommand.
+ *
  * @package Pantheon\Terminus\Commands\Connection
  */
 class InfoCommand extends TerminusCommand implements SiteAwareInterface
@@ -48,29 +47,20 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     redis_url: Redis URL
      *     redis_password: Redis Password
      * @default-fields *_command
-     * @return PropertyList
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
+     *
+     * @return PropertyList
      *
      * @usage <site>.<env> Displays connection information for <site>'s <env> environment.
      * @usage <site>.<env> --fields='git_*' Displays connection information fields related to Git for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function connectionInfo($site_env)
     {
-        [$site, $env] = explode('.', $site_env);
-        if (empty($site) || empty($env)) {
-            throw new TerminusNotFoundException(
-                'The Site and environment must take the form of {site}.{env} followed by the domain name you are adding'
-            );
-        }
+        $env = $this->getEnv($site_env);
 
-        $env = $this->sites()->get($site)->getEnvironments()->get($env);
-        if (!$env instanceof Environment) {
-            throw new TerminusNotFoundException(
-                'Site/env not found {site}.{env}',
-                ['site' => $site, 'env' => $env]
-            );
-        }
         return new PropertyList($env->connectionInfo());
     }
 }

--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -55,7 +55,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> --fields='git_*' Displays connection information fields related to Git for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function connectionInfo($site_env)
     {

--- a/src/Commands/Connection/SetCommand.php
+++ b/src/Commands/Connection/SetCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
- * Class SetCommand
+ * Class SetCommand.
+ *
  * @package Pantheon\Terminus\Commands\Connection
  */
 class SetCommand extends TerminusCommand implements SiteAwareInterface
@@ -37,12 +38,12 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function connectionSet($site_env, $mode)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-
-        if (in_array($env->id, ['test', 'live',])) {
+        $env = $this->getEnv($site_env);
+        $envName = $env->getName();
+        if (in_array($envName, ['test', 'live',])) {
             throw new TerminusException(
                 'Connection mode cannot be set on the {env} environment',
-                ['env' => $env->id,]
+                ['env' => $envName]
             );
         }
         if ($env->hasUncommittedChanges()) {
@@ -52,7 +53,7 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
             );
             if (!$this->confirm(
                 'Are you sure you want to change the connection mode of {env}?',
-                ['env' => $env->id,]
+                ['env' => $envName]
             )) {
                 return;
             }

--- a/src/Commands/Dashboard/ViewCommand.php
+++ b/src/Commands/Dashboard/ViewCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class ViewCommand
+ * Class ViewCommand.
+ *
  * @package Pantheon\Terminus\Commands\Dashboard
  */
 class ViewCommand extends TerminusCommand implements SiteAwareInterface
@@ -26,22 +27,34 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      * @option string $site_env Site & environment in the format `site-name.env`
      * @option boolean $print Print URL only
      *
+     * @param null $site_env
+     * @param false[] $options
+     *
      * @return string|null
      *
      * @usage Opens browser to user's account on the Pantheon Dashboard.
      * @usage --print Prints the URL for user's account on the Pantheon Dashboard.
      * @usage <site> Opens browser to <site> on the Pantheon Dashboard.
      * @usage <site>.<env> Opens browser to <site>'s <env> environment on the Pantheon Dashboard.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function view($site_env = null, $options = ['print' => false,])
     {
-        list($site, $env) = $this->getOptionalSiteEnv($site_env);
-        $url = isset($site)
-            ? isset($env) ? $env->dashboardUrl() : $site->dashboardUrl()
-            : $this->session()->getUser()->dashboardUrl();
+        if (!$site_env) {
+            $url = $this->session()->getUser()->dashboardUrl();
+        } elseif ($env = $this->getOptionalEnv($site_env)) {
+            $url = $env->dashboardUrl();
+        } else {
+            $url = $this->getSite($site_env)->dashboardUrl();
+        }
+
         if ($options['print']) {
             return $url;
         }
         $this->getContainer()->get(LocalMachineHelper::class)->openUrl($url);
+
+        return null;
     }
 }

--- a/src/Commands/Dashboard/ViewCommand.php
+++ b/src/Commands/Dashboard/ViewCommand.php
@@ -27,8 +27,8 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      * @option string $site_env Site & environment in the format `site-name.env`
      * @option boolean $print Print URL only
      *
-     * @param null $site_env
-     * @param false[] $options
+     * @param string|null $site_env
+     * @param array $options
      *
      * @return string|null
      *
@@ -40,21 +40,38 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
-    public function view($site_env = null, $options = ['print' => false,])
+    public function view($site_env = null, array $options = ['print' => false])
     {
-        if (!$site_env) {
-            $url = $this->session()->getUser()->dashboardUrl();
-        } elseif ($env = $this->getOptionalEnv($site_env)) {
-            $url = $env->dashboardUrl();
-        } else {
-            $url = $this->getSite($site_env)->dashboardUrl();
-        }
-
         if ($options['print']) {
-            return $url;
+            return $this->getDashboardUrl($site_env);
         }
-        $this->getContainer()->get(LocalMachineHelper::class)->openUrl($url);
+        $this->getContainer()
+            ->get(LocalMachineHelper::class)
+            ->openUrl($this->getDashboardUrl($site_env));
 
         return null;
+    }
+
+    /**
+     * Returns the dashboard URL.
+     *
+     * @param string|null $site_env
+     *
+     * @return string
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
+     */
+    private function getDashboardUrl(?string $site_env): string
+    {
+        if (null === $site_env) {
+            return $this->session()->getUser()->dashboardUrl();
+        }
+
+        if ($this->getOptionalEnv($site_env)) {
+            return $this->getOptionalEnv($site_env)->dashboardUrl();
+        }
+
+        return $this->getSite($site_env)->dashboardUrl();
     }
 }

--- a/src/Commands/Dashboard/ViewCommand.php
+++ b/src/Commands/Dashboard/ViewCommand.php
@@ -38,7 +38,6 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Opens browser to <site>'s <env> environment on the Pantheon Dashboard.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function view($site_env = null, array $options = ['print' => false])
     {
@@ -60,7 +59,6 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      * @return string
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     private function getDashboardUrl(?string $site_env): string
     {

--- a/src/Commands/Domain/AddCommand.php
+++ b/src/Commands/Domain/AddCommand.php
@@ -28,7 +28,6 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <domain_name> Associates <domain_name> with <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function add($site_env, $domain)
     {

--- a/src/Commands/Domain/AddCommand.php
+++ b/src/Commands/Domain/AddCommand.php
@@ -3,13 +3,12 @@
 namespace Pantheon\Terminus\Commands\Domain;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
-use Pantheon\Terminus\Exceptions\TerminusException;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class AddCommand
+ * Class AddCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain
  */
 class AddCommand extends TerminusCommand implements SiteAwareInterface
@@ -27,28 +26,22 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $domain Domain e.g. `example.com`
      *
      * @usage <site>.<env> <domain_name> Associates <domain_name> with <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function add($site_env, $domain)
     {
-        [$site, $env] = explode('.', $site_env);
-        if (empty($site) || empty($env) || empty($domain)) {
-            throw new TerminusNotFoundException(
-                'The Site and environment must take the form of {site}.{env} followed by the domain name you are adding'
-            );
-        }
-
-        $env = $this->sites()->get($site)->getEnvironments()->get($env) ?? null;
-        if (!$env instanceof Environment) {
-            throw new TerminusNotFoundException(
-                'Site/env not found {site}.{env}',
-                ['site' => $site, 'env' => $env]
-            );
-        }
-        $result = $env->getDomains()->create($domain);
+        $env = $this->getEnv($site_env);
+        $env->getDomains()->create($domain);
 
         $this->log()->notice(
             'Added {domain} to {site}.{env}',
-            ['domain' => $domain, 'site' => $site, 'env' => $env]
+            [
+                'domain' => $domain,
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
+            ]
         );
     }
 }

--- a/src/Commands/Domain/DNSCommand.php
+++ b/src/Commands/Domain/DNSCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class DNSCommand
+ * Class DNSCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain
  */
 class DNSCommand extends TerminusCommand implements SiteAwareInterface
@@ -29,24 +30,28 @@ class DNSCommand extends TerminusCommand implements SiteAwareInterface
      *     detected_value: Detected Value
      *     status: Status
      *     status_message: Status Message
-     * @return RowsOfFields
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Displays recommended DNS settings for <site>'s <env> environment.
+     *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function getRecommendations($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
         $domains = $env->getDomains()->filter(
             function ($domain) {
                 return $domain->get('type') === 'custom';
             }
         )->all();
-        $settings = [];
+
+        $dnsSettings = [];
         foreach ($domains as $domain) {
-            $settings = array_merge($settings, $domain->getDNSRecords()->serialize());
+            $dnsSettings = array_merge($dnsSettings, $domain->getDNSRecords()->serialize());
         }
-        return new RowsOfFields($settings);
+
+        return new RowsOfFields($dnsSettings);
     }
 }

--- a/src/Commands/Domain/ListCommand.php
+++ b/src/Commands/Domain/ListCommand.php
@@ -2,16 +2,14 @@
 
 namespace Pantheon\Terminus\Commands\Domain;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
-use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class ListCommand
+ * Class ListCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain
  */
 class ListCommand extends TerminusCommand implements SiteAwareInterface
@@ -34,27 +32,19 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     primary: Is Primary
      *     deletable: Is Deletable
      *     status: status
-     * @return RowsOfFields
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
      * @usage <site>.<env> Displays domains associated with <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function listDomains($site_env)
     {
-        [$site, $env] = explode('.', $site_env);
-        if (empty($site) || empty($env)) {
-            throw new TerminusNotFoundException(
-                'The Site and environment must take the form of {site}.{env} followed by the domain name you are adding'
-            );
-        }
-        $env = $this->sites()->get($site)->getEnvironments()->get($env) ?? null;
-        if (!$env instanceof Environment) {
-            throw new TerminusNotFoundException(
-                'Site/env not found {site}.{env}',
-                ['site' => $site, 'env' => $env]
-            );
-        }
+        $env = $this->getEnv($site_env);
+
         return $this->getRowsOfFields($env->getDomains());
     }
 }

--- a/src/Commands/Domain/ListCommand.php
+++ b/src/Commands/Domain/ListCommand.php
@@ -38,7 +38,6 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @usage <site>.<env> Displays domains associated with <site>'s <env> environment.
      *
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function listDomains($site_env)

--- a/src/Commands/Domain/LookupCommand.php
+++ b/src/Commands/Domain/LookupCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 
 /**
- * Class LookupCommand
+ * Class LookupCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain
  */
 class LookupCommand extends TerminusCommand implements SiteAwareInterface
@@ -44,17 +45,18 @@ class LookupCommand extends TerminusCommand implements SiteAwareInterface
         foreach ($sites as $site) {
             foreach ($environments as $env_name) {
                 if ($site->getEnvironments()->get($env_name)->getDomains()->has($domain)) {
-                    $env = ['site_id' => $site->id, 'site_name' => $site->get('name'), 'env_id' => $env_name];
-                    break 2;
+                    return new PropertyList([
+                        'site_id' => $site->id,
+                        'site_name' => $site->getName(),
+                        'env_id' => $env_name,
+                    ]);
                 }
             }
         }
-        if (!isset($env)) {
-            throw new TerminusNotFoundException(
-                'Could not locate an environment with the domain {domain}.',
-                compact('domain')
-            );
-        }
-        return new PropertyList($env);
+
+        throw new TerminusNotFoundException(
+            'Could not locate an environment with the domain {domain}.',
+            compact('domain')
+        );
     }
 }

--- a/src/Commands/Domain/Primary/AddCommand.php
+++ b/src/Commands/Domain/Primary/AddCommand.php
@@ -1,20 +1,18 @@
 <?php
 
-
 namespace Pantheon\Terminus\Commands\Domain\Primary;
 
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
-use Pantheon\Terminus\Models\Environment;
-use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Class AddCommand
+ * Class AddCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain\Primary
  */
 class AddCommand extends TerminusCommand implements SiteAwareInterface
@@ -35,21 +33,23 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $domain A domain that has been associated to your site. Optional when running interactively.
      *
      * @usage <site>.<env> <domain> Designates <domain> as the primary domain of <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function add($site_env, $domain)
     {
-        /**
-         * @var $site Site
-         * @var $env Environment
-         */
-        list($site, $env) = $this->getSiteEnv($site_env);
-
+        $env = $this->getEnv($site_env);
         // The primary domain is set via a workflow so as to use workflow logging to track changes & update policy docs.
         $workflow = $env->getPrimaryDomainModel()->setPrimaryDomain($domain);
         $this->processWorkflow($workflow);
         $this->log()->notice(
             'Set {domain} as primary for {site}.{env}',
-            ['domain' => $domain, 'site' => $site->get('name'), 'env' => $env->id,]
+            [
+                'domain' => $domain,
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
+            ]
         );
     }
 
@@ -63,33 +63,34 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @param AnnotationData $annotationData
      *
      * @hook interact domain:primary:add
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function interact(InputInterface $input, OutputInterface $output, AnnotationData $annotationData)
     {
-        $domain = $input->getArgument('domain');
-        if (empty($domain)) {
-            /**
-             * @var $site Site
-             * @var $env Environment
-             */
-            list($site, $env) = $this->getSiteEnv($input->getArgument('site_env'));
-            $domains = $this->filterPlatformDomains($env->getDomains()->ids());
-            sort($domains);
+        if (!$input->getArgument('domain')) {
+            return;
+        }
 
-            if (!empty($domains)) {
-                $domain = $this->io()->choice('Select the primary domain for this site', $domains);
-                $input->setArgument('domain', $domain);
-            }
+        $env = $this->getEnv($input->getArgument('site_env'));
+        $domains = $this->filterPlatformDomains($env->getDomains()->ids());
+        sort($domains);
+
+        if (!empty($domains)) {
+            $domain = $this->io()->choice('Select the primary domain for this site', $domains);
+            $input->setArgument('domain', $domain);
         }
     }
 
     /**
      * Filters strings ending in the platform domain from an array.
      *
-     * @param $domains
+     * @param array $domains
+     *
      * @return array
      */
-    public function filterPlatformDomains($domains)
+    public function filterPlatformDomains(array $domains)
     {
         return array_filter($domains, function ($domain) {
             return substr_compare($domain, self::PLATFORM_DOMAIN, -strlen(self::PLATFORM_DOMAIN)) !== 0;

--- a/src/Commands/Domain/Primary/AddCommand.php
+++ b/src/Commands/Domain/Primary/AddCommand.php
@@ -35,7 +35,6 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <domain> Designates <domain> as the primary domain of <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function add($site_env, $domain)
     {
@@ -65,7 +64,6 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
      * @hook interact domain:primary:add
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function interact(InputInterface $input, OutputInterface $output, AnnotationData $annotationData)
     {

--- a/src/Commands/Domain/Primary/RemoveCommand.php
+++ b/src/Commands/Domain/Primary/RemoveCommand.php
@@ -30,7 +30,6 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Un-designates the primary domain of <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function remove($site_env)
     {
@@ -40,8 +39,8 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
         $this->log()->notice(
             'Primary domain has been removed from {site}.{env}',
             [
-                'site' => $this->getSite($site_env)->getNme(),
-                'env' => $env->geName(),
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
             ]
         );
     }

--- a/src/Commands/Domain/Primary/RemoveCommand.php
+++ b/src/Commands/Domain/Primary/RemoveCommand.php
@@ -1,15 +1,17 @@
 <?php
 
-
 namespace Pantheon\Terminus\Commands\Domain\Primary;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
-use Pantheon\Terminus\Models\Environment;
-use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
+/**
+ * Class RemoveCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Domain\Primary
+ */
 class RemoveCommand extends TerminusCommand implements SiteAwareInterface
 {
     use SiteAwareTrait;
@@ -26,20 +28,21 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Un-designates the primary domain of <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function remove($site_env)
     {
-        /**
-         * @var $site Site
-         * @var $env Environment
-         */
-        list($site, $env) = $this->getSiteEnv($site_env);
-
+        $env = $this->getEnv($site_env);
         $workflow = $env->getPrimaryDomainModel()->removePrimaryDomain();
         $this->processWorkflow($workflow);
         $this->log()->notice(
             'Primary domain has been removed from {site}.{env}',
-            ['site' => $site->get('name'), 'env' => $env->id,]
+            [
+                'site' => $this->getSite($site_env)->getNme(),
+                'env' => $env->geName(),
+            ]
         );
     }
 }

--- a/src/Commands/Domain/RemoveCommand.php
+++ b/src/Commands/Domain/RemoveCommand.php
@@ -3,14 +3,13 @@
 namespace Pantheon\Terminus\Commands\Domain;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
-use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class RemoveCommand
+ * Class RemoveCommand.
+ *
  * @package Pantheon\Terminus\Commands\Domain
  */
 class RemoveCommand extends TerminusCommand implements SiteAwareInterface
@@ -29,26 +28,22 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $domain Domain e.g. `example.com`
      *
      * @usage <site>.<env> <domain_name> Disassociates <domain_name> from <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function remove($site_env, $domain)
     {
-
-        [$site, $env] = explode(".", $site_env);
-        if (empty($site) || empty($env)) {
-            throw new TerminusNotFoundException("The Site and environment must take the form of {site}.{env}");
-        }
-
-        $env = $this->sites()->get($site)->getEnvironments()->get($env) ?? null;
-        if (!$env instanceof Environment) {
-            throw new TerminusNotFoundException(
-                'Site/env not found {site}.{env}',
-                ['site' => $site, 'env' => $env]
-            );
-        }
+        $env = $this->getEnv($site_env);
         $env->getDomains()->get($domain)->delete();
+
         $this->log()->notice(
             'Removed {domain} from {site}.{env}',
-            ['domain' => $domain, 'site' => $site, 'env' => $env]
+            [
+                'domain' => $domain,
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
+            ]
         );
     }
 }

--- a/src/Commands/Domain/RemoveCommand.php
+++ b/src/Commands/Domain/RemoveCommand.php
@@ -29,7 +29,6 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @usage <site>.<env> <domain_name> Disassociates <domain_name> from <site>'s <env> environment.
      *
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function remove($site_env, $domain)

--- a/src/Commands/Env/ClearCacheCommand.php
+++ b/src/Commands/Env/ClearCacheCommand.php
@@ -32,7 +32,6 @@ class ClearCacheCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusProcessException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function clearCache($site_env)
     {

--- a/src/Commands/Env/ClearCacheCommand.php
+++ b/src/Commands/Env/ClearCacheCommand.php
@@ -4,14 +4,13 @@ namespace Pantheon\Terminus\Commands\Env;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
-use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Exceptions\TerminusProcessException;
-use Pantheon\Terminus\Models\Environment;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class ClearCacheCommand
+ * Class ClearCacheCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class ClearCacheCommand extends TerminusCommand implements SiteAwareInterface
@@ -30,33 +29,20 @@ class ClearCacheCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Clears caches for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusProcessException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function clearCache($site_env)
     {
-        [$site, $env] = explode('.', $site_env);
-        if (empty($site) || empty($env)) {
-            throw new TerminusNotFoundException(
-                'The Site and environment must take the form of {site}.{env} followed by the domain name you are adding'
-            );
-        }
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
 
-        $env = $this->sites()->get($site)->getEnvironments()->get($env) ?? null;
-        if (!$env instanceof Environment) {
-            throw new TerminusNotFoundException(
-                'Site/env not found {env}',
-                ['env' => $env]
-            );
-        }
-        if ($env->getSite()->isFrozen()) {
-            throw new TerminusProcessException(
-                "This operation does not work on a frozen site: {env}.",
-                ["env" => $env]
-            );
-        }
         $this->processWorkflow($env->clearCache());
         $this->log()->notice(
             'Caches cleared on {env}.',
-            [ 'env' => $env]
+            ['env' => $env->getName()]
         );
     }
 }

--- a/src/Commands/Env/CloneContentCommand.php
+++ b/src/Commands/Env/CloneContentCommand.php
@@ -66,7 +66,9 @@ class CloneContentCommand extends TerminusCommand implements SiteAwareInterface
             throw new TerminusException('You cannot specify both --db-only and --files-only');
         }
 
-        list($site, $this->source_env) = $this->getUnfrozenSiteEnv($site_env);
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite($site_env);
+        $this->source_env = $this->getEnv($site_env);
         $this->target_env = $site->getEnvironments()->get($target_env);
 
         if ($this->source_env->id === $target_env) {

--- a/src/Commands/Env/CodeLogCommand.php
+++ b/src/Commands/Env/CodeLogCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 
 /**
- * Class CodeLogCommand
+ * Class CodeLogCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class CodeLogCommand extends TerminusCommand implements SiteAwareInterface
@@ -28,15 +29,19 @@ class CodeLogCommand extends TerminusCommand implements SiteAwareInterface
      *     labels: Labels
      *     hash: Commit ID
      *     message: Message
-     * @return RowsOfFields
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
      * @usage <site>.<env> Displays the code log for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function codeLog($site_env)
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env, 'dev');
-        return new RowsOfFields($env->getCommits()->serialize());
+        $this->requireSiteIsNotFrozen($site_env);
+
+        return new RowsOfFields($this->getEnv($site_env)->getCommits()->serialize());
     }
 }

--- a/src/Commands/Env/CodeLogCommand.php
+++ b/src/Commands/Env/CodeLogCommand.php
@@ -36,7 +36,6 @@ class CodeLogCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Displays the code log for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function codeLog($site_env)
     {

--- a/src/Commands/Env/CommitCommand.php
+++ b/src/Commands/Env/CommitCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class CommitCommand
+ * Class CommitCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class CommitCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,15 +26,20 @@ class CommitCommand extends TerminusCommand implements SiteAwareInterface
      * @command env:commit
      *
      * @param string $site_env Site & environment in the format `site-name.env`
+     * @param array $options
      * @option string $message Commit message
      * @option boolean $force Force a commit even if there doesn't seem to be anything to commit. This can lead to an empty commit.
      *
      * @usage <site>.<env> Commits code changes to <site>'s <env> environment with the default message.
      * @usage <site>.<env> --message=<message> Commits code changes to <site>'s <env> environment with the message <message>.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function commit($site_env, $options = ['message' => 'Terminus commit.', 'force' => false])
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env, 'dev');
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
 
         if (empty($options['force'])) {
             $change_count = count((array)$env->diffstat());

--- a/src/Commands/Env/CommitCommand.php
+++ b/src/Commands/Env/CommitCommand.php
@@ -34,7 +34,6 @@ class CommitCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> --message=<message> Commits code changes to <site>'s <env> environment with the message <message>.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function commit($site_env, $options = ['message' => 'Terminus commit.', 'force' => false])
     {

--- a/src/Commands/Env/DeployCommand.php
+++ b/src/Commands/Env/DeployCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class DeployCommand
+ * Class DeployCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class DeployCommand extends TerminusCommand implements SiteAwareInterface
@@ -34,7 +35,7 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
      * @option string $updatedb Run update.php after deploy (Drupal only)
      * @option string $note Custom deploy log message
      *
-     * @throws TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
      * @usage <site>.test Deploy code from <site>'s Dev environment to the Test environment.
      * @usage <site>.live Deploy code from <site>'s Test environment to the Live environment.
@@ -46,7 +47,9 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
         $site_env,
         $options = ['sync-content' => false, 'note' => 'Deploy from Terminus', 'cc' => false, 'updatedb' => false,]
     ) {
-        list($site, $env) = $this->getUnfrozenSiteEnv($site_env, 'dev');
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
 
         $annotation = $options['note'];
         if ($env->isInitialized()) {
@@ -59,7 +62,7 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
               'updatedb'    => (integer)$options['updatedb'],
               'annotation'  => $annotation,
             ];
-            if ($env->id == 'test' && isset($options['sync-content']) && $options['sync-content']) {
+            if ($env->getName() === 'test' && isset($options['sync-content']) && $options['sync-content']) {
                 $live_env = 'live';
                 if (!$site->getEnvironments()->get($live_env)->isInitialized()) {
                     throw new TerminusException(

--- a/src/Commands/Env/DiffStatCommand.php
+++ b/src/Commands/Env/DiffStatCommand.php
@@ -33,7 +33,6 @@ class DiffStatCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Displays a diff of uncommitted code changes on <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function diffstat($site_env)
     {

--- a/src/Commands/Env/DiffStatCommand.php
+++ b/src/Commands/Env/DiffStatCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class DiffStatCommand
+ * Class DiffStatCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class DiffStatCommand extends TerminusCommand implements SiteAwareInterface
@@ -22,18 +23,23 @@ class DiffStatCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & development environment in the format `site-name.env`
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
      * @field-labels
      *     file: File
      *     status: Status
      *     deletions: Deletions
      *     additions: Additions
-     * @return RowsOfFields
-     *
      * @usage <site>.<env> Displays a diff of uncommitted code changes on <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function diffstat($site_env)
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env);
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
+
         $diff = (array)$env->diffstat();
         $data = [];
         if (empty($diff)) {

--- a/src/Commands/Env/InfoCommand.php
+++ b/src/Commands/Env/InfoCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class InfoCommand
+ * Class InfoCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class InfoCommand extends TerminusCommand implements SiteAwareInterface
@@ -33,15 +34,19 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     connection_mode: Connection Mode
      *     php_version: PHP Version
      *     drush_version: Drush Version
-     * @return PropertyList
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\PropertyList
+     *
      * @usage <site>.<env> Displays status and configuration for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env);
-        return $this->getPropertyList($env);
+        $this->requireSiteIsNotFrozen($site_env);
+
+        return $this->getPropertyList($this->getEnv($site_env));
     }
 }

--- a/src/Commands/Env/InfoCommand.php
+++ b/src/Commands/Env/InfoCommand.php
@@ -41,7 +41,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Displays status and configuration for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {

--- a/src/Commands/Env/MetricsCommand.php
+++ b/src/Commands/Env/MetricsCommand.php
@@ -65,7 +65,8 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
             'datapoints' => 'auto'
         ]
     ) {
-        if ($env = $this->getOptionalEnv($site_env)) {
+        $env = $this->getOptionalEnv($site_env);
+        if (null !== $env) {
             $metrics = $env->getEnvironmentMetrics()
                 ->setPeriod($options['period'])
                 ->setDatapoints($this->selectDatapoints($options['datapoints'], $options['period']))

--- a/src/Commands/Env/MetricsCommand.php
+++ b/src/Commands/Env/MetricsCommand.php
@@ -56,7 +56,6 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFieldsWithMetadata
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function metrics(
         $site_env,

--- a/src/Commands/Env/ViewCommand.php
+++ b/src/Commands/Env/ViewCommand.php
@@ -6,7 +6,6 @@ use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Helpers\LocalMachineHelper;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
-use Pantheon\Terminus\Exceptions\TerminusException;
 
 class ViewCommand extends TerminusCommand implements SiteAwareInterface
 {
@@ -22,16 +21,17 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @option boolean $print Print URL only
-     * @return string
+     * @return string|null
      *
      * @usage <site>.<env> Opens the browser to <site>'s <env> environment.
      * @usage <site>.<env> --print Prints the URL for <site>'s <env> environment.
      *
-     * @throws TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function view($site_env, $options = ['print' => false,])
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env);
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
 
         $domain = $env->domain();
         $protocol = 'https';
@@ -48,5 +48,7 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
             return $url;
         }
         $this->getContainer()->get(LocalMachineHelper::class)->openUrl($url);
+
+        return null;
     }
 }

--- a/src/Commands/Env/WakeCommand.php
+++ b/src/Commands/Env/WakeCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
- * Class WakeCommand
+ * Class WakeCommand.
+ *
  * @package Pantheon\Terminus\Commands\Env
  */
 class WakeCommand extends TerminusCommand implements SiteAwareInterface
@@ -31,17 +32,18 @@ class WakeCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function wake($site_env)
     {
-        list(, $env) = $this->getUnfrozenSiteEnv($site_env);
-        $data = $env->wake();
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
+        $wakeStatus = $env->wake();
 
         // @TODO: Move the exceptions up the chain to the `wake` function. (One env is ported over).
-        if (empty($data['success'])) {
-            throw new TerminusException('Could not reach {target}', $data);
+        if (empty($wakeStatus['success'])) {
+            throw new TerminusException('Could not reach {target}', $wakeStatus);
         }
-        if (empty($data['styx'])) {
+        if (empty($wakeStatus['styx'])) {
             throw new TerminusException('Pantheon headers missing, which is not quite right.');
         }
 
-        $this->log()->notice('OK >> {target} responded', $data);
+        $this->log()->notice('OK >> {target} responded', $wakeStatus);
     }
 }

--- a/src/Commands/Env/WipeCommand.php
+++ b/src/Commands/Env/WipeCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class WipeCommand
+ * Class WipeCommand.
+ *
  * Testing class for Pantheon\Terminus\Commands\Env\WipeCommand
  * @package Pantheon\Terminus\Commands\Env
  */
@@ -26,23 +27,27 @@ class WipeCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
-     * @throws TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
      * @usage <site>.<env> Deletes all database/files on <site>'s <env> environment.
      */
     public function wipe($site_env)
     {
-        list($site, $env) = $this->getUnfrozenSiteEnv($site_env);
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
 
-        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
-        if (!$this->confirm('Are you sure you want to wipe {env} on {site}?', $tr)) {
+        if (!$this->confirm(
+            'Are you sure you want to wipe {env} on {site}?',
+            ['site' => $site->getName(), 'env' => $env->getName()]
+        )) {
             return;
         }
 
         $workflow = $env->wipe();
         $this->log()->notice(
             'Wiping the "{env}" environment of "{site}"',
-            ['site' => $site->get('name'), 'env' => $env->id,]
+            ['site' => $site->getName(), 'env' => $env->getName()]
         );
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());

--- a/src/Commands/HTTPS/InfoCommand.php
+++ b/src/Commands/HTTPS/InfoCommand.php
@@ -2,14 +2,14 @@
 
 namespace Pantheon\Terminus\Commands\HTTPS;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
 use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class InfoCommand
+ * Class InfoCommand.
+ *
  * @package Pantheon\Terminus\Commands\HTTPS
  */
 class InfoCommand extends TerminusCommand implements SiteAwareInterface
@@ -30,15 +30,19 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     status: Status
      *     status_message: Status Message
      *     deletable: Is Deletable
-     * @return RowsOfFields
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
      * @usage <site>.<env> Displays HTTPS configuration for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {
-        list(, $env) = $this->getOptionalSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
+
         return $this->getRowsOfFields($env->getDomains()->fetchWithRecommendations());
     }
 }

--- a/src/Commands/HTTPS/InfoCommand.php
+++ b/src/Commands/HTTPS/InfoCommand.php
@@ -37,7 +37,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Displays HTTPS configuration for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {

--- a/src/Commands/HTTPS/RemoveCommand.php
+++ b/src/Commands/HTTPS/RemoveCommand.php
@@ -29,7 +29,6 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Disables HTTPS and removes the SSL certificate from <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function remove($site_env)
     {

--- a/src/Commands/HTTPS/RemoveCommand.php
+++ b/src/Commands/HTTPS/RemoveCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class RemoveCommand
+ * Class RemoveCommand.
+ *
  * @package Pantheon\Terminus\Commands\HTTPS
  */
 class RemoveCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,15 +26,15 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases https:disable https:rm
      *
      * @param string $site_env Site & environment in the format `site-name.env`
-     *
      * @usage <site>.<env> Disables HTTPS and removes the SSL certificate from <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function remove($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-
         // Launch a workflow to remove the cert, bindings will be converged as part of this
-        $workflow = $env->disableHttpsCertificate();
+        $workflow = $this->getEnv($site_env)->disableHttpsCertificate();
 
         // Wait for the workflow to complete.
         $this->processWorkflow($workflow);

--- a/src/Commands/HTTPS/SetCommand.php
+++ b/src/Commands/HTTPS/SetCommand.php
@@ -36,7 +36,6 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <cert> <key> --intermediate-certificate=<int_cert_file> Enables HTTPS for <site>'s <env> environment using the SSL certificate at <cert_file>, private key at <key_file> and intermediate certificate(s) at <int_cert_file>.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function set($site_env, $certificate, $private_key, $options = ['intermediate-certificate' => null,])
     {

--- a/src/Commands/HTTPS/SetCommand.php
+++ b/src/Commands/HTTPS/SetCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class SetCommand
+ * Class SetCommand.
+ *
  * @package Pantheon\Terminus\Commands\HTTPS
  */
 class SetCommand extends TerminusCommand implements SiteAwareInterface
@@ -27,14 +28,18 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      * @param string $certificate File containing the SSL certificate
      * @param string $private_key File containing the private key
+     * @param null[] $options
+     *
      * @option string $intermediate-certificate File containing the CA intermediate certificate(s)
      *
      * @usage <site>.<env> <cert_file> <key_file> Enables HTTPS for <site>'s <env> environment using the SSL certificate at <cert_file> and private key at <key_file>.
      * @usage <site>.<env> <cert> <key> --intermediate-certificate=<int_cert_file> Enables HTTPS for <site>'s <env> environment using the SSL certificate at <cert_file>, private key at <key_file> and intermediate certificate(s) at <int_cert_file>.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function set($site_env, $certificate, $private_key, $options = ['intermediate-certificate' => null,])
     {
-        list(, $env) = $this->getSiteEnv($site_env);
         $key = [
             'cert' => file_exists($certificate) ? trim(file_get_contents($certificate)) : $certificate,
             'key' => file_exists($private_key) ? trim(file_get_contents($private_key)) : $private_key,
@@ -48,7 +53,7 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
         }
 
         // Set the key for the environment.
-        $workflow = $env->setHttpsCertificate($key);
+        $workflow = $this->getEnv($site_env)->setHttpsCertificate($key);
 
         // Wait for the workflow to complete.
         $this->log()->notice('SSL certificate updated. Converging loadbalancer.');

--- a/src/Commands/Import/CompleteCommand.php
+++ b/src/Commands/Import/CompleteCommand.php
@@ -32,6 +32,6 @@ class CompleteCommand extends TerminusCommand implements SiteAwareInterface
     {
         $site = $this->sites->get($site_name);
         $this->processWorkflow($site->completeMigration());
-        $this->log()->notice('The import of {site} has been marked as complete.', ['site' => $site->get('name'),]);
+        $this->log()->notice('The import of {site} has been marked as complete.', ['site' => $site->getName()]);
     }
 }

--- a/src/Commands/Import/DatabaseCommand.php
+++ b/src/Commands/Import/DatabaseCommand.php
@@ -30,7 +30,6 @@ class DatabaseCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <archive_url> Imports the database archive at <archive_url> to <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function import($site_env, $url)
     {

--- a/src/Commands/Import/FilesCommand.php
+++ b/src/Commands/Import/FilesCommand.php
@@ -29,7 +29,6 @@ class FilesCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <archive_url> Imports the files in the archive at <archive_url> to <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function import($site_env, $url)
     {

--- a/src/Commands/Import/FilesCommand.php
+++ b/src/Commands/Import/FilesCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class FilesCommand
+ * Class FilesCommand.
+ *
  * @package Pantheon\Terminus\Commands\Import
  */
 class FilesCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,22 +26,27 @@ class FilesCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @param string $url Publicly accessible URL of the file archive
-     *
      * @usage <site>.<env> <archive_url> Imports the files in the archive at <archive_url> to <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function import($site_env, $url)
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
 
-        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
-        if (!$this->confirm('Are you sure you overwrite the files for {env} on {site}?', $tr)) {
+        if (!$this->confirm(
+            'Are you sure you overwrite the files for {env} on {site}?',
+            ['site' => $site->getName(), 'env' => $env->getName()]
+        )) {
             return;
         }
 
         $this->processWorkflow($env->importFiles($url));
         $this->log()->notice(
             'Imported files to {site}.{env}.',
-            ['site' => $site->get('name'), 'env' => $env->id,]
+            ['site' => $site->getName(), 'env' => $env->getName()]
         );
     }
 }

--- a/src/Commands/Import/SiteCommand.php
+++ b/src/Commands/Import/SiteCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
- * Class SiteCommand
+ * Class SiteCommand.
+ *
  * @package Pantheon\Terminus\Commands\Import
  */
 class SiteCommand extends TerminusCommand implements SiteAwareInterface
@@ -27,15 +28,20 @@ class SiteCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_name Site name
      * @param string $url Publicly accessible URL of the site archive
-     *
      * @usage <site_name> <url> Imports the site archive at <url> to <site_name>.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function import($site_name, $url)
     {
-        list($site, $env) = $this->getSiteEnv($site_name, 'dev');
+        $site = $this->getSite($site_name);
+        $env = $site->getEnvironments()->get('dev');
 
-        $tr = ['site' => $site->getName(), 'env' => $env->getName()];
-        if (!$this->confirm('Are you sure you overwrite the code, database and files for {env} on {site}?', $tr)) {
+        if (!$this->confirm(
+            'Are you sure you overwrite the code, database and files for {env} on {site}?',
+            ['site' => $site->getName(), 'env' => $env->getName()]
+        )) {
             return;
         }
 

--- a/src/Commands/Import/SiteCommand.php
+++ b/src/Commands/Import/SiteCommand.php
@@ -31,7 +31,6 @@ class SiteCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site_name> <url> Imports the site archive at <url> to <site_name>.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function import($site_name, $url)
     {

--- a/src/Commands/Lock/DisableCommand.php
+++ b/src/Commands/Lock/DisableCommand.php
@@ -28,7 +28,6 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> Disables HTTP basic authentication on <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function disable($site_env)
     {

--- a/src/Commands/Lock/DisableCommand.php
+++ b/src/Commands/Lock/DisableCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class DisableCommand
+ * Class DisableCommand.
+ *
  * @package Pantheon\Terminus\Commands\Lock
  */
 class DisableCommand extends TerminusCommand implements SiteAwareInterface
@@ -24,16 +25,21 @@ class DisableCommand extends TerminusCommand implements SiteAwareInterface
      * @command lock:disable
      *
      * @param string $site_env Site & environment in the format `site-name.env`
-     *
      * @usage <site>.<env> Disables HTTP basic authentication on <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function disable($site_env)
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
         $this->processWorkflow($env->getLock()->disable());
         $this->log()->notice(
             '{site}.{env} has been unlocked.',
-            ['site' => $site->get('name'), 'env' => $env->id,]
+            [
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
+            ]
         );
     }
 }

--- a/src/Commands/Lock/EnableCommand.php
+++ b/src/Commands/Lock/EnableCommand.php
@@ -31,7 +31,6 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <username> <password> Enables HTTP basic authentication on <site>'s <env> environment with the username <username> and the password <password>.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function enable($site_env, $username, $password)
     {

--- a/src/Commands/Lock/EnableCommand.php
+++ b/src/Commands/Lock/EnableCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class EnableCommand
+ * Class EnableCommand.
+ *
  * @package Pantheon\Terminus\Commands\Lock
  */
 class EnableCommand extends TerminusCommand implements SiteAwareInterface
@@ -27,16 +28,22 @@ class EnableCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site_env Site & environment in the format `site-name.env`
      * @param string $username HTTP basic authentication username
      * @param string $password HTTP basic authentication password
-     *
      * @usage <site>.<env> <username> <password> Enables HTTP basic authentication on <site>'s <env> environment with the username <username> and the password <password>.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function enable($site_env, $username, $password)
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
+
         $this->processWorkflow($env->getLock()->enable(['username' => $username, 'password' => $password,]));
         $this->log()->notice(
             '{site}.{env} has been locked.',
-            ['site' => $site->get('name'), 'env' => $env->id,]
+            [
+                'site' => $this->getSite($site_env)->getName(),
+                'env' => $env->getName(),
+            ]
         );
     }
 }

--- a/src/Commands/Lock/InfoCommand.php
+++ b/src/Commands/Lock/InfoCommand.php
@@ -36,7 +36,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      * @return \Consolidation\OutputFormatters\StructuredData\PropertyList
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {

--- a/src/Commands/Lock/InfoCommand.php
+++ b/src/Commands/Lock/InfoCommand.php
@@ -9,7 +9,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class InfoCommand
+ * Class InfoCommand.
+ *
  * @package Pantheon\Terminus\Commands\Lock
  */
 class InfoCommand extends TerminusCommand implements SiteAwareInterface
@@ -28,15 +29,17 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     locked: Locked?
      *     username: Username
      *     password: Password
-     * @return PropertyList
-     *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
      * @usage <site>.<env> Displays HTTP basic authentication status and configuration for <site>'s <env> environment.
+     *
+     * @return \Consolidation\OutputFormatters\StructuredData\PropertyList
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function info($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-        return $this->getPropertyList($env->getLock());
+        return $this->getPropertyList($this->getEnv($site_env)->getLock());
     }
 }

--- a/src/Commands/Multidev/CreateCommand.php
+++ b/src/Commands/Multidev/CreateCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class CreateCommand
+ * Class CreateCommand.
+ *
  * @package Pantheon\Terminus\Commands\Multidev
  */
 class CreateCommand extends TerminusCommand implements SiteAwareInterface
@@ -28,12 +29,16 @@ class CreateCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & source environment in the format `site-name.env`
      * @param string $multidev Multidev environment name
+     * @param array $options
      * @option bool $no-db Do not clone database
      * @option bool $no-files Do not clone files
      *
      * @usage <site>.<env> <multidev> Creates the Multidev environment, <multidev>, within <site> with database and files from the <env> environment.
      * @usage <site>.<env> <multidev> --no-db Creates the <multidev> environment without database from the <env> environment.
      * @usage <site>.<env> <multidev> --no-files Creates the <multidev> environment without files from the <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function create(
         string $site_env,
@@ -43,13 +48,17 @@ class CreateCommand extends TerminusCommand implements SiteAwareInterface
             'no-files' => false,
         ]
     ) {
-        [$site, $env] = $this->getUnfrozenSiteEnv($site_env, 'dev');
+        $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
 
         if (strlen($multidev) > 11) {
             $multidev = substr($multidev, 0, 11);
             $this->output()->write(
-                "Pantheon puts an 11 character limit on env names. Your name has been truncated to :" .
-                $multidev
+                sprintf(
+                    'Pantheon puts an 11 character limit on env names. Your name has been truncated to: %s',
+                    $multidev
+                )
             );
         }
 

--- a/src/Commands/Multidev/CreateCommand.php
+++ b/src/Commands/Multidev/CreateCommand.php
@@ -38,7 +38,6 @@ class CreateCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<env> <multidev> --no-files Creates the <multidev> environment without files from the <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function create(
         string $site_env,

--- a/src/Commands/Multidev/DeleteCommand.php
+++ b/src/Commands/Multidev/DeleteCommand.php
@@ -33,7 +33,6 @@ class DeleteCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<multidev> --delete-branch Deletes <site>'s <multidev> Multidev environment and deletes its associated Git branch.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function deleteMultidev($site_env, $options = ['delete-branch' => false,])
     {

--- a/src/Commands/Multidev/DeleteCommand.php
+++ b/src/Commands/Multidev/DeleteCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class DeleteCommand
+ * Class DeleteCommand.
+ *
  * @package Pantheon\Terminus\Commands\Multidev
  */
 class DeleteCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,23 +26,31 @@ class DeleteCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases env:delete
      *
      * @param string $site_env Site & Multidev environment in the format `site-name.env`
+     * @param false[] $options
      * @option boolean $delete-branch Delete associated Git branch
      *
      * @usage <site>.<multidev> Deletes <site>'s <multidev> Multidev environment.
      * @usage <site>.<multidev> --delete-branch Deletes <site>'s <multidev> Multidev environment and deletes its associated Git branch.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function deleteMultidev($site_env, $options = ['delete-branch' => false,])
     {
-        list(, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
 
-        if (!$this->confirm('Are you sure you want to delete {env}?', ['env' => $env->getName()])) {
+        if (!$this->confirm(
+            'Are you sure you want to delete {env}?',
+            ['env' => $env->getName()]
+        )) {
             return;
         }
 
-        $workflow = $env->delete(
-            ['delete_branch' => isset($options['delete-branch']) ? $options['delete-branch'] : false,]
-        );
+        $workflow = $env->delete(['delete_branch' => $options['delete-branch'] ?? false]);
         $this->processWorkflow($workflow);
-        $this->log()->notice('Deleted the multidev environment {env}.', ['env' => $env->id,]);
+        $this->log()->notice(
+            'Deleted the multidev environment {env}.',
+            ['env' => $env->getName()]
+        );
     }
 }

--- a/src/Commands/Multidev/MergeFromDevCommand.php
+++ b/src/Commands/Multidev/MergeFromDevCommand.php
@@ -33,7 +33,6 @@ class MergeFromDevCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<multidev> --updatedb Merges code commits from <site>'s Dev environment into the <multidev> environment and runs update.php afterwards.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function mergeFromDev($site_env, $options = ['updatedb' => false,])
     {

--- a/src/Commands/Multidev/MergeFromDevCommand.php
+++ b/src/Commands/Multidev/MergeFromDevCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class MergeFromDevCommand
+ * Class MergeFromDevCommand.
+ *
  * @package Pantheon\Terminus\Commands\Multidev
  */
 class MergeFromDevCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,15 +26,22 @@ class MergeFromDevCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases env:merge-from-dev
      *
      * @param string $site_env Site & Multidev environment in the form `site-name.env`
+     * @param false[] $options
      * @option boolean $updatedb Run update.php afterwards
      *
      * @usage <site>.<multidev> Merges code commits from <site>'s Dev environment into the <multidev> environment.
      * @usage <site>.<multidev> --updatedb Merges code commits from <site>'s Dev environment into the <multidev> environment and runs update.php afterwards.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function mergeFromDev($site_env, $options = ['updatedb' => false,])
     {
-        list(, $env) = $this->getSiteEnv($site_env);
+        $env = $this->getEnv($site_env);
         $this->processWorkflow($env->mergeFromDev(['updatedb' => $options['updatedb'],]));
-        $this->log()->notice('Merged the dev environment into {env}.', ['env' => $env->id,]);
+        $this->log()->notice(
+            'Merged the dev environment into {env}.',
+            ['env' => $env->getName()]
+        );
     }
 }

--- a/src/Commands/Multidev/MergeToDevCommand.php
+++ b/src/Commands/Multidev/MergeToDevCommand.php
@@ -33,7 +33,6 @@ class MergeToDevCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <site>.<multidev> --updatedb Merges code commits from <site>'s <multidev> environment into the Dev environment and runs update.php afterwards.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function mergeToDev($site_env, $options = ['updatedb' => false,])
     {

--- a/src/Commands/Multidev/MergeToDevCommand.php
+++ b/src/Commands/Multidev/MergeToDevCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareInterface;
 use Pantheon\Terminus\Site\SiteAwareTrait;
 
 /**
- * Class MergeToDevCommand
+ * Class MergeToDevCommand.
+ *
  * @package Pantheon\Terminus\Commands\Multidev
  */
 class MergeToDevCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,18 +26,30 @@ class MergeToDevCommand extends TerminusCommand implements SiteAwareInterface
      * @aliases env:merge-to-dev
      *
      * @param string $site_env Site & Multidev environment in the form `site-name.env`
+     * @param false[] $options
      * @option boolean $updatedb Run update.php afterwards
      *
      * @usage <site>.<multidev> Merges code commits from <site>'s <multidev> environment into the Dev environment.
      * @usage <site>.<multidev> --updatedb Merges code commits from <site>'s <multidev> environment into the Dev environment and runs update.php afterwards.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function mergeToDev($site_env, $options = ['updatedb' => false,])
     {
-        list($site, $env) = $this->getSiteEnv($site_env);
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
+
         $workflow = $site->getEnvironments()->get('dev')->mergeToDev(
-            ['from_environment' => $env->id, 'updatedb' => $options['updatedb'],]
+            [
+                'from_environment' => $env->getName(),
+                'updatedb' => $options['updatedb']
+            ]
         );
         $this->processWorkflow($workflow);
-        $this->log()->notice('Merged the {env} environment into dev.', ['env' => $env->id,]);
+        $this->log()->notice(
+            'Merged the {env} environment into dev.',
+            ['env' => $env->getName()]
+        );
     }
 }

--- a/src/Commands/PaymentMethod/AddCommand.php
+++ b/src/Commands/PaymentMethod/AddCommand.php
@@ -36,7 +36,7 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
         $this->processWorkflow($site->addPaymentMethod($pm->id));
         $this->log()->notice(
             '{method} has been applied to the {site} site.',
-            ['method' => $pm->get('label'), 'site' => $site->get('name'),]
+            ['method' => $pm->get('label'), 'site' => $site->getName(),]
         );
     }
 }

--- a/src/Commands/PaymentMethod/RemoveCommand.php
+++ b/src/Commands/PaymentMethod/RemoveCommand.php
@@ -34,7 +34,7 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
         $this->processWorkflow($site->removePaymentMethod());
         $this->log()->notice(
             'The payment method for the {site} site has been removed.',
-            ['site' => $site->get('name'),]
+            ['site' => $site->getName()]
         );
     }
 }

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -45,7 +45,6 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
      * @param string $site_env The site/env to retrieve in <site>.<env> format
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     protected function prepareEnvironment($site_env)
     {

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -42,11 +42,15 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
     /**
      * Define the environment and site properties
      *
-     * @param string $site_env_id The site/env to retrieve in <site>.<env> format
+     * @param string $site_env The site/env to retrieve in <site>.<env> format
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
-    protected function prepareEnvironment($site_env_id)
+    protected function prepareEnvironment($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env_id);
+        $this->site = $this->getSite($site_env);
+        $this->environment = $this->getEnv($site_env);
     }
 
     /**
@@ -80,7 +84,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $ssh_data = $this->sendCommandViaSsh($command_line);
 
         $this->log()->notice('Command: {site}.{env} -- {command} [Exit: {exit}]', [
-            'site'    => $this->site->get('name'),
+            'site'    => $this->site->getName(),
             'env'     => $this->environment->id,
             'command' => $command_summary,
             'exit'    => $ssh_data['exit_code'],

--- a/src/Commands/Self/ConsoleCommand.php
+++ b/src/Commands/Self/ConsoleCommand.php
@@ -7,7 +7,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Commands\TerminusCommand;
 
 /**
- * Class ConsoleCommand
+ * Class ConsoleCommand.
+ *
  * @package Pantheon\Terminus\Commands\Self
  */
 class ConsoleCommand extends TerminusCommand implements SiteAwareInterface
@@ -25,10 +26,14 @@ class ConsoleCommand extends TerminusCommand implements SiteAwareInterface
      * @usage Opens an interactive PHP console within Terminus.
      * @usage <site> Opens an interactive PHP console within Terminus and loads <site> as $site.
      * @usage <site>.<env> Opens an interactive PHP console within Terminus and loads <site> and its <env> environment as $site and $env.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function console($site_env = null)
     {
-        list($site, $env) = $this->getOptionalSiteEnv($site_env, null);
+        $site = $site_env ?? $this->getSite($site_env);
+        $env = $site_env ?? $this->getOptionalEnv($site_env);
+
         eval(\Psy\sh());
     }
 }

--- a/src/Commands/Site/Upstream/ClearCacheCommand.php
+++ b/src/Commands/Site/Upstream/ClearCacheCommand.php
@@ -32,6 +32,6 @@ class ClearCacheCommand extends TerminusCommand implements SiteAwareInterface
     {
         $site_obj = $this->sites->get($site);
         $this->processWorkflow($site_obj->getUpstream()->clearCache());
-        $this->log()->notice('Code cache cleared on {site}.', ['site' => $site_obj->get('name'),]);
+        $this->log()->notice('Code cache cleared on {site}.', ['site' => $site_obj->getName(),]);
     }
 }

--- a/src/Commands/Site/Upstream/SetCommand.php
+++ b/src/Commands/Site/Upstream/SetCommand.php
@@ -23,7 +23,6 @@ class SetCommand extends SiteCommand
      *
      * @param string $site_name Site name
      * @param string $upstream_id Upstream name or UUID
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      *
      * @usage <site> <upstream_id> Updates <site>'s upstream to <upstream_id>.
      */

--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -32,12 +32,13 @@ class ApplyCommand extends UpdatesCommand
      */
     public function applyUpstreamUpdates($site_env, $options = ['updatedb' => false, 'accept-upstream' => false,])
     {
-        list($site, $env) = $this->getSiteEnv($site_env, 'dev');
+        $site = $this->getSite($site_env);
+        $env = $this->getEnv($site_env);
 
-        if (in_array($env->id, ['test', 'live',])) {
+        if (in_array($env->getName(), ['test', 'live'])) {
             throw new TerminusException(
                 'Upstream updates cannot be applied to the {env} environment',
-                ['env' => $env->id,]
+                ['env' => $env->getName()]
             );
         }
 
@@ -55,13 +56,13 @@ class ApplyCommand extends UpdatesCommand
                 '{prefix} to the {env} environment of {site_id}...',
                 [
                     'prefix' => $prefix,
-                    'env' => $env->id,
-                    'site_id' => $site->get('name'),
+                    'env' => $env->getName(),
+                    'site_id' => $site->getName(),
                 ]
             );
             $workflow = $env->applyUpstreamUpdates(
-                isset($options['updatedb']) ? $options['updatedb'] : false,
-                isset($options['accept-upstream']) ? $options['accept-upstream'] : false
+                $options['updatedb'] ?? false,
+                $options['accept-upstream'] ?? false
             );
             $this->processWorkflow($workflow);
             $this->log()->notice($workflow->getMessage());

--- a/src/Commands/Upstream/Updates/ListCommand.php
+++ b/src/Commands/Upstream/Updates/ListCommand.php
@@ -32,7 +32,6 @@ class ListCommand extends UpdatesCommand
      * @usage <site>.<env> Displays a list of new code commits available from the upstream for <site>'s <env> environment.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function listUpstreamUpdates($site_env)
     {

--- a/src/Commands/Upstream/Updates/ListCommand.php
+++ b/src/Commands/Upstream/Updates/ListCommand.php
@@ -5,7 +5,8 @@ namespace Pantheon\Terminus\Commands\Upstream\Updates;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 
 /**
- * Class ListCommand
+ * Class ListCommand.
+ *
  * @package Pantheon\Terminus\Commands\Upstream\Updates
  */
 class ListCommand extends UpdatesCommand
@@ -24,19 +25,22 @@ class ListCommand extends UpdatesCommand
      *     datetime: Timestamp
      *     message: Message
      *     author: Author
-     * @return RowsOfFields
-     *
      * @param string $site_env Site & development environment
      *
+     * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+     *
      * @usage <site>.<env> Displays a list of new code commits available from the upstream for <site>'s <env> environment.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function listUpstreamUpdates($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env, 'dev');
+        $env = $this->getEnv($site_env);
 
-        $data = [];
+        $upstreamUpdatesLog = [];
         foreach ($this->getUpstreamUpdatesLog($env) as $commit) {
-            $data[] = [
+            $upstreamUpdatesLog[] = [
                 'hash' => $commit->hash,
                 'datetime' => $commit->datetime,
                 'message' => $commit->message,
@@ -45,7 +49,7 @@ class ListCommand extends UpdatesCommand
         }
 
         usort(
-            $data,
+            $upstreamUpdatesLog,
             function ($a, $b) {
                 if (strtotime($a['datetime']) === strtotime($b['datetime'])) {
                     return 0;
@@ -54,11 +58,11 @@ class ListCommand extends UpdatesCommand
             }
         );
 
-        if (empty($data)) {
+        if (empty($upstreamUpdatesLog)) {
             $this->log()->warning('There are no available updates for this site.');
         }
 
         // Return the output data.
-        return new RowsOfFields($data);
+        return new RowsOfFields($upstreamUpdatesLog);
     }
 }

--- a/src/Commands/Upstream/Updates/StatusCommand.php
+++ b/src/Commands/Upstream/Updates/StatusCommand.php
@@ -3,7 +3,8 @@
 namespace Pantheon\Terminus\Commands\Upstream\Updates;
 
 /**
- * Class StatusCommand
+ * Class StatusCommand.
+ *
  * @package Pantheon\Terminus\Commands\Upstream\Updates
  */
 class StatusCommand extends UpdatesCommand
@@ -17,12 +18,13 @@ class StatusCommand extends UpdatesCommand
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @return string Either 'outdated' or 'current'
-     *
      * @usage <site>.<env> Displays either "outdated" if <site>'s <env> environment has upstream updates or "current" if not.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function status($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
-        return $env->getUpstreamStatus()->getStatus();
+        return $this->getEnv($site_env)->getUpstreamStatus()->getStatus();
     }
 }

--- a/src/Commands/Upstream/Updates/StatusCommand.php
+++ b/src/Commands/Upstream/Updates/StatusCommand.php
@@ -21,7 +21,6 @@ class StatusCommand extends UpdatesCommand
      * @usage <site>.<env> Displays either "outdated" if <site>'s <env> environment has upstream updates or "current" if not.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
-     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      */
     public function status($site_env)
     {

--- a/src/Commands/Upstream/Updates/UpdatesCommand.php
+++ b/src/Commands/Upstream/Updates/UpdatesCommand.php
@@ -8,7 +8,8 @@ use Pantheon\Terminus\Site\SiteAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
- * Class UpdatesCommand
+ * Class UpdatesCommand.
+ *
  * @package Pantheon\Terminus\Commands\Upstream\Updates
  */
 abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterface
@@ -18,9 +19,11 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
     /**
      * Return the upstream for the given site
      *
-     * @param Site $site
+     * @param \Pantheon\Terminus\Models\Environment $env
+     *
      * @return object The upstream information
-     * @throws TerminusException
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     protected function getUpstreamUpdates($env)
     {
@@ -33,9 +36,11 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
     /**
      * Get the list of upstream updates for a site
      *
-     * @param Site $site
+     * @param \Pantheon\Terminus\Models\Environment $env
+     *
      * @return array The list of updates
-     * @throws TerminusException
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     protected function getUpstreamUpdatesLog($env)
     {
@@ -46,9 +51,9 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
     /**
      * Get the list of composer dependency updates for a site environment
      *
-     * @param Environment $env
+     * @param \Pantheon\Terminus\Models\Environment $env
+     *
      * @return array The list of updates
-     * @throws TerminusException
      */
     protected function getComposerUpdatesLog($env)
     {

--- a/src/Commands/Workflow/ListCommand.php
+++ b/src/Commands/Workflow/ListCommand.php
@@ -47,7 +47,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
             $site->getWorkflows()->setPaging(false)->fetch(),
             [
                 'message' => 'No workflows have been run on {site}.',
-                'message_options' => ['site' => $site->get('name'),],
+                'message_options' => ['site' => $site->getName()],
             ]
         );
     }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -176,15 +176,17 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
     }
 
     /**
-     * Commits changes to code
+     * Commits changes to code.
      *
-     * @param string $commit Should be the commit message to use if committing
+     * @param string|null $commit Should be the commit message to use if committing
      *   on server changes
-     * @return array Response data
+     *
+     * @return \Pantheon\Terminus\Models\Workflow
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
-    public function commitChanges($commit = null)
+    public function commitChanges(?string $commit = null): Workflow
     {
-        $nickname = \uniqid(__FUNCTION__ . "-");
         $local = $this->getContainer()->get(LocalMachineHelper::class);
 
         $git_email_result = $local->exec('git config user.email');
@@ -594,7 +596,7 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         $domain = "codeserver.dev.{$site->id}.drush.in";
         $port = '2222';
         $url = "ssh://$username@$domain:$port/~/repository.git";
-        $command = trim("git clone $url {$site->get('name')}");
+        $command = trim("git clone $url {$site->getName()}");
         return [
             'username' => $username,
             'host' => $domain,

--- a/src/Site/SiteAwareInterface.php
+++ b/src/Site/SiteAwareInterface.php
@@ -3,47 +3,38 @@
 namespace Pantheon\Terminus\Site;
 
 use Pantheon\Terminus\Collections\Sites;
+use Pantheon\Terminus\Models\Site;
 
 /**
- * Interface SiteAwareInterface
+ * Interface SiteAwareInterface.
+ *
  * Provides an interface for commands that need access to one or more Pantheon sites.
+ *
  * @package Pantheon\Terminus\Site
  */
 interface SiteAwareInterface
 {
     /***
+     * Sets the sites.
+     *
      * @param Sites $sites
-     * @return void
      */
     public function setSites(Sites $sites);
 
     /**
-     * @return Sites The sites collection for the authenticated user.
+     * Returns the sites.
+     *
+     * @return Sites
+     *   The sites' collection for the authenticated user.
      */
-    public function sites();
+    public function sites(): Sites;
 
     /**
-     * Look up a site by id.
+     * Returns the site by site id, name or site_env.
      *
-     * @param $site_id
+     * @param string $site_id
+     *
      * @return mixed
      */
-    public function getSite($site_id);
-
-    /**
-     * Get the site and environment with the given ids.
-     *
-     * @param string $site_env_id The site/environment id in the form <site>[.<env>]
-     * @param string $default_env The default environment to use if none is specified; null if not required
-     * @return array The site and environment in an array.
-     */
-    public function getSiteEnv($site_env_id, $default_env);
-
-    /**
-     * Get the site and environment with the given ids if provided
-     *
-     * @param string $site_env_id The site/environment id in the form <site>[.<env>]
-     * @return array The site and environment in an array, if provided; may return [null, null]
-     */
-    public function getOptionalSiteEnv($site_env_id);
+    public function getSite(string $site_id): Site;
 }

--- a/tests/Functional/DashboardCommandsTest.php
+++ b/tests/Functional/DashboardCommandsTest.php
@@ -6,7 +6,7 @@ use Pantheon\Terminus\Tests\Traits\TerminusTestTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class DashboardCommandsTest
+ * Class DashboardCommandsTest.
  *
  * @package Pantheon\Terminus\Tests\Functional
  */
@@ -21,17 +21,18 @@ class DashboardCommandsTest extends TestCase
      * @group dashboard
      * @group short
      */
-    public function testDashboardUrl()
+    public function testDashboardViewCommand()
     {
-        $response = $this->terminus("dashboard --print");
-        $this->assertNotNull($response);
-        $this->assertIsString($response);
-        $this->assertGreaterThan(0, strlen($response));
-        $siteName = $this->getSiteName();
-        $env = getenv('TERMINUS_ENV');
-        $response = $this->terminus("dashboard {$siteName}.{$env} --print");
-        $this->assertNotNull($response);
-        $this->assertIsString($response);
-        $this->assertGreaterThan(0, strlen($response));
+        $dashboardUrl = $this->terminus(sprintf('dashboard %s --print', $this->getSiteEnv()));
+        $this->assertIsString($dashboardUrl);
+        $this->assertNotEmpty($dashboardUrl);
+
+        $dashboardUrl = $this->terminus(sprintf('dashboard %s --print', $this->getSiteName()));
+        $this->assertIsString($dashboardUrl);
+        $this->assertNotEmpty($dashboardUrl);
+
+        $dashboardUrl = $this->terminus('dashboard --print');
+        $this->assertIsString($dashboardUrl);
+        $this->assertNotEmpty($dashboardUrl);
     }
 }

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -59,8 +59,7 @@ class EnvCommandsTest extends TestCase
      */
     public function testCodelogCommand()
     {
-        $sitename = $this->getSiteName();
-        $codeLogs = $this->terminusJsonResponse(sprintf('env:code-log %s', $sitename));
+        $codeLogs = $this->terminusJsonResponse(sprintf('env:code-log %s', $this->getSiteEnv()));
         $this->assertIsArray($codeLogs);
         $this->assertNotEmpty($codeLogs);
         $codeLog = array_shift($codeLogs);

--- a/tests/unit_tests/Site/SiteAwareTraitTest.php
+++ b/tests/unit_tests/Site/SiteAwareTraitTest.php
@@ -2,11 +2,11 @@
 
 namespace Pantheon\Terminus\UnitTests\Site;
 
-use Pantheon\Terminus\Exceptions\TerminusException;
-use Pantheon\Terminus\Models\Environment;
-use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\UnitTests\Commands\CommandTestCase;
 
+/**
+ * @todo: implement tests for SiteAwareTrait.
+ */
 class SiteAwareTraitTest extends CommandTestCase
 {
     /**
@@ -23,67 +23,5 @@ class SiteAwareTraitTest extends CommandTestCase
 
         $this->class = new DummyClass();
         $this->class->setSites($this->sites);
-    }
-
-    public function testGetSiteEnv()
-    {
-        $this->site->id = 'site id';
-        $this->environment->id = 'environment id';
-
-        list($site, $env) = $this->class->getSiteEnv("{$this->site->id}.{$this->environment->id}");
-
-        $this->assertInstanceOf(Site::class, $site);
-        $this->assertInstanceOf(Environment::class, $env);
-    }
-
-    /**
-     * Tests SiteAwareTrait::getSiteEnv(string) when the given string is in an incorrect format
-     */
-    public function testGetSiteEnvWrongFormat()
-    {
-        $this->setExpectedException(
-            TerminusException::class,
-            'The environment argument must be given as <site_name>.<environment>'
-        );
-
-        $out = $this->class->getSiteEnv('');
-        $this->assertNull($out);
-    }
-
-    public function testGetUnfrozenSiteEnv()
-    {
-        $this->site->id = 'site id';
-        $this->environment->id = 'live';
-
-        $this->site->expects($this->once())
-            ->method('isFrozen')
-            ->willReturn(false);
-
-        list($site, $env) = $this->class->getUnfrozenSiteEnv("{$this->site->id}.{$this->environment->id}");
-
-        $this->assertInstanceOf(Site::class, $site);
-        $this->assertInstanceOf(Environment::class, $env);
-    }
-
-    /**
-     * Tests SiteAwareTrait::getUnfrozenSiteEnv(string) when the site is frozen and the env test or live
-     */
-    public function testGetUnfrozenSiteEnvFrozenAndLive()
-    {
-        $this->site->id = 'site id';
-        $this->environment->id = 'live';
-
-        $this->site->expects($this->once())
-            ->method('isFrozen')
-            ->willReturn(true);
-
-        $this->setExpectedException(
-            TerminusException::class,
-            'This site is frozen. Its test and live environments and many commands will be '
-            . 'unavailable while it remains frozen.'
-        );
-
-        $out = $this->class->getUnfrozenSiteEnv("{$this->site->id}.{$this->environment->id}");
-        $this->assertNull($out);
     }
 }


### PR DESCRIPTION
* code duplicates (such as `list($site, $env) = explode('.', $site_env);` are removed
* deprecated method `getSiteEnv()` is removed
* `getSite()` is refactored and `getEnv()` is added to create a pair of unified methods to work with `<site_env>` string
* redundant/unnecessary code (like `throw new TerminusNotFoundException`) is removed
* tests are updated