### PR TITLE
[CMS-488] Increase Solr and Redis functional tests stability

### DIFF
--- a/tests/Functional/RedisCommandsTest.php
+++ b/tests/Functional/RedisCommandsTest.php
@@ -18,7 +18,7 @@ class RedisCommandsTest extends TerminusTestBase
      */
     public function testRedisEnable()
     {
-        $this->terminus("redis:enable {$this->getSiteName()}");
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('redis:enable %s', $this->getSiteName()));
     }
 
     /**
@@ -30,6 +30,6 @@ class RedisCommandsTest extends TerminusTestBase
      */
     public function testRedisDisable()
     {
-        $this->terminus("redis:disable {$this->getSiteName()}");
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('redis:disable %s', $this->getSiteName()));
     }
 }

--- a/tests/Functional/SolrCommandsTest.php
+++ b/tests/Functional/SolrCommandsTest.php
@@ -18,7 +18,7 @@ class SolrCommandsTest extends TerminusTestBase
      */
     public function testSolrEnableCommand()
     {
-        $this->terminus(sprintf('solr:enable %s', $this->getSiteName()));
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('solr:enable %s', $this->getSiteName()));
     }
 
     /**
@@ -30,6 +30,6 @@ class SolrCommandsTest extends TerminusTestBase
      */
     public function testSolrDisableCommand()
     {
-        $this->terminus(sprintf('solr:disable %s', $this->getSiteName()));
+        $this->assertTerminusCommandSucceedsInAttempts(sprintf('solr:disable %s', $this->getSiteName()));
     }
 }

--- a/tests/Functional/TerminusTestBase.php
+++ b/tests/Functional/TerminusTestBase.php
@@ -161,6 +161,23 @@ abstract class TerminusTestBase extends TestCase
     }
 
     /**
+     * Asserts terminus command execution succeeds in multiple attempts.
+     *
+     * @param string $command
+     *   The command to execute.
+     * @param int $attempts
+     *   The maximum number of attempts.
+     */
+    protected function assertTerminusCommandSucceedsInAttempts(string $command, int $attempts = 3): void
+    {
+        $this->assertTerminusCommandResultEqualsInAttempts(
+            fn() => static::callTerminus(sprintf('%s --yes', $command))[1],
+            0,
+            $attempts
+        );
+    }
+
+    /**
      * Returns the site name.
      *
      * @return string


### PR DESCRIPTION
An example of failing Solr-related functional test - https://github.com/pantheon-systems/terminus/runs/4838028226?check_suite_focus=true