### PR TITLE
Add new test for self-update command.

### DIFF
--- a/bin/terminus
+++ b/bin/terminus
@@ -31,7 +31,7 @@ if (!getenv('TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP') && version_compare(PHP_VERSI
 
 // This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
 // which is run after every call to composer update.
-$terminusPluginsDependenciesVersion = '1b1da7aadb';
+$terminusPluginsDependenciesVersion = 'f79ed6c0da';
 
 // Cannot use $_SERVER superglobal since that's empty during phpunit testing
 // getenv('HOME') isn't set on Windows and generates a Notice.

--- a/composer.lock
+++ b/composer.lock
@@ -517,16 +517,16 @@
         },
         {
             "name": "consolidation/self-update",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/self-update.git",
-                "reference": "48d3bfac6d37b10c8ddae6e366ea79db5594d918"
+                "reference": "8a64bdd8daf5faa8e85f56534dd99caf928164b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/self-update/zipball/48d3bfac6d37b10c8ddae6e366ea79db5594d918",
-                "reference": "48d3bfac6d37b10c8ddae6e366ea79db5594d918",
+                "url": "https://api.github.com/repos/consolidation/self-update/zipball/8a64bdd8daf5faa8e85f56534dd99caf928164b3",
+                "reference": "8a64bdd8daf5faa8e85f56534dd99caf928164b3",
                 "shasum": ""
             },
             "require": {
@@ -566,9 +566,9 @@
             "description": "Provides a self:update command for Symfony Console applications.",
             "support": {
                 "issues": "https://github.com/consolidation/self-update/issues",
-                "source": "https://github.com/consolidation/self-update/tree/2.0.4"
+                "source": "https://github.com/consolidation/self-update/tree/2.0.5"
             },
-            "time": "2022-02-08T16:22:44+00:00"
+            "time": "2022-02-09T22:44:24+00:00"
         },
         {
             "name": "consolidation/site-alias",

--- a/tests/Functional/SelfCommandsTest.php
+++ b/tests/Functional/SelfCommandsTest.php
@@ -20,5 +20,19 @@ class SelfCommandsTest extends TerminusTestBase
     public function testSelfUpdateCommand()
     {
         $this->assertCommandExists(self::SELF_UPDATE_COMMAND);
+
+        // Test that the command works when plugins are not installed.
+        $output = $this->terminus(self::SELF_UPDATE_COMMAND);
+        $this->assertEquals('No update available', $output);
+
+        // Test that the command works when plugins are installed.
+        $pluginList = $this->terminusWithStderrRedirected('self:plugin:install pantheon-systems/terminus-plugin-example');
+        $this->assertStringContainsString(
+            'Installed pantheon-systems/terminus-plugin-example',
+            $pluginList,
+            'Failed installing plugins to setup self:update command test.'
+        );
+        $output = $this->terminus(self::SELF_UPDATE_COMMAND);
+        $this->assertEquals('No update available', $output);
     }
 }

--- a/tests/Functional/SelfCommandsTest.php
+++ b/tests/Functional/SelfCommandsTest.php
@@ -26,7 +26,9 @@ class SelfCommandsTest extends TerminusTestBase
         $this->assertEquals('No update available', $output);
 
         // Test that the command works when plugins are installed.
-        $pluginList = $this->terminusWithStderrRedirected('self:plugin:install pantheon-systems/terminus-plugin-example');
+        $pluginList = $this->terminusWithStderrRedirected(
+            'self:plugin:install pantheon-systems/terminus-plugin-example'
+        );
         $this->assertStringContainsString(
             'Installed pantheon-systems/terminus-plugin-example',
             $pluginList,


### PR DESCRIPTION
This PR:
- Updates consolidation/self-update to include latest fix in the library.
- Adds a new test that ensure that the command execution works properly (to do this, it assumes that we're running the tests with the latest available version and no newer version will be available)

Failing test (before updating self-update): https://github.com/pantheon-systems/terminus/runs/5133821175
Passing test (after updating it): https://github.com/pantheon-systems/terminus/actions/runs/1821171615