### PR TITLE
[FEAT-596] Add multiple tag filter support

### DIFF
--- a/src/Collections/Sites.php
+++ b/src/Collections/Sites.php
@@ -164,17 +164,30 @@ class Sites extends APICollection implements SessionAwareInterface
     }
 
     /**
-     * Filters sites list by tag.
+     * Filters sites list by tags separated by a comma (ANY).
      *
      * @param string $tag
-     *   A tag to filter by.
+     *   Comma-separated list of tags to filter by.
      *
      * @return \Pantheon\Terminus\Collections\Sites
      */
     public function filterByTag($tag)
     {
         return $this->filter(function ($site) use ($tag) {
-            return $site->tags->has($tag);
+            return (empty($tag)) ? $site->tags->containsNone() : $site->tags->containsAny($this->splitString($tag));
+        });
+    }
+
+    /**
+     * Filters sites list by tags separated by a comma (ALL).
+     *
+     * @param string $tags Comma-separated list of tags to filter by
+     * @return Sites
+     */
+    public function filterByTags($tags)
+    {
+        return $this->filter(function ($site) use ($tags) {
+            return (empty($tags)) ? $site->tags->containsNone() : $site->tags->containsAll($this->splitString($tags));
         });
     }
 

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -178,6 +178,40 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     }
 
     /**
+     * Determines whether the models contain any object provided a list of IDs
+     *
+     * @param array $ids UUIDs of object to seek
+     * @return boolean True if object is found, false if it is not
+     */
+    public function containsAny($ids)
+    {
+        $ids = array_flip($ids);
+        return !is_null($models = $this->all()) && !empty(array_intersect_key($ids, $models));
+    }
+
+    /**
+     * Determines whether the models contain all objects provided a list of IDs
+     *
+     * @param array $ids UUIDs of object to seek
+     * @return boolean True if object is found, false if it is not
+     */
+    public function containsAll($ids)
+    {
+        $ids = array_flip($ids);
+        return !is_null($models = $this->all()) && empty(array_diff(array_keys($ids), array_keys($models)));
+    }
+
+    /**
+     * Determines whether the models contain no objects.
+     *
+     * @return boolean False if object is found, True if it is not
+     */
+    public function containsNone()
+    {
+        return !is_null($models = $this->all()) && empty($models);
+    }
+
+    /**
      * List Model IDs
      *
      * @return string[] Array of all model IDs
@@ -218,5 +252,19 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     public function setData(array $data = [])
     {
         $this->data = $data;
+    }
+
+    /**
+     * Convert comma-separated string into an array.
+     * @param string $input
+     * @return array
+     */
+    public function splitString(string $input = "")
+    {
+        /**
+         * array_map to trim each item
+         * array_filter to always return an array, even if empty
+         */
+        return array_filter(array_map('trim', explode(',', $input)));
     }
 }

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -180,7 +180,7 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     /**
      * Determines whether the models contain any object provided a list of IDs
      *
-     * @param array $ids UUIDs of object to seek
+     * @param array $ids Ids of object to seek
      * @return boolean True if object is found, false if it is not
      */
     public function containsAny($ids)
@@ -192,13 +192,12 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     /**
      * Determines whether the models contain all objects provided a list of IDs
      *
-     * @param array $ids UUIDs of object to seek
+     * @param array $ids Ids of object to seek
      * @return boolean True if object is found, false if it is not
      */
     public function containsAll($ids)
     {
-        $ids = array_flip($ids);
-        return !is_null($models = $this->all()) && empty(array_diff(array_keys($ids), array_keys($models)));
+        return !is_null($models = $this->all()) && empty(array_diff($ids, array_keys($models)));
     }
 
     /**

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -44,10 +44,11 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @usage <organization> Displays the list of sites associated with <organization>.
      * @usage <organization> --plan=<plan> Displays the list of sites associated with <organization> having the plan named <plan>.
-     * @usage <organization> --tag=<tag> Displays the list of sites associated with <organization> that have the <tag> tag.
+     * @usage <organization> --tag=<tag> Displays the list of sites associated with <organization> that have ANY <tag> tag.
+     * @usage <organization> --tags=<tags> Displays the list of sites associated with <organization> that have ALL <tags> tags.
      * @usage <organization> --upstream=<upstream> Displays the list of sites associated with <organization> with the upstream having UUID <upstream>.
      */
-    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'upstream' => null,])
+    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,])
     {
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
@@ -56,6 +57,9 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
         }
         if (!is_null($tag = $options['tag'])) {
             $this->sites->filterByTag($tag);
+        }
+        if (!is_null($tags = $options['tags'])) {
+            $this->sites->filterByTags($tags);
         }
         if (!is_null($upstream = $options['upstream'])) {
             $this->sites->filterByUpstream($upstream);

--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -48,8 +48,10 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @usage <organization> --tags=<tags> Displays the list of sites associated with <organization> that have ALL <tags> tags.
      * @usage <organization> --upstream=<upstream> Displays the list of sites associated with <organization> with the upstream having UUID <upstream>.
      */
-    public function listSites($organization, $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,])
-    {
+    public function listSites(
+        $organization,
+        $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,]
+    ) {
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
         if (isset($options['plan']) && !is_null($plan = $options['plan'])) {


### PR DESCRIPTION
This is a re-roll of @kyletaylored's #2359 and #2105 from within the repo so the automated tests run.

- Add the ability to provide a comma-separated list of tags that will return a list of sites that have ANY tag in the list.
- Add an additional --tags options which takes a comma-separated list of tags, but requires ALL tags to match.
- Now supports NO tags and will return only sites with no tags if the tag option value is empty.