### PR TITLE
[CMS-1194] Add clear_cache option back to env:deploy

### DIFF
--- a/src/Commands/Env/DeployCommand.php
+++ b/src/Commands/Env/DeployCommand.php
@@ -31,7 +31,7 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env` (only Test or Live environment)
      * @option string $sync-content Clone database/files from Live environment when deploying Test environment
-     * @option string $cc [DEPRECATED 2.2.1-dev] Does not work. Meant to clear caches after deploy. Please use env:clear-cache instead.
+     * @option string $cc Clear caches after deploy.
      * @option string $updatedb Run update.php after deploy (Drupal only)
      * @option string $note Custom deploy log message
      *
@@ -61,6 +61,7 @@ class DeployCommand extends TerminusCommand implements SiteAwareInterface
             $params = [
               'updatedb'    => (integer)$options['updatedb'],
               'annotation'  => $annotation,
+              'clear_cache' => (integer)$options['cc'],
             ];
             if ($env->getName() === 'test' && isset($options['sync-content']) && $options['sync-content']) {
                 $live_env = 'live';

--- a/tests/fixtures/env-deploy-uninitialized-source.yml
+++ b/tests/fixtures/env-deploy-uninitialized-source.yml
@@ -232,7 +232,7 @@
             absolute_url: ''
             json: ''
             Accept: null
-        body: '{"type":"deploy","params":{"updatedb":0,"annotation":"Deploy test","clone_database":{"from_environment":"live"},"clone_files":{"from_environment":"live"}}}'
+        body: '{"type":"deploy","params":{"updatedb":0,"clear_cache":0,"annotation":"Deploy test","clone_database":{"from_environment":"live"},"clone_files":{"from_environment":"live"}}}'
     response:
         status:
             http_version: '1.1'

--- a/tests/fixtures/env-deploy.yml
+++ b/tests/fixtures/env-deploy.yml
@@ -191,7 +191,7 @@
             User-Agent: 'Terminus/0.11.4 (php_version=7.0.6&script=boot-fs.php)'
             Content-type: application/json
             Authorization: 'Bearer 11111111-1111-1111-1111-111111111111:4a2fe1de-6640-11e6-8d03-bc764e10b0ce:ufQocJfmb6tEtFlbf9z62'
-        body: '{"type":"deploy","params":{"updatedb":0,"annotation":"Deploy test","clone_database":{"from_environment":"live"},"clone_files":{"from_environment":"live"}}}'
+        body: '{"type":"deploy","params":{"updatedb":0,"clear_cache":0,"annotation":"Deploy test","clone_database":{"from_environment":"live"},"clone_files":{"from_environment":"live"}}}'
     response:
         status:
             http_version: '1.1'

--- a/tests/unit_tests/Commands/Env/DeployCommandTest.php
+++ b/tests/unit_tests/Commands/Env/DeployCommandTest.php
@@ -46,6 +46,7 @@ class DeployCommandTest extends EnvCommandTest
             ->willReturn($this->workflow)
             ->with([
                 'updatedb' => 0,
+                'clear_cache' => 0,
                 'annotation' => 'Deploy from Terminus',
                 'clone_database' => [
                     'from_environment' => 'live'
@@ -58,7 +59,7 @@ class DeployCommandTest extends EnvCommandTest
         // Run the deploy.
         $this->command->deploy(
             "mysite.{$this->environment->id}",
-            ['sync-content' => true, 'note' => 'Deploy from Terminus', 'updatedb' => false,]
+            ['sync-content' => true, 'note' => 'Deploy from Terminus', 'updatedb' => false, 'cc' => false,]
         );
     }
 
@@ -102,13 +103,14 @@ class DeployCommandTest extends EnvCommandTest
             ->willReturn($this->workflow)
             ->with([
                 'updatedb' => 1,
+                'clear_cache' => 1,
                 'annotation' => 'Deploy from Terminus',
             ]);
 
         // Run the deploy.
         $this->command->deploy(
             "mysite.{$this->environment->id}",
-            ['sync-content' => true, 'note' => 'Deploy from Terminus', 'updatedb' => true,]
+            ['sync-content' => true, 'note' => 'Deploy from Terminus', 'updatedb' => true, 'cc' => true,]
         );
     }
 


### PR DESCRIPTION
Dependent upon internal BUGS-5746 being resolved, re-enable cache_clear task as part of deploy workflow.