### PR TITLE
[BUGS-5028] Check is_initialized setting rather than code commits for new environments

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -757,10 +757,8 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
         if (!in_array($this->id, ['test', 'live',])) {
             return true;
         }
-        // One can determine whether an environment has been initialized
-        // by checking if it has code commits. Uninitialized environments do not.
-        $commits = $this->getCommits()->all();
-        return (count($commits) > 0);
+
+        return $this->settings('is_initialized');
     }
 
     /**
@@ -951,7 +949,7 @@ class Environment extends TerminusModel implements ContainerAwareInterface, Site
     private function settings($setting = null)
     {
         $path = "sites/{$this->getSite()->id}/environments/{$this->id}/settings";
-        $response = (array)$this->request()->request($path, ['method' => 'get',]);
+        $response = $this->request()->request($path, ['method' => 'get',]);
         return $response['data']->$setting;
     }
 


### PR DESCRIPTION
## Summary
Use the API to determine if a site environment has been initialized rather than looking at the commits.

## Test Plan

- Found a site ID that was not getting its test/live environments initialized before code was deployed
- Verified `isInitialized()` was returning true for the uninitialized environment
- Applied this PR to my local install of terminus
- Verified `isInitialized()` was returning false for the uninitialized environment

## Issue IDs

https://getpantheon.atlassian.net/browse/BUGS-5028