### PR TITLE
[BUGS-6663] Return empty string on zero dates.

### DIFF
--- a/src/Commands/StructuredListTrait.php
+++ b/src/Commands/StructuredListTrait.php
@@ -93,6 +93,9 @@ trait StructuredListTrait
         $list->addRendererFunction(
             function ($key, $cell_data) use ($config, $date_attributes) {
                 if (!is_numeric($key) && in_array($key, $date_attributes)) {
+                    if (empty($cell_data)) {
+                        return '-';
+                    }
                     return $config->formatDatetime($cell_data);
                 }
                 return $cell_data;


### PR DESCRIPTION
Before:

<img width="1398" alt="Screen Shot 2023-08-31 at 08 18 26" src="https://github.com/pantheon-systems/terminus/assets/2217820/4d65217e-bb43-4cbc-91d3-eaba96f7b440">


After:

<img width="1364" alt="Screen Shot 2023-08-31 at 08 18 36" src="https://github.com/pantheon-systems/terminus/assets/2217820/766a9e12-5b50-4cad-a6bf-d342b3e77f35">


Note: I forced the date to be null to reproduce the error.