### PR TITLE
Allow remote commands to work on sandboxen

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -296,7 +296,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
      *
      * @return string
      */
-    private function lookupHostViaAlternateNameserver($host)
+    private function lookupHostViaAlternateNameserver(string $host): string
     {
         $alternateNameserver = $this->getConfig()->get('alternate_nameserver');
         if (!$alternateNameserver || !class_exists('\Net_DNS2_Resolver')) {

--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -307,7 +307,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         $nameserver = gethostbyname($alternateNameserver);
         $r = new \Net_DNS2_Resolver(array('nameservers' => [$nameserver]));
         $result = $r->query($host, 'A');
-        foreach($result->answer as $index => $o) {
+        foreach ($result->answer as $index => $o) {
             return $o->address;
         }
 


### PR DESCRIPTION
Look up host for 'terminus drush' / 'terminus wp' commands via an alternate nameserver, if selected.

In order for this to work, Terminus also needs access to the \Net_DNS2_Resolver class. There are two ways we could provide this:

1. `composer require pear/net_dns2` in Terminus itself
2. Add pear/net_dns2 as a dependency of the Terminus admin plugin

The advantage of option #2 is that it keeps pear/net_dns2 out of the distribution terminus.phar, since most users won't need it.

Add `TERMINUS_ALTERNATE_NAMESERVER=eco.onebox.panth.io` to your termineco alias to use this with sandbox-eco.