### PR TITLE
[BUGS-4442] Backup:restore command should work with element = all.

### DIFF
--- a/src/Commands/Backup/GetCommand.php
+++ b/src/Commands/Backup/GetCommand.php
@@ -35,6 +35,8 @@ class GetCommand extends SingleBackupCommand implements RequestAwareInterface
      */
     public function get($site_env, array $options = ['file' => null, 'element' => 'files', 'to' => null,])
     {
+        $this->validateElement($site_env, $options['element'], false);
+
         $backup_url = $this->getBackup($site_env, $options)->getArchiveURL();
         if (!isset($options['to']) || is_null($save_path = $options['to'])) {
             return $backup_url;

--- a/src/Commands/Backup/InfoCommand.php
+++ b/src/Commands/Backup/InfoCommand.php
@@ -39,6 +39,8 @@ class InfoCommand extends SingleBackupCommand
      */
     public function info($site_env, array $options = ['file' => null, 'element' => 'all',])
     {
+        $this->validateElement($site_env, $options['element'], false);
+
         $backup = $this->getBackup($site_env, $options);
         // By retrieving the archive URL it will appear in the model's serialize data
         $backup->getArchiveURL();

--- a/src/Commands/Backup/InfoCommand.php
+++ b/src/Commands/Backup/InfoCommand.php
@@ -31,13 +31,13 @@ class InfoCommand extends SingleBackupCommand
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @option string $file [filename.tgz] Name of backup file
-     * @option string $element [all|code|files|database|db] Backup element to retrieve
+     * @option string $element [code|files|database|db] Backup element to retrieve
      *
      * @usage <site>.<env> Displays information about the most recent backup of any type in <site>'s <env> environment.
      * @usage <site>.<env> --file=<file_name> Displays information about the backup with the file name <file_name> in <site>'s <env> environment.
      * @usage <site>.<env> --element=<element> Displays information about the most recent <element> backup in <site>'s <env> environment.
      */
-    public function info($site_env, array $options = ['file' => null, 'element' => 'all',])
+    public function info($site_env, array $options = ['file' => null, 'element' => 'files',])
     {
         $this->validateElement($site_env, $options['element'], false);
 

--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -31,6 +31,7 @@ class RestoreCommand extends SingleBackupCommand
      */
     public function restoreBackup($site_env, array $options = ['file' => null, 'element' => 'all',])
     {
+        $this->validateElement($site_env, $options['element'], true);
         $site = $this->getSite($site_env);
         $env = $this->getEnv($site_env);
 

--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -80,7 +80,8 @@ class RestoreCommand extends SingleBackupCommand
      * @param array $options
      *   Options to pass to the getBackup function.
      */
-    protected function doGetBackups(string $site_env, array $elements, array $options) {
+    protected function doGetBackups(string $site_env, array $elements, array $options)
+    {
         $backups = [];
         foreach ($elements as $element) {
             $options['element'] = $element;
@@ -101,7 +102,8 @@ class RestoreCommand extends SingleBackupCommand
      * @param string $env
      *   Environment name.
      */
-    protected function doRestoreBackups(array $backups, string $env) {
+    protected function doRestoreBackups(array $backups, string $env)
+    {
         foreach ($backups as $type => $backup) {
             $workflow = $backup->restore();
             try {

--- a/src/Commands/Backup/RestoreCommand.php
+++ b/src/Commands/Backup/RestoreCommand.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\Commands\Backup;
 
 use Pantheon\Terminus\Commands\WorkflowProcessingTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 
 /**
  * Class RestoreCommand
@@ -32,10 +33,32 @@ class RestoreCommand extends SingleBackupCommand
     public function restoreBackup($site_env, array $options = ['file' => null, 'element' => 'all',])
     {
         $this->validateElement($site_env, $options['element'], true);
+
         $site = $this->getSite($site_env);
         $env = $this->getEnv($site_env);
 
-        $backup = $this->getBackup($site_env, $options);
+        if ($options['file'] && $options['element'] !== 'all') {
+            throw new TerminusException('You cannot specify a file and an element at the same time.');
+        }
+
+        $elements = [];
+        if ($options['element'] === 'all') {
+            $elements = ['code', 'files', 'database'];
+        } else {
+            $elements[] = $this->getElement($options['element']);
+        }
+
+        $backups = $this->doGetBackups($site_env, $elements, $options);
+
+        if (!$backups) {
+            throw new TerminusNotFoundException(
+                'No backups available. Create one with `terminus backup:create {site}.{env}`',
+                [
+                    'site' => $this->getSite($site_env)->getName(),
+                    'env' => $env->getName(),
+                ]
+            );
+        }
 
         if (!$this->confirm(
             'Are you sure you want to restore to {env} on {site}?',
@@ -44,16 +67,53 @@ class RestoreCommand extends SingleBackupCommand
             return;
         }
 
-        $workflow = $backup->restore();
-        try {
-            $this->processWorkflow($workflow);
-            $this->log()->notice('Restored the backup to {env}.', ['env' => $env->id,]);
-        } catch (\Exception $e) {
-            $message = $workflow->getMessage();
-            if (trim($message) == 'Successfully queued restore_site') {
-                $message = 'There was an error while restoring your backup.';
+        $this->doRestoreBackups($backups, $env->id);
+    }
+
+    /**
+     * Get backups for given elements.
+     *
+     * @param string $site_env
+     *   Site & environment in the format `site-name.env`
+     * @param array $elements
+     *   Elements to get backups for.
+     * @param array $options
+     *   Options to pass to the getBackup function.
+     */
+    protected function doGetBackups(string $site_env, array $elements, array $options) {
+        $backups = [];
+        foreach ($elements as $element) {
+            $options['element'] = $element;
+            try {
+                $backups[$element] = $this->getBackup($site_env, $options);
+            } catch (TerminusNotFoundException $e) {
+                continue;
             }
-            throw new TerminusException($message);
+        }
+        return $backups;
+    }
+
+    /**
+     * Restore backups to given site.
+     *
+     * @param array $backups
+     *   Backup files to restore
+     * @param string $env
+     *   Environment name.
+     */
+    protected function doRestoreBackups(array $backups, string $env) {
+        foreach ($backups as $type => $backup) {
+            $workflow = $backup->restore();
+            try {
+                $this->processWorkflow($workflow);
+                $this->log()->notice('Restored the {type} backup to {env}.', ['env' => $env, 'type' => $type]);
+            } catch (\Exception $e) {
+                $message = $workflow->getMessage();
+                if (trim($message) == 'Successfully queued restore_site') {
+                    $message = 'There was an error while restoring your backup.';
+                }
+                throw new TerminusException($message);
+            }
         }
     }
 }

--- a/src/Commands/Backup/SingleBackupCommand.php
+++ b/src/Commands/Backup/SingleBackupCommand.php
@@ -65,7 +65,9 @@ abstract class SingleBackupCommand extends BackupCommand
             $supported[] = 'all';
         }
         if (!in_array($element, $supported)) {
-            throw new TerminusException(sprintf('Element should be one of the following items: %s', implode(', ', $supported)));
+            throw new TerminusException(
+                sprintf('Element should be one of the following items: %s', implode(', ', $supported))
+            );
         }
     }
 }

--- a/src/Commands/Backup/SingleBackupCommand.php
+++ b/src/Commands/Backup/SingleBackupCommand.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\Commands\Backup;
 
 use Pantheon\Terminus\Exceptions\TerminusNotFoundException;
 use Pantheon\Terminus\Models\Backup;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 abstract class SingleBackupCommand extends BackupCommand
 {
@@ -37,5 +38,34 @@ abstract class SingleBackupCommand extends BackupCommand
             $backup = array_shift($backups);
         }
         return $backup;
+    }
+
+    /**
+     * Validate the provided element name and throw exceptions if unsupported.
+     *
+     * @param string $site_env
+     *   Site & environment in the format `site-name.env`
+     * @param string $element
+     *   The element name to validate.
+     * @param bool $supportAll
+     *   Whether to support the "all" element.
+     *
+     * @throws TerminusException If the element is not supported.
+     */
+    protected function validateElement(string $siteEnv, string $element, bool $supportAll = true): void
+    {
+        if ($element == 'all' && !$supportAll) {
+            throw new TerminusException('The backup element "all" is not supported for this command.');
+        }
+
+        $env = $this->getEnv($siteEnv);
+        $supported = $env->getBackups()->getValidElements();
+
+        if ($supportAll) {
+            $supported[] = 'all';
+        }
+        if (!in_array($element, $supported)) {
+            throw new TerminusException(sprintf('Element should be one of the following items: %s', implode(', ', $supported)));
+        }
     }
 }


### PR DESCRIPTION
backup:restore output:

```
terminus backup:restore site.dev --element=all

 Are you sure you want to restore to dev on site? (yes/no) [no]:
 > yes

 [notice] Restored the code backup to dev.
 [notice] Restored the files backup to dev.
 [notice] Restored the database backup to dev.
```

backup:get and backup:info output:

```
terminus backup:get site.dev --element=something
 [error]  Element should be one of the following items: code, files, database, db

terminus backup:get site.dev --element=all
 [error]  The backup element "all" is not supported for this command.
```