### PR TITLE
Allow terminus to be installed with drupal/core and pantheon-systems/wordpress-composer

### DIFF
--- a/bin/terminus
+++ b/bin/terminus
@@ -32,7 +32,7 @@ if (!getenv('TERMINUS_ALLOW_UNSUPPORTED_NEWER_PHP') && version_compare(PHP_VERSI
 
 // This variable is automatically managed via updateDependenciesversion() in /RoboFile.php,
 // which is run after every call to composer update.
-$terminusPluginsDependenciesVersion = '8f30ee04b5';
+$terminusPluginsDependenciesVersion = 'b38e36384a';
 
 // Cannot use $_SERVER superglobal since that's empty during phpunit testing
 // getenv('HOME') isn't set on Windows and generates a Notice.

--- a/composer.json
+++ b/composer.json
@@ -48,10 +48,6 @@
     "squizlabs/php_codesniffer": "^3.5",
     "wdalmut/php-deb-packager": "^0.0.14"
   },
-  "conflict": {
-    "drupal/core": "*",
-    "pantheon-systems/wordpress-composer": "*"
-  },
   "autoload": {
     "psr-4": {
       "Pantheon\\Terminus\\": "src/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "70f8b8ff1c1eaec64d57dc6b8649bef4",
+    "content-hash": "49455f5a417e773c5d3692705db41736",
     "packages": [
         {
             "name": "composer/semver",


### PR DESCRIPTION
Fixes #2451.

Terminus is often added as project-level dependency to Pantheon hosted projects which also require `pantheon-systems/wordpress-composer` so there is no harm installing both packages at the same time.