### PR TITLE
Fix Windows home directory error

### DIFF
--- a/src/Config/DefaultsConfig.php
+++ b/src/Config/DefaultsConfig.php
@@ -101,7 +101,7 @@ class DefaultsConfig extends TerminusConfig
         $home = getenv('HOME');
         if (!$home) {
             $system = '';
-            if (getenv('MSYSTEM') !== null) {
+            if (getenv('MSYSTEM')) {
                 $system = strtoupper(substr(getenv('MSYSTEM'), 0, 4));
             }
             if ($system != 'MING') {


### PR DESCRIPTION
Based on downstream user reports (https://github.com/acquia/cli/pull/1611), there's a bug in home directory detection on Windows.

It seems like Terminus doesn't officially support native Windows terminals (CMD, PowerShell, etc), in which case maybe this is dead code that should be removed entirely.