### PR TITLE
More specific description in env:code-rebuild

### DIFF
--- a/src/Commands/Env/CodeRebuildCommand.php
+++ b/src/Commands/Env/CodeRebuildCommand.php
@@ -19,7 +19,7 @@ class CodeRebuildCommand extends TerminusCommand implements SiteAwareInterface
     use WorkflowProcessingTrait;
 
     /**
-     * Rebuild code for the given environment (only dev and multidev allowed).
+     * Moves code to the specified environment's runtime from the associated git branch, retriggering Composer builds for sites using Integrated Composer. (Not applicable for Test and Live environments which run on git tags made from the Dev environment's git history.)
      *
      * @authorize
      *


### PR DESCRIPTION
The existing description of the env:code-rebuild just rephrases what's implied by the name of the command without much additional explanation.

While this proposed change might be too verbose for the norms of Terminus descriptions/help text, I would rather that we over-explain than under-explain.