### PR TITLE
Updated README.md to remove references to homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,6 @@ Run this in your terminal client:
 cd /install/location ; composer update
 ```
 
-### Updating with [Homebrew](http://brew.sh/) (for Macs)
-Update Terminus with this command:
-```bash
-brew upgrade homebrew/php/terminus
-```
-
 ### Updating with Git
 To update with Git and use Terminus HEAD, you should update this repository and then update its dependencies via Composer.
 


### PR DESCRIPTION
Removed references to homebrew because the tap has been removed.

When you try to install via homebrew you get the following message:
```
$ brew install homebrew/php/terminus
Error: homebrew/php was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```