### PR TITLE
[CMSO-1054] Do not check for user membership to remove supporting org.

### DIFF
--- a/src/Commands/Site/Org/RemoveCommand.php
+++ b/src/Commands/Site/Org/RemoveCommand.php
@@ -28,20 +28,20 @@ class RemoveCommand extends TerminusCommand implements SiteAwareInterface
      * @param string $site Site name
      * @param string $organization Organization name or UUID
      *
-     * @throws TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusNotFoundException
      *
      * @usage <site> <organization> Disassociates <organization> as a supporting organization from <site>.
      */
     public function remove($site, $organization)
     {
-        $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $site = $this->getSiteById($site);
-
         $membership = $site->getOrganizationMemberships()->get($organization);
+
         $workflow = $membership->delete();
         $this->log()->notice(
             'Removing {org} as a supporting organization from {site}.',
-            ['site' => $site->getName(), 'org' => $org->getName()]
+            ['site' => $site->getName(), 'org' => $membership->getOrganization()->getName()]
         );
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());


### PR DESCRIPTION
Success:

```
terminus site:org:remove <site> <org>
 [notice] Removing <org> as a supporting organization from <site>.
 [notice] Removed supporting organization
```

Error because of not found membership (site-org membership):

```
terminus site:org:remove <site> <invalid-org>
 [error]  Could not find a site-organization membership identified by <invalid-org>.
```