### PR TITLE
CMS-375: Use different terminus dependencies dir based on composer lock hash.

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -71,6 +71,23 @@ class RoboFile extends \Robo\Tasks
     }
 
     /**
+     * Updates $terminusPluginsDependenciesVersion variable.
+     */
+    public function updateDependenciesversion()
+    {
+        $this->say('Updating terminus dependencies version.');
+        $composerFilePath = realpath(dirname(\Composer\Factory::getComposerFile()));
+        $composerLockContents = file_get_contents($composerFilePath . DIRECTORY_SEPARATOR . 'composer.lock');
+        $composerLockJson = json_decode($composerLockContents, true, 10);
+        $hash = substr($composerLockJson['content-hash'], 0, 7);
+        $binFileContents = file_get_contents('bin/terminus');
+        $newBinFileContents = preg_replace("/(terminusPluginsDependenciesVersion\s?=)(.*)/m", "$1 '${hash}';", $binFileContents);
+        if ($newBinFileContents && $newBinFileContents !== $binFileContents) {
+            file_put_contents('bin/terminus', $newBinFileContents);
+        }
+    }
+
+    /**
      * @return mixed|null
      * @throws Exception
      */

--- a/bin/terminus
+++ b/bin/terminus
@@ -10,7 +10,7 @@
  */
 
 // Increase this number to force terminus dependencies to be reloaded.
-$terminusPluginsDependenciesVersion = '1';
+$terminusPluginsDependenciesVersion = '2512c16';
 
 // Cannot use $_SERVER superglobal since that's empty during phpunit testing
 // getenv('HOME') isn't set on Windows and generates a Notice.

--- a/bin/terminus
+++ b/bin/terminus
@@ -9,7 +9,8 @@
  *   - Exits with a status code
  */
 
-// Increase this number to force terminus dependencies to be reloaded.
+// This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
+// which is run after every call to composer update.
 $terminusPluginsDependenciesVersion = '2512c16';
 
 // Cannot use $_SERVER superglobal since that's empty during phpunit testing

--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,8 @@
       "Tooly\\ScriptHandler::installPharTools"
     ],
     "post-update-cmd": [
-      "Tooly\\ScriptHandler::installPharTools"
+      "Tooly\\ScriptHandler::installPharTools",
+      "vendor/bin/robo update:Dependenciesversion"
     ],
     "pre-commit": [
       "@code:fix",

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -32,7 +32,8 @@ TERMINUS_TIME_ZONE:       'UTC'
 
 # File Storage
 TERMINUS_CACHE_DIR:             '[[ TERMINUS_USER_HOME ]]/.terminus/cache'
-TERMINUS_PLUGINS_DIR:           '[[ TERMINUS_USER_HOME ]]/.terminus/plugins-3.x'
+TERMINUS_PLUGINS_DIR_BASENAME:  'plugins-3.x'
+TERMINUS_PLUGINS_DIR:           '[[ TERMINUS_USER_HOME ]]/.terminus/[[ TERMINUS_PLUGINS_DIR_BASENAME ]]'
 TERMINUS_DEPENDENCIES_BASE_DIR: '[[ TERMINUS_USER_HOME ]]/.terminus/terminus-dependencies'
 TERMINUS_COMMAND_CACHE_DIR:     '[[ TERMINUS_CACHE_DIR ]]/commands'
 TERMINUS_TOKENS_DIR:            '[[ TERMINUS_CACHE_DIR ]]/tokens'

--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -276,18 +276,22 @@ abstract class PluginBaseCommand extends TerminusCommand
         $fs = $this->getLocalMachine()->getFileSystem();
         foreach ($all_folders as $folder) {
             $full_path = $parent_folder . DIRECTORY_SEPARATOR . $folder;
-            if (is_dir($full_path) && strpos($folder, $pattern_start) === 0) {
-                if ($full_path !== $current_dependencies_dir) {
-                    // This folder should be deleted.
-                    try {
-                        $fs->remove($full_path);
-                    } catch (IOException $e) {
-                        $this->log()->warning(
-                            'Error removing old dependencies folder: {full_path}.',
-                            compact('full_path')
-                        );
-                    }
-                }
+            if (!is_dir($full_path)
+                || strpos($folder, $pattern_start) !== 0
+                || $full_path === $current_dependencies_dir) {
+                continue;
+            }
+            // Delete folder if:
+            // - it's a folder
+            // - the folder name starts with $pattern_start
+            // - it's not the current dependencies folder.
+            try {
+                $fs->remove($full_path);
+            } catch (IOException $e) {
+                $this->log()->warning(
+                    'Error removing old dependencies folder: {full_path}.',
+                    compact('full_path')
+                );
             }
         }
     }

--- a/src/Commands/Self/Plugin/PluginBaseCommand.php
+++ b/src/Commands/Self/Plugin/PluginBaseCommand.php
@@ -282,7 +282,10 @@ abstract class PluginBaseCommand extends TerminusCommand
                     try {
                         $fs->remove($full_path);
                     } catch (IOException $e) {
-                        $this->log()->warning('Error removing old dependencies folder: {full_path}.', compact('full_path'));
+                        $this->log()->warning(
+                            'Error removing old dependencies folder: {full_path}.',
+                            compact('full_path')
+                        );
                     }
                 }
             }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -526,7 +526,7 @@ class Terminus implements
         $terminus = new static($config, $input, $output);
         if ($dependencies_warning) {
             $terminus->logger->warning(
-                "Could not load plugins because dependencies version have changed. " .
+                "Could not load plugins because Terminus was upgraded. " .
                 "Please run terminus self:plugin:reload to refresh.",
             );
         }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -519,15 +519,15 @@ class Terminus implements
             $config->set('terminus_dependencies_dir', $terminusDependenciesDir);
             if (file_exists($terminusDependenciesDir . '/vendor/autoload.php')) {
                 include_once("$terminusDependenciesDir/vendor/autoload.php");
-            }
-            else {
+            } else {
                 $dependencies_warning = true;
             }
         }
         $terminus = new static($config, $input, $output);
         if ($dependencies_warning) {
             $terminus->logger->warning(
-                "Could not load plugins because dependencies version have changed. Please run terminus self:plugin:reload to refresh.",
+                "Could not load plugins because dependencies version have changed. " .
+                "Please run terminus self:plugin:reload to refresh.",
             );
         }
         return $terminus;

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -514,7 +514,10 @@ class Terminus implements
             return false;
         }
 
-        $composerJsonContents = json_decode(file_get_contents($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json'), true);
+        $composerJsonContents = json_decode(
+            file_get_contents($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json'),
+            true
+        );
         $dependencies = $composerJsonContents['require'] ?? [];
 
         return count($dependencies) > 0;

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -512,6 +512,7 @@ class Terminus implements
         $config->extend(new YamlConfig($config->get('user_home') . '/.terminus/config.yml'));
         $config->extend(new DotEnvConfig(getcwd()));
         $config->extend(new EnvConfig());
+        $dependencies_warning = false;
         if ($dependencies_version) {
             $dependenciesBaseDir = $config->get('dependencies_base_dir');
             $terminusDependenciesDir = $dependenciesBaseDir . '-' . $dependencies_version;
@@ -519,7 +520,16 @@ class Terminus implements
             if (file_exists($terminusDependenciesDir . '/vendor/autoload.php')) {
                 include_once("$terminusDependenciesDir/vendor/autoload.php");
             }
+            else {
+                $dependencies_warning = true;
+            }
         }
-        return new static($config, $input, $output);
+        $terminus = new static($config, $input, $output);
+        if ($dependencies_warning) {
+            $terminus->logger->warning(
+                "Could not load plugins because dependencies version have changed. Please run terminus self:plugin:reload to refresh.",
+            );
+        }
+        return $terminus;
     }
 }

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -507,12 +507,12 @@ class Terminus implements
     /**
      * Determines whether Terminus is supposed to have plugins or not without loading them.
      */
-    public function hasPlugins()
+    public function hasPlugins(): bool
     {
         $plugins_dir = $this->getConfig()->get('plugins_dir');
         $fs = new Filesystem();
         if ($fs->exists($plugins_dir . '/composer.json')) {
-            $composer_json_contents = json_decode(file_get_contents($plugins_dir . '/composer.json'), true, 10);
+            $composer_json_contents = json_decode(file_get_contents($plugins_dir . '/composer.json'), true);
             if (!empty($composer_json_contents['require']) && count($composer_json_contents['require'])) {
                 return true;
             }
@@ -544,8 +544,8 @@ class Terminus implements
         $terminus = new static($config, $input, $output);
         if ($dependencies_folder_absent && $terminus->hasPlugins()) {
             $terminus->logger->warning(
-                "Could not load plugins because Terminus was upgraded. " .
-                "Please run terminus self:plugin:reload to refresh.",
+                'Could not load plugins because Terminus was upgraded. ' .
+                'Please run terminus self:plugin:reload to refresh.',
             );
         }
         return $terminus;

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -514,7 +514,7 @@ class Terminus implements
             return false;
         }
 
-        $composerJsonContents = json_decode(file_get_contents($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json'));
+        $composerJsonContents = json_decode(file_get_contents($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json'), true);
         $dependencies = $composerJsonContents['require'] ?? [];
 
         return count($dependencies) > 0;

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -509,16 +509,15 @@ class Terminus implements
      */
     public function hasPlugins(): bool
     {
-        $plugins_dir = $this->getConfig()->get('plugins_dir');
-        $fs = new Filesystem();
-        if ($fs->exists($plugins_dir . '/composer.json')) {
-            $composer_json_contents = json_decode(file_get_contents($plugins_dir . '/composer.json'), true);
-            if (!empty($composer_json_contents['require']) && count($composer_json_contents['require'])) {
-                return true;
-            }
+        $pluginsDir = $this->getConfig()->get('plugins_dir');
+        if (!(new Filesystem())->exists($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json')) {
+            return false;
         }
 
-        return false;
+        $composerJsonContents = json_decode(file_get_contents($pluginsDir . DIRECTORY_SEPARATOR . 'composer.json'));
+        $dependencies = $composerJsonContents['require'] ?? [];
+
+        return count($dependencies) > 0;
     }
 
     public static function factory($dependencies_version = null): Terminus


### PR DESCRIPTION
This PR includes 3 changes:

- A new script will run on composer update to make sure the hash is updated if composer.lock hash changed.
- A warning was added to Terminus bootstrap in case the terminus dependencies dir does not exist (should we somehow make this warning optional?).
- Old dependencies folder are cleaned up when plugin manager operations are executed.
