### PR TITLE
Restore filter hooks for the --filter option

### DIFF
--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -255,6 +255,7 @@ class Terminus implements
     {
         // List of all hooks and commands. Update via 'composer update-class-lists'
         $this->commands = [
+            'Consolidation\\Filter\\Hooks\\FilterHooks',
             'Pantheon\\Terminus\\Hooks\\Authorizer',
             'Pantheon\\Terminus\\Hooks\\RoleValidator',
             'Pantheon\\Terminus\\Hooks\\SiteEnvLookup',


### PR DESCRIPTION
The filter hooks were removed in t3, which means that the --filter option was not available. This restores it.