### PR TITLE
[CMS-461] Change env:wake to use https on the platform domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 2.6.5-dev
+- Change env:wake to use https on the platform domain (#2287)
+
 ## 2.6.4 2021-12-06
 - Fix Terminus for PHP 5.5, 5.6, and 7.0 (#2264)
 

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -864,11 +864,12 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         $domains = array_filter(
             $this->getDomains()->all(),
             function ($domain) {
-                return !empty($domain->get('dns_zone_name'));
+                $domain_type = $domain->get('type');
+                return (!empty($domain_type) && "platform" == $domain_type);
             }
         );
         $domain = array_pop($domains);
-        $response = $this->request()->request("http://{$domain->id}/pantheon_healthcheck");
+        $response = $this->request()->request("https://{$domain->id}/pantheon_healthcheck");
         return [
             'success' => ($response['status_code'] === 200),
             'styx' => $response['headers']['X-Pantheon-Styx-Hostname'],


### PR DESCRIPTION
This PR changes the filter in the env:wake command to look for the platform domain and changes the scheme for the healthcheck to https.  It's the same as #2283, but for the 2.x branch.

@jspellman814 and I worked on this together. We feel the original filter looking for the domain with the dns_zone_name was a valid approach, but felt that the domain with type=platform was more clear to those looking at this in the future.

Relates to #1518, #1530, and #2276.