### PR TITLE
BUGS-4091: Use the user workflow API for watching a delete_site workflow - Terminus 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
+## 2.6.6-dev
+- Fix bug where `site:delete` command always fails (#2323)
+
 ## 2.6.5 2021-12-17
 - Change env:wake to use https on the platform domain (#2287)
 

--- a/src/Commands/Site/DeleteCommand.php
+++ b/src/Commands/Site/DeleteCommand.php
@@ -32,6 +32,10 @@ class DeleteCommand extends SiteCommand
         }
 
         $workflow = $site->delete();
+
+        // We need to query the user workflows API to watch the delete_site workflow, since the site object won't exist anymore
+        $workflow->setOwnerObject($this->session()->getUser());
+
         try {
             $this->processWorkflow($workflow);
             $message = $workflow->getMessage();

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -175,6 +175,16 @@ class Workflow extends TerminusModel implements ContainerAwareInterface, Session
     }
 
     /**
+     * Sets the object which owns this workflow
+     *
+     * @param $owner The object that owns this workflow
+     */
+    public function setOwnerObject($owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
      * Returns the status of this workflow
      *
      * @return string


### PR DESCRIPTION
When deleting a site, we can't query the site workflows API at `/sites/<site_id>/workflows`, because the site object will no longer exist. Instead, we should query the user workflows API.

This is the cause of `site:delete` commands always failing, even if the workflow eventually succeeds.

Before this change:
```
$ ./bin/terminus site:delete 36bc1d93-690d-4d45-ab62-12bd0ab55393

 Are you sure you want to delete joeb-deleteme-2? (yes/no) [no]:
 > yes

 0/6 [>---------------------------] Delete site [warning] HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Retrying in 133 milliseconds..
 [warning] HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Retrying in 248 milliseconds..
 [warning] HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Retrying in 415 milliseconds..
 [warning] HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Retrying in 809 milliseconds..
 [warning] HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Retrying in 1648 milliseconds..
 [error]  HTTPS request failed with error Server error: `GET https://terminus.pantheon.io/api/sites/36bc1d93-690d-4d45-ab62-12bd0ab55393/workflows/4004387e-8609-11ec-97ab-42010a8001a4` resulted in a `500 Internal Server Error` response:
"Processing failed."
. Maximum retry attempts reached. 
```

After this change:
```
$ ./bin/terminus site:delete 0831c2b4-06c4-448f-983e-d1c6812f4583

 Are you sure you want to delete joeb-deleteme-3? (yes/no) [no]:
 > yes

 [notice] Deleted site
```