### PR TITLE
[BUGS-6297] fix: passthrough exit code from `drush` and `wp-cli`

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -90,7 +90,7 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
         ]);
 
         if ($ssh_data['exit_code'] != 0) {
-            throw new TerminusProcessException($ssh_data['output']);
+            throw new TerminusProcessException($ssh_data['output'], [], $ssh_data['exit_code']);
         }
     }
 


### PR DESCRIPTION
This is #2457 from terminus repo to run tests.