### PR TITLE
[CMSO-1434] Add upstream label field to site:info.

### DIFF
--- a/src/Commands/Site/InfoCommand.php
+++ b/src/Commands/Site/InfoCommand.php
@@ -33,6 +33,7 @@ class InfoCommand extends SiteCommand
      *     plan_name: Plan
      *     max_num_cdes: Max Multidevs
      *     upstream: Upstream
+     *     upstream_label: Upstream Label
      *     holder_type: Holder Type
      *     holder_id: Holder ID
      *     owner: Owner

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -454,6 +454,7 @@ class Site extends TerminusModel implements ContainerAwareInterface, Organizatio
             'plan_name' => $this->get('plan_name'),
             'max_num_cdes' => $settings ? $settings->max_num_cdes : 0,
             'upstream' => (string)$this->getUpstream(),
+            'upstream_label' => $this->getUpstream()->get('label'),
             'holder_type' => $this->get('holder_type'),
             'holder_id' => $this->get('holder_id'),
             'owner' => $this->get('owner'),

--- a/tests/Functional/SiteCommandsTest.php
+++ b/tests/Functional/SiteCommandsTest.php
@@ -95,6 +95,7 @@ class SiteCommandsTest extends TerminusTestBase
         // Format table prints processed value.
         $siteInfoTable = $this->terminus(sprintf('site:info %s', $this->mockSiteName));
         $this->assertStringContainsString('Drupal 8 or later', $siteInfoTable);
+        $this->assertStringContainsString("Drupal 9 (deprecated)", $siteInfoTable);
     }
 
     /**


### PR DESCRIPTION
```
terminus site:info <site>
 ------------------ ---------------------------------------------------------------------------------------------------------
  ID                 MASKED
  Name               MASKED
  Label              MASKED
  Created            2021-10-20 22:14:00
  Framework          Drupal 8 or later
  Region             United States
  Organization       MASKED
  Plan               Sandbox
  Max Multidevs      10
  Upstream           bde48795-b16d-443f-af01-8b1790caa1af: https://github.com/pantheon-upstreams/drupal-composer-managed.git
  Upstream Label     Drupal (Composer Managed)
...
```