### PR TITLE
[CMSO-1592] New command to wait for workflows and run wake.

### DIFF
--- a/src/Collections/Workflows.php
+++ b/src/Collections/Workflows.php
@@ -50,6 +50,46 @@ class Workflows extends APICollection implements SessionAwareInterface
     }
 
     /**
+     * Returns all existing workflows that match given environment id and status.
+     *
+     * @return Workflow[]
+     */
+    public function allByEnvironmentIdAndStatus($environment_id, $status)
+    {
+        $status_map = [
+            'finished' => 'isFinished',
+            'unfinished' => 'isUnfinished',
+            'successful' => 'isSuccessful',
+            'failed' => 'isFailed',
+        ];
+        if (!isset($status_map[$status])) {
+            throw new TerminusException('Invalid status "{status}".', compact('status'));
+        }
+        $status_method = $status_map[$status];
+        return array_filter(
+            $this->all(),
+            function ($workflow) use ($environment_id, $status_method) {
+                return $workflow->getEnvironmentId() == $environment_id && $workflow->$status_method();
+            }
+        );
+    }
+
+    /**
+     * Returns all existing workflows that match given environment id.
+     *
+     * @return Workflow[]
+     */
+    public function allByEnvironmentId($environment_id)
+    {
+        return array_filter(
+            $this->all(),
+            function ($workflow) use ($environment_id) {
+                return $workflow->getEnvironmentId() == $environment_id;
+            }
+        );
+    }
+
+    /**
      * Returns all existing workflows that have finished
      *
      * @return Workflow[]
@@ -60,6 +100,51 @@ class Workflows extends APICollection implements SessionAwareInterface
             $this->all(),
             function ($workflow) {
                 return $workflow->isFinished();
+            }
+        );
+    }
+
+    /**
+     * Returns all existing workflows that have not finished
+     *
+     * @return Workflow[]
+     */
+    public function allUnfinished()
+    {
+        return array_filter(
+            $this->all(),
+            function ($workflow) {
+                return $workflow->isUnfinished();
+            }
+        );
+    }
+
+    /**
+     * Returns all existing workflows that have succeeded
+     *
+     * @return Workflow[]
+     */
+    public function allSuccessful()
+    {
+        return array_filter(
+            $this->all(),
+            function ($workflow) {
+                return $workflow->isSuccessful();
+            }
+        );
+    }
+
+    /**
+     * Returns all existing workflows that have failed
+     *
+     * @return Workflow[]
+     */
+    public function allFailed()
+    {
+        return array_filter(
+            $this->all(),
+            function ($workflow) {
+                return $workflow->isFailed();
             }
         );
     }

--- a/src/Commands/Env/WaitWorkflowsCommand.php
+++ b/src/Commands/Env/WaitWorkflowsCommand.php
@@ -48,7 +48,21 @@ class WaitWorkflowsCommand extends TerminusCommand implements SiteAwareInterface
         $this->log()->notice('Waiting for {number} workflow(s).', ['number' => count($workflows)]);
 
         $startWaiting = time();
+        $wf_types_to_wait = [
+            'sync_code',
+            'sync_code_with_build',
+            'sync_code_external_vcs',
+            'environment_update_pantheon_yml',
+            'check_database_version',
+            'change_database_version',
+            'change_object_cache_version',
+            'change_search_version',
+        ];
         foreach ($workflows as $workflow) {
+            $type = $workflow->get('type');
+            if (!in_array($type, $wf_types_to_wait)) {
+                continue;
+            }
             $description = $workflow->get('description');
             $workflow->fetch();
             while ($workflow->isUnfinished()) {

--- a/src/Commands/Env/WaitWorkflowsCommand.php
+++ b/src/Commands/Env/WaitWorkflowsCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Env;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\Terminus\Site\SiteAwareTrait;
+use Pantheon\Terminus\Exceptions\TerminusException;
+
+/**
+ * Class WaitWorkflowsCommand.
+ *
+ * @package Pantheon\Terminus\Commands\Env
+ */
+class WaitWorkflowsCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use SiteAwareTrait;
+
+    /**
+     * Waits for all workflows in a given environment and optionally attempt to do healthcheck on it.
+     *
+     * @authorize
+     *
+     * @command env:wait-workflows
+     * @aliases env:ww
+     *
+     * @param string $site_env Site & environment in the format `site-name.env`
+     * @option bool $healthcheck Whether to wait for the healthcheck to pass
+     *
+     * @throws TerminusException
+     *
+     * @usage <site>.<env> Wakes <site>'s <env> environment by pinging it.
+     */
+    public function waitWorkflows($site_env, $options = [
+        'healthcheck' => true,
+    ])
+    {
+        $this->requireSiteIsNotFrozen($site_env);
+        $env = $this->getEnv($site_env);
+
+        if ($options['healthcheck']) {
+            $env->wake();            
+        }
+
+        $this->log()->notice('OK');
+    }
+}

--- a/src/Commands/Env/WaitWorkflowsCommand.php
+++ b/src/Commands/Env/WaitWorkflowsCommand.php
@@ -26,6 +26,7 @@ class WaitWorkflowsCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      * @option bool $healthcheck Whether to wait for the healthcheck to pass
+     * @option int $timeout How long to wait for the workflows to finish
      *
      * @throws TerminusException
      *
@@ -33,15 +34,53 @@ class WaitWorkflowsCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function waitWorkflows($site_env, $options = [
         'healthcheck' => true,
+        'timeout' => 300,
     ])
     {
         $this->requireSiteIsNotFrozen($site_env);
+        $site = $this->getSite($site_env);
         $env = $this->getEnv($site_env);
 
-        if ($options['healthcheck']) {
-            $env->wake();            
+        $workflows = $site->getWorkflows()->setPaging(false)->fetch()->allByEnvironmentIdAndStatus($env->id, 'unfinished');
+        $this->log()->notice('Waiting for {number} workflow(s).', ['number' => count($workflows)]);
+
+        $startWaiting = time();
+        foreach ($workflows as $workflow) {
+            $description = $workflow->get('description');
+            $workflow->fetch();
+            while ($workflow->isUnfinished()) {
+                $this->log()->notice(
+                    "Workflow '{description}' is running...",
+                    ['description' => $description]
+                );
+
+                if (time() - $startWaiting > $options['timeout']) {
+                    throw new TerminusException(
+                        'Timeout waiting for workflows to finish. Please check the status of the workflows manually.'
+                    );
+                }
+                sleep(5);
+                $workflow->fetch();
+            }
+            // Abort if workflow failed.
+            if ($workflow->isFailed()) {
+                throw new TerminusException(
+                    'Workflow failed. Please check the status of the workflows manually.'
+                );
+            }
+            if ($workflow->isSuccessful()) {
+                $this->log()->notice(
+                    "Workflow '{description}' succeeded.",
+                    ['description' => $description]
+                );
+            }
         }
 
-        $this->log()->notice('OK');
+        if ($options['healthcheck']) {
+            $this->log()->notice('Running healthcheck on environment...');
+            $env->wake();
+        }
+
+        $this->log()->notice('All done!');
     }
 }

--- a/src/Commands/Env/WaitWorkflowsCommand.php
+++ b/src/Commands/Env/WaitWorkflowsCommand.php
@@ -41,7 +41,10 @@ class WaitWorkflowsCommand extends TerminusCommand implements SiteAwareInterface
         $site = $this->getSite($site_env);
         $env = $this->getEnv($site_env);
 
-        $workflows = $site->getWorkflows()->setPaging(false)->fetch()->allByEnvironmentIdAndStatus($env->id, 'unfinished');
+        $workflows = $site->getWorkflows()->setPaging(false)->fetch()->allByEnvironmentIdAndStatus(
+            $env->id,
+            'unfinished'
+        );
         $this->log()->notice('Waiting for {number} workflow(s).', ['number' => count($workflows)]);
 
         $startWaiting = time();

--- a/src/Commands/Env/WakeCommand.php
+++ b/src/Commands/Env/WakeCommand.php
@@ -36,14 +36,6 @@ class WakeCommand extends TerminusCommand implements SiteAwareInterface
         $env = $this->getEnv($site_env);
         $wakeStatus = $env->wake();
 
-        // @TODO: Move the exceptions up the chain to the `wake` function. (One env is ported over).
-        if (empty($wakeStatus['success'])) {
-            throw new TerminusException('Could not reach {target}', $wakeStatus);
-        }
-        if (empty($wakeStatus['styx'])) {
-            throw new TerminusException('Pantheon headers missing, which is not quite right.');
-        }
-
         $this->log()->notice('OK >> {target} responded', $wakeStatus);
     }
 }

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -1008,6 +1008,12 @@ class Environment extends TerminusModel implements
         $response = $this->request()->request(
             "https://{$domain->id}/pantheon_healthcheck"
         );
+        if ($response['status_code'] != 200) {
+            throw new TerminusException('Could not reach {target}', $wakeStatus);
+        }
+        if (empty($response['headers']['X-Pantheon-Styx-Hostname'])) {
+            throw new TerminusException('Pantheon headers missing, which is not quite right.');
+        }
         return [
             'success' => ($response['status_code'] === 200),
             'styx' => $response['headers']['X-Pantheon-Styx-Hostname'],

--- a/src/Models/Workflow.php
+++ b/src/Models/Workflow.php
@@ -231,6 +231,29 @@ class Workflow extends TerminusModel implements
     }
 
     /**
+     * Returns the environment_id of this workflow
+     *
+     * @return string
+     */
+    public function getEnvironmentId()
+    {
+        if ($this->has('environment_id')) {
+            return $this->get('environment_id');
+        }
+        return null;
+    }
+
+    /**
+     * Detects if the workflow has not finished
+     *
+     * @return bool True if workflow has not finished
+     */
+    public function isUnfinished()
+    {
+        return !$this->has('result');
+    }
+
+    /**
      * Detects if the workflow has finished
      *
      * @return bool True if workflow has finished
@@ -248,6 +271,16 @@ class Workflow extends TerminusModel implements
     public function isSuccessful()
     {
         return $this->get('result') == 'succeeded';
+    }
+
+    /**
+     * Detects if the workflow was failed
+     *
+     * @return bool True if workflow failed
+     */
+    public function isFailed()
+    {
+        return $this->get('result') != 'succeeded';
     }
 
     /**

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -337,6 +337,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Env\\MetricsCommand',
             'Pantheon\\Terminus\\Commands\\Env\\RotateRandomSeedCommand',
             'Pantheon\\Terminus\\Commands\\Env\\ViewCommand',
+            'Pantheon\\Terminus\\Commands\\Env\\WaitWorkflowsCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
             'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',

--- a/tests/Functional/EnvCommandsTest.php
+++ b/tests/Functional/EnvCommandsTest.php
@@ -68,6 +68,20 @@ class EnvCommandsTest extends TerminusTestBase
 
     /**
      * @test
+     * @covers \Pantheon\Terminus\Commands\Env\WaitWorkflowsCommand
+     *
+     * @group env
+     * @group short
+     */
+    public function testWaitWorkflowsCommand()
+    {
+        $this->terminus(
+            sprintf('env:wait-workflows %s.%s', $this->getSiteName(), 'dev')
+        );
+    }
+
+    /**
+     * @test
      * @covers \Pantheon\Terminus\Commands\Env\CloneContentCommand
      *
      * @group env


### PR DESCRIPTION
Sample output:

```
 [notice] Waiting for 2 workflow(s).
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' is running...
 [notice] Workflow 'Sync code on "dev"' succeeded.
 [notice] Workflow 'Change database version for an environment' succeeded.
 [notice] Running healthcheck on environment...
 [notice] All done!
```

Healthcheck is optional, it could be avoided by passing `--no-healthcheck` option. Timeout is set to `300s` by default.