### PR TITLE
Undeprecate --tags from org:site:list

### DIFF
--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -39,7 +39,8 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @param string $organization Organization name, label, or ID
      * @option plan DEPRECATED Plan filter; filter by the plan's label
-     * @option string $tag DEPRECATED Tag name to filter
+     * @option string $tag Tag name to filter (ANY)
+     * @option string $tags Multiple tag names to filter (ALL)
      * @option string $upstream Upstream name to filter
      *
      * @usage <organization> Displays the list of sites associated with <organization>.


### PR DESCRIPTION
Based on the merged code in pantheon-systems/terminus#2360, we should undeprecate --tags, and add --tag to option list (already exists but isn't documented).