### PR TITLE
[LOPS-1990] Fix fatal error on payment methods.

### DIFF
--- a/src/Collections/PaymentMethods.php
+++ b/src/Collections/PaymentMethods.php
@@ -36,7 +36,7 @@ class PaymentMethods extends UserOwnedCollection
      * @throws TerminusException When there is more than one matching payment method
      * @throws TerminusNotFoundException When there are no matching payment methods
      */
-    public function get($id): ?TerminusModel
+    public function get($id): TerminusModel
     {
         $payment_methods = $this->all();
         if (isset($payment_methods[$id])) {

--- a/src/Collections/TerminusCollection.php
+++ b/src/Collections/TerminusCollection.php
@@ -94,6 +94,10 @@ abstract class TerminusCollection implements ContainerAwareInterface, RequestAwa
     public function fetch()
     {
         foreach ($this->getData() as $id => $model_data) {
+            if (!$id && !is_object($model_data)) {
+                // Empty model, just skip it.
+                continue;
+            }
             if (!is_object($model_data)) {
                 // This should always be an object, however occasionally it is returning as a string
                 // We need more information about what it is and to handle the error


### PR DESCRIPTION
Before:

Getting error when running `terminus payment-method:list`:
```
Fatal error: Declaration of Pantheon\Terminus\Collections\PaymentMethods::get($id): ?Pantheon\Terminus\Models\TerminusModel must be compatible with Pantheon\Terminus\Collections\TerminusCollection::get($id): Pantheon\Terminus\Models\TerminusModel in phar:///opt/homebrew/Cellar/terminus/3.3.0/bin/terminus/src/Collections/PaymentMethods.php on line 39
```

The second commit addresses the following message:

```
terminus payment-method:list
 [warning] Model data missing for 0
 [warning] There are no payment methods attached to this account.
 ------- ----
  Label   ID
 ------- ----
```