### PR TITLE
CMS-468: Set memory limit with ini_set() rather than /usr/bin/env -S

### DIFF
--- a/bin/terminus
+++ b/bin/terminus
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S php -d memory_limit=2048M
+#!/usr/bin/env php 
 <?php
 
 /**
@@ -8,6 +8,9 @@
  *   - Starts a runner instance and runs the command
  *   - Exits with a status code
  */
+
+// Set memory limit
+ini_set('memory_limit', "2048M");
 
 // Version compatibility check and messaging
 if (version_compare(PHP_VERSION, '7.4.0', '<') === true) {

--- a/bin/terminus
+++ b/bin/terminus
@@ -10,7 +10,7 @@
  */
 
 // Set memory limit
-ini_set('memory_limit', "2048M");
+ini_set('memory_limit', -1);
 
 // Version compatibility check and messaging
 if (version_compare(PHP_VERSION, '7.4.0', '<') === true) {

--- a/bin/terminus
+++ b/bin/terminus
@@ -9,7 +9,7 @@
  *   - Exits with a status code
  */
 
-// Set memory limit
+// Unset memory limit
 ini_set('memory_limit', -1);
 
 // Version compatibility check and messaging


### PR DESCRIPTION
Have not been able to demonstrate break/fix with a built .phar