### PR TITLE
[CMS-488] Improve error verbosity in `Sites::get()`

### DIFF
--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -293,7 +293,7 @@ class Sites extends APICollection implements SessionAwareInterface
      *
      * @param string $site_id
      *   The site name or UUID.
-     * @return string
+     * @return string|null
      *   The site UUID.
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException

--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -2,6 +2,7 @@
 
 namespace Pantheon\Terminus\Collections;
 
+use Exception;
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Models\Site;
 use Pantheon\Terminus\Models\TerminusModel;
@@ -205,8 +206,10 @@ class Sites extends APICollection implements SessionAwareInterface
      *
      * @return \Pantheon\Terminus\Models\Site
      *
-     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function get($id): TerminusModel
     {
@@ -229,11 +232,10 @@ class Sites extends APICollection implements SessionAwareInterface
             $this->models[$uuid] = $site;
 
             return $this->models[$uuid];
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             throw new TerminusException(
-                'Could not locate a site your user may access identified by {id}.',
-                compact('id'),
-                1
+                'Could not locate a site your user may access identified by {id}: {error_message}',
+                ['id' => $id, 'error_message' => $e->getMessage()],
             );
         }
     }

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -144,8 +144,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
         $particle = in_array(substr($pretty_name, 0, 1), ['a', 'e', 'i', 'o', 'u',]) ? 'an' : 'a';
         throw new TerminusNotFoundException(
             "Could not find $particle {model} identified by {id}.",
-            ['model' => $pretty_name, 'id' => $id,],
-            1
+            ['model' => $pretty_name, 'id' => $id,]
         );
     }
 

--- a/src/Commands/Self/Plugin/CreateCommand.php
+++ b/src/Commands/Self/Plugin/CreateCommand.php
@@ -73,10 +73,7 @@ class CreateCommand extends PluginBaseCommand
             );
             $results = $this->runCommand($command);
             if ($results['exit_code'] !== 0) {
-                throw new TerminusException(
-                    'Error creating plugin project.',
-                    []
-                );
+                throw new TerminusException('Error creating plugin project.');
             }
             $this->renameProject($realpath, $project_name);
             $project_name = $this->getProjectNameFromPath($realpath) . ':@dev';

--- a/src/Commands/Self/Plugin/UninstallCommand.php
+++ b/src/Commands/Self/Plugin/UninstallCommand.php
@@ -82,19 +82,13 @@ class UninstallCommand extends PluginBaseCommand
             );
             $results = $this->runCommand($command);
             if ($results['exit_code'] !== 0) {
-                throw new TerminusException(
-                    'Error removing package in terminus-dependencies.',
-                    []
-                );
+                throw new TerminusException('Error removing package in terminus-dependencies.');
             }
 
             // Then, Update terminus-dependencies composer.
             $results = $this->runComposerUpdate($dependencies_dir);
             if ($results['exit_code'] !== 0) {
-                throw new TerminusException(
-                    'Error running composer update in terminus-dependencies.',
-                    []
-                );
+                throw new TerminusException('Error running composer update in terminus-dependencies.');
             }
 
             // Cleanup path repositories if they exist.
@@ -106,10 +100,7 @@ class UninstallCommand extends PluginBaseCommand
                 );
                 $results = $this->runCommand($command);
                 if ($results['exit_code'] !== 0) {
-                    throw new TerminusException(
-                        'Error removing path repository in ' . basename($dir),
-                        []
-                    );
+                    throw new TerminusException('Error removing path repository in ' . basename($dir));
                 }
             }
 

--- a/src/Commands/Self/Plugin/UpdateCommand.php
+++ b/src/Commands/Self/Plugin/UpdateCommand.php
@@ -98,10 +98,7 @@ class UpdateCommand extends PluginBaseCommand
                     $messages[] = $results['stderr'];
                 }
                 if ($results['exit_code'] !== 0) {
-                    throw new TerminusException(
-                        'Error updating packages in terminus-depedencies.',
-                        []
-                    );
+                    throw new TerminusException('Error updating packages in terminus-depedencies.');
                 }
 
                 $this->replaceFolder($plugins_dir, $original_plugins_dir);

--- a/src/Exceptions/TerminusException.php
+++ b/src/Exceptions/TerminusException.php
@@ -19,11 +19,11 @@ class TerminusException extends \Exception
     private $raw_message;
 
   /**
-   * Object constructor. Sets context array as replacements property
+   * Object constructor. Sets context array as replacements property.
    *
-   * @param string $message      Message to send when throwing the exception
-   * @param array  $replacements Context array to interpolate into message
-   * @param int    $code         Exit code
+   * @param string $message      Message to send when throwing the exception.
+   * @param array  $replacements Context array to interpolate into message.
+   * @param int    $code         The Exception code.
    */
     public function __construct(
         $message = null,

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -786,8 +786,7 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         if (!$this->isMultidev()) {
             throw new TerminusException(
                 'The {env} environment is not a multidev environment',
-                ['env' => $this->id],
-                1
+                ['env' => $this->id]
             );
         }
         $default_params = ['updatedb' => false,];


### PR DESCRIPTION
Improves error verbosity in `Sites::get()` so that to help in debugging failed tests like https://github.com/pantheon-systems/terminus/runs/4837926003?check_suite_focus=true