### PR TITLE
[FEAT-898] Integrate site cache hit rate metrics

### DIFF
--- a/src/Commands/Env/MetricsCommand.php
+++ b/src/Commands/Env/MetricsCommand.php
@@ -96,7 +96,7 @@ class MetricsCommand extends TerminusCommand implements SiteAwareInterface
             ->addRendererFunction(
                 function ($key, $cellData) {
                     if ($key == 'datetime') {
-                        $cellData = str_replace('T00:00:00Z', '', $cellData ?? '');
+                        $cellData = str_replace('T00:00:00', '', $cellData ?? '');
                     }
                     return $cellData;
                 }

--- a/src/Site/SiteMetricsTrait.php
+++ b/src/Site/SiteMetricsTrait.php
@@ -121,7 +121,7 @@ trait SiteMetricsTrait
      */
     protected function getCacheHitRatio($pages_served, $cache_hits)
     {
-        if(!$pages_served){
+        if (!$pages_served) {
             return '--';
         }
 

--- a/src/Site/SiteMetricsTrait.php
+++ b/src/Site/SiteMetricsTrait.php
@@ -94,7 +94,7 @@ trait SiteMetricsTrait
         // Format for display
         $data = array_map(
             function ($item) {
-                $item->datetime = $item->time;
+                $item->datetime = gmdate("Y-m-d\TH:i:s", $item->timestamp);
                 unset($item->time);
                 unset($item->timestamp);
                 $item->cache_hit_ratio = $this->getCacheHitRatio($item->pages_served, $item->cache_hits);


### PR DESCRIPTION
This a proof of concept integrating the deprecated terminus-cache-metrics plugin into Terminus 3.x

It has not been refactored to match any current preferred patterns.

<img width="633" alt="image" src="https://user-images.githubusercontent.com/91161717/192124007-52066694-07ae-4123-8abf-56e78d83cfbe.png">

To-do:
- See if this can fully replace the existing env:metrics. (Same filters, date ranges, etc available?)
- Test the tests
- Test as a non-admin user

Closes #2357