### PR TITLE
Note support for PHP up to 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Our documentation is kept in the Terminus Manual, located here: https://pantheon
 ## Dependencies
 ### Required
 - A command-line client
-- PHP version 5.6.40 or later recommended (5.5.38 minimum)
+- PHP version 5.6.40 up to version 7.4. PHP 8.x support will be included with Terminus 3.
 - [PHP-CLI](https://www.php-cli.com/)
 - [PHP-CURL](https://php.net/manual/curl.setup.php)
 - [PHP-XML](https://php.net/manual/book.xml.php)


### PR DESCRIPTION
Terminus 2.x does not support PHP 8

Docs page mentions only PHP 7+, not sure if that is a true constraint here. 
https://pantheon.io/docs/terminus/install