### PR TITLE
Catch down network exception and non-object responses in fetch

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -244,12 +244,20 @@ class Request implements
                 }
             }
 
+            if (is_object($response) && is_object($response->getBody()) && $response->getBody()->getContents() !== '') {
+                $error = $response->getBody()->getContents();
+            } elseif (null !== $exception && '' != $exception->getMessage()) {
+                $error = $exception->getMessage();
+            } else {
+                $error = "Undefined";
+            }
+
             $this->logger->error(
                 "HTTP request {method} {uri} has failed with error {error}.",
                 [
                     'method' => $request->getMethod(),
                     'uri' => $request->getUri(),
-                    'error' => $response->getBody()->getContents(),
+                    'error' => $error,
                 ]
             );
 


### PR DESCRIPTION
Catching of exceptions arising from two states.

## 1) Network is completely down. 
This would previously give an uncaught exception when doing any operation from Terminus.
```
$ terminus site:info jms-vanilla-wp
PHP Fatal error:  Uncaught Error: Call to a member function getBody() on null in phar:///usr/local/Cellar/terminus/3.2.1/bin/terminus/src/Request/Request.php:239
Stack trace:
#0 /Users/jms/.terminus/terminus-dependencies-27a446d993/vendor/guzzlehttp/guzzle/src/RetryMiddleware.php(101): Pantheon\Terminus\Request\Request->Pantheon\Terminus\Request\{closure}(5, Object(GuzzleHttp\Psr7\Request), NULL, Object(GuzzleHttp\Exception\ConnectException))
```

That is now caught and handled
```
$ terminus site:info jms-vanilla-wp
 [error]  HTTP request GET https://terminus.pantheon.io/api/site-names/jms-vanilla-wp has failed with error Connection refused for URI https://terminus.pantheon.io/api/site-names/jms-vanilla-wp.
 [error]  Could not locate a site your user may access identified by jms-vanilla-wp: HTTP request has failed with error "Maximum retry attempts reached".
```

## 2) Invalid network responses.
This I couldn't reproduce, but based on a stack trace found that certain API responses would sometimes come back processed as a string rather than an object while monitoring workflow logs.

Previous uncaught fatal exception:
```
$ terminus workflow:wait d9-aus.dev
PHP Fatal error: Uncaught Error: Attempt to assign property "id" on string in /Users/jms/pantheon/terminus-repo/src/Collections/TerminusCollection.php:124
Stack trace:
#0 /Users/jms/pantheon/terminus-repo/src/Commands/Workflow/WaitCommand.php(69): Pantheon\Terminus\Collections\TerminusCollection->fetch(Array)
#1 /Users/jms/pantheon/terminus-repo/src/Commands/Workflow/WaitCommand.php(44): Pantheon\Terminus\Commands\Workflow\WaitCommand->waitForWorkflow(1693326839, Object(Pantheon\Terminus\Models\Site), 'dev', 'Sync code on de...', 180)
#2 [internal function]: Pantheon\Terminus\Commands\Workflow\WaitCommand->workflowWait('d9-aus.dev', '', Array)
#3 /Users/jms/pantheon/terminus-repo/vendor/consolidation/annotated-command/src/CommandProcessor.php(276): call_user_func_array(Array, Array)
#4 /Users/jms/pantheon/terminus-repo/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#5 /Users/jms/pantheon/terminus-repo/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#6 /Users/jms/pantheon/terminus-repo/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(391): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#7 /Users/jms/pantheon/terminus-repo/vendor/symfony/console/Command/Command.php(298): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /Users/jms/pantheon/terminus-repo/vendor/symfony/console/Application.php(1058): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /Users/jms/pantheon/terminus-repo/vendor/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /Users/jms/pantheon/terminus-repo/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /Users/jms/pantheon/terminus-repo/vendor/consolidation/robo/src/Runner.php(282): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /Users/jms/pantheon/terminus-repo/src/Terminus.php(486): Robo\Runner->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput), Object(Symfony\Component\Console\Application), Array)
#13 /Users/jms/pantheon/terminus-repo/bin/terminus(80): Pantheon\Terminus\Terminus->run()
#14 {main}
thrown in /Users/jms/pantheon/terminus-repo/src/Collections/TerminusCollection.php on line 124
```

Since I wasn't able to reproduce this, I added a handler for it to give more details of the error and a clearer failure.
```
$ terminus workflow:wait d9-aus.dev
 [error]  Fetch failed from /Users/jms/pantheon/terminus-repo/src/Commands/Workflow/WaitCommand.php:69, model_data expected as object but returned as string. String value: Hello World
```
