### PR TITLE
[BUGS-5275] Update plan:set docs to sku instead of id.

### DIFF
--- a/src/Commands/Plan/SetCommand.php
+++ b/src/Commands/Plan/SetCommand.php
@@ -24,16 +24,16 @@ class SetCommand extends TerminusCommand implements SiteAwareInterface
      * @command plan:set
      *
      * @param string $site_id Site name
-     * @param string $plan_id The SKU or UUID of the plan to set
+     * @param string $plan_sku The SKU of the plan to set
      *
      * @usage <site> <plan> Updates <site>'s plan to <plan>.
      */
-    public function set($site_id, $plan_id)
+    public function set($site_id, $plan_sku)
     {
         $site = $this->getSite($site_id);
         $plans = $site->getPlans();
-        $workflow = $plans->set($plans->get($plan_id));
-        $this->log()->notice('Setting plan of "{site_id}" to "{plan_id}".', compact('site_id', 'plan_id'));
+        $workflow = $plans->set($plans->get($plan_sku));
+        $this->log()->notice('Setting plan of "{site_id}" to "{plan_sku}".', compact('site_id', 'plan_sku'));
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());
     }


### PR DESCRIPTION
A customer reported that plan id is no longer showing on the terminus command  like
```
terminus plan:list <site-id>
terminus plan:info <site-id>
```
and SKUs are being used instead for `terminus plan:set`.

This change happened on the back-end...

The [online docs](https://pantheon.io/docs/terminus/commands/plan-set)  are automatically generated from the terminus code, so this change is to specifically update the documentation to reflect the back-end behavior