### PR TITLE
[LOPS-1951] Avoid hitting APIs so hard.

### DIFF
--- a/src/Commands/WorkflowProcessingTrait.php
+++ b/src/Commands/WorkflowProcessingTrait.php
@@ -25,9 +25,12 @@ trait WorkflowProcessingTrait
             return $progressBar->cycle();
         }
         $retry_interval = $this->getConfig()->get('http_retry_delay_ms', 100);
+        $retry_count = 1;
         do {
             $workflow->fetch();
-            usleep($retry_interval * 1000);
+            $sleep = $retry_interval * $retry_count * 1000;
+            usleep($sleep);
+            $retry_count++;
         } while (!$workflow->isFinished());
         return $workflow;
     }

--- a/src/Commands/WorkflowProcessingTrait.php
+++ b/src/Commands/WorkflowProcessingTrait.php
@@ -24,13 +24,14 @@ trait WorkflowProcessingTrait
             $progressBar = $this->getContainer()->get($nickname);
             return $progressBar->cycle();
         }
-        $retry_interval = $this->getConfig()->get('http_retry_delay_ms', 100);
-        $retry_count = 1;
+        $retry_interval = $this->getConfig()->get('workflow_polling_delay_ms', 5000);
+        if ($retry_interval < 1000) {
+            // The API will not allow polling faster than once per second.
+            $retry_interval = 1000;
+        }
         do {
             $workflow->fetch();
-            $sleep = $retry_interval * $retry_count * 1000;
-            usleep($sleep);
-            $retry_count++;
+            usleep($retry_interval * 1000);
         } while (!$workflow->isFinished());
         return $workflow;
     }

--- a/src/ProgressBars/TerminusProgressBar.php
+++ b/src/ProgressBars/TerminusProgressBar.php
@@ -32,9 +32,10 @@ abstract class TerminusProgressBar implements ConfigAwareInterface
     /**
      * Sleeps to prevent spamming the API.
      */
-    protected function sleep()
+    protected function sleep($invocation_count = 1)
     {
         $retry_interval = $this->getConfig()->get('http_retry_delay_ms', 100);
+        $retry_interval = $retry_interval * $invocation_count;
         usleep($retry_interval * 1000);
     }
 

--- a/src/ProgressBars/TerminusProgressBar.php
+++ b/src/ProgressBars/TerminusProgressBar.php
@@ -32,10 +32,9 @@ abstract class TerminusProgressBar implements ConfigAwareInterface
     /**
      * Sleeps to prevent spamming the API.
      */
-    protected function sleep($invocation_count = 1)
+    protected function sleep()
     {
         $retry_interval = $this->getConfig()->get('http_retry_delay_ms', 100);
-        $retry_interval = $retry_interval * $invocation_count;
         usleep($retry_interval * 1000);
     }
 

--- a/src/ProgressBars/WorkflowProgressBar.php
+++ b/src/ProgressBars/WorkflowProgressBar.php
@@ -50,6 +50,19 @@ class WorkflowProgressBar extends TerminusProgressBar
     }
 
     /**
+     * Sleeps to prevent spamming the API.
+     */
+    protected function sleep()
+    {
+        $retry_interval = $this->getConfig()->get('workflow_polling_delay_ms', 5000);
+        if ($retry_interval < 1000) {
+            // The API will not allow polling faster than once per second.
+            $retry_interval = 1000;
+        }
+        usleep($retry_interval * 1000);
+    }
+
+    /**
      * Runs a single iteration of the progress bar.
      * @return bool
      * @throws TerminusException

--- a/src/ProgressBars/WorkflowProgressBar.php
+++ b/src/ProgressBars/WorkflowProgressBar.php
@@ -42,8 +42,10 @@ class WorkflowProgressBar extends TerminusProgressBar
      */
     public function cycle()
     {
+        $invocation_count = 0;
         while ($this->update()) {
-            $this->sleep();
+            $invocation_count++;
+            $this->sleep($invocation_count);
         }
     }
 

--- a/src/ProgressBars/WorkflowProgressBar.php
+++ b/src/ProgressBars/WorkflowProgressBar.php
@@ -42,10 +42,8 @@ class WorkflowProgressBar extends TerminusProgressBar
      */
     public function cycle()
     {
-        $invocation_count = 0;
         while ($this->update()) {
-            $invocation_count++;
-            $this->sleep($invocation_count);
+            $this->sleep();
         }
     }
 

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -176,8 +176,12 @@ class Request implements
     private function createRetryDecider(): callable
     {
         $config = $this->getConfig();
-        $maxRetries = $config->get('http_max_retries', 5);
+        $maxRetries = $config->get('http_max_retries', $defaultMaxRetries);
+        // Cap max retries at 10.
+        $maxRetries = $maxRetries > 10 ? 10 : $maxRetries;
         $retryBackoff = $config->get('http_retry_backoff', 5);
+        // Retry backoff should be at least 3.
+        $retryBackoff = $retryBackoff < 3 ? 3 : $retryBackoff;
         $logger = $this->logger;
         $logWarning = function (string $message) use ($logger) {
             if ($this->output()->isVerbose()) {


### PR DESCRIPTION
Before:

```
kporras07@Kevins-MacBook-Pro.local ➜  ~  date ; termibox site:list -v ; date
Wed Jan  3 08:56:47 CST 2024
 [info] #### REQUEST ####
Headers: {"User-Agent":"Terminus/3.3.0 (php_version=8.2.11&script=bin/terminus)","Accept":"application/json","X-Pantheon-Trace-Id":"92c1cf4b-ef31-8e22-294c-aefc0c80aea8","X-Pantheon-Terminus-Command":"{\"command\":\"site:list\",\"arguments\":{\"command\":\"site:list\"},\"options\":{\"name\":null,\"org\":\"all\",\"owner\":null,\"plan\":null,\"team\":false,\"upstream\":null,\"format\":\"table\",\"fields\":\"name,id,plan_name,framework,region,owner,created,memberships,frozen\",\"field\":\"\",\"filter\":\"\",\"admin\":null,\"help\":false,\"quiet\":false,\"verbose\":true,\"version\":false,\"ansi\":null,\"no-interaction\":false,\"define\":[],\"yes\":false},\"truncated\":false}","Authorization":"**HIDDEN**"}
URI: https://hermes.sandbox-lops.sbx02.pantheon.io:443/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100
Method: GET
Body: null
 [warning] HTTP request GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 has failed: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 1 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 2 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 3 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 4 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [error]  HTTP request GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 has failed with error Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100.
 [error]  HTTP request has failed with error "Maximum retry attempts reached".
Wed Jan  3 08:57:19 CST 2024
```

Result: All retries went in approx. 32 seconds


After:

```
date ; termibox site:list -v ; date
Wed Jan  3 08:53:38 CST 2024
 [info] #### REQUEST ####
Headers: {"User-Agent":"Terminus/3.3.0 (php_version=8.2.11&script=bin/terminus)","Accept":"application/json","X-Pantheon-Trace-Id":"cc017be2-23dc-4f0d-3a88-32453827304b","X-Pantheon-Terminus-Command":"{\"command\":\"site:list\",\"arguments\":{\"command\":\"site:list\"},\"options\":{\"name\":null,\"org\":\"all\",\"owner\":null,\"plan\":null,\"team\":false,\"upstream\":null,\"format\":\"table\",\"fields\":\"name,id,plan_name,framework,region,owner,created,memberships,frozen\",\"field\":\"\",\"filter\":\"\",\"admin\":null,\"help\":false,\"quiet\":false,\"verbose\":true,\"version\":false,\"ansi\":null,\"no-interaction\":false,\"define\":[],\"yes\":false},\"truncated\":false}","Authorization":"**HIDDEN**"}
URI: https://hermes.sandbox-lops.sbx02.pantheon.io:443/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100
Method: GET
Body: null
 [warning] HTTP request GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 has failed: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100
 [warning] Retrying in 5 seconds.
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 1 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying in 10 seconds.
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 2 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying in 15 seconds.
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 3 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying in 20 seconds.
 [warning] Retrying GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 4 out of 5 (reason: Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100)
 [warning] Retrying in 25 seconds.
 [error]  HTTP request GET https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100 has failed with error Connection refused for URI https://hermes.sandbox-lops.sbx02.pantheon.io/api/users/ab17855f-293f-43b4-85f9-04349cb1d4ec/memberships/sites?limit=100.
 [error]  HTTP request has failed with error "Maximum retry attempts reached".
Wed Jan  3 08:55:24 CST 2024
```

Result: All retries went in approx. 106 seconds due to the retry backoff.


Also, workflow processing (both interactive and non-interactive), is now based on the config value `workflow_polling_delay_ms` (default 5000ms, min 1000ms)
