### PR TITLE
[BUGS-6554] Add retry and delay options.

### DIFF
--- a/src/Commands/Env/WakeCommand.php
+++ b/src/Commands/Env/WakeCommand.php
@@ -26,15 +26,35 @@ class WakeCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $site_env Site & environment in the format `site-name.env`
      *
+     * @option int $retry Number of times to retry if the environment is not awake
+     * @option int $delay Number of seconds to wait between retries
+     *
      * @throws TerminusException
      *
      * @usage <site>.<env> Wakes <site>'s <env> environment by pinging it.
      */
-    public function wake($site_env)
+    public function wake($site_env, $options = [
+        'retry' => 3,
+        'delay' => 3,
+    ])
     {
+        $attempt = 0;
         $this->requireSiteIsNotFrozen($site_env);
         $env = $this->getEnv($site_env);
-        $wakeStatus = $env->wake();
+
+        while ($attempt < $options['retry']) {
+            $wakeStatus = $env->wake();
+            if (empty($wakeStatus['success'])) {
+                $this->log()->notice('{target} is not awake, retrying in {delay} seconds', [
+                    'target' => $site_env,
+                    'delay' => $options['delay'],
+                ]);
+                sleep($options['delay']);
+                $attempt++;
+            } else {
+                break;
+            }
+        }
 
         // @TODO: Move the exceptions up the chain to the `wake` function. (One env is ported over).
         if (empty($wakeStatus['success'])) {


### PR DESCRIPTION
Retry output:

```
terminus env:wake solr8-sandbox.dev
 [notice] solr8-sandbox.dev is not awake (attempt 1/3)...
 [notice] Sleeping for 3 seconds...
 [notice] solr8-sandbox.dev is not awake (attempt 2/3)...
 [notice] Sleeping for 3 seconds...
 [notice] solr8-sandbox.dev is not awake (attempt 3/3)...
```