### PR TITLE
LOPS-2047: Environment Variables to Terminus Functional Tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="./tests/config/bootstrap.php"
-         colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="./tests/config/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="functional">
             <directory suffix="Test.php">tests/Functional/</directory>
         </testsuite>
     </testsuites>
-    <coverage
-            processUncoveredFiles="true"
-            cacheDirectory="reports">
+    <coverage processUncoveredFiles="true" cacheDirectory="reports">
         <include>
             <directory suffix="Command.php">src/Commands</directory>
         </include>
@@ -19,10 +14,15 @@
         <testdoxXml outputFile="reports/logfile.xml"/>
     </logging>
     <php>
-        <server   name="TERMINUS_TOKEN"           value="${TERMINUS_TOKEN}" />
-        <server   name="TERMINUS_SITE"            value="${TERMINUS_SITE}" />
-        <server   name="TERMINUS_SITE_WP"         value="${TERMINUS_SITE}" />
-        <server   name="TERMINUS_SITE_WP_NETWORK" value="${TERMINUS_SITE}" />
-        <server   name="TERMINUS_ORG"             value="${TERMINUS_ORG}" />
+        <server name="TERMINUS_TOKEN" value="${TERMINUS_TOKEN}" />
+        <server name="TERMINUS_SITE" value="${TERMINUS_SITE}" />
+        <server name="TERMINUS_SITE_WP" value="${TERMINUS_SITE}" />
+        <server name="TERMINUS_SITE_WP_NETWORK" value="${TERMINUS_SITE}" />
+        <server name="TERMINUS_ORG" value="${TERMINUS_ORG}" />
+        <server name="TERMINUS_HOST" value="${TERMINUS_HOST}" />
+        <server name="TERMINUS_PORT" value="${TERMINUS_PORT}" />
+        <server name="PANTHEON_CERT" value="${PANTHEON_CERT}" />
+        <server name="TERMINUS_VERIFY_HOST_CERT" value="${TERMINUS_VERIFY_HOST_CERT}" />
+        <server name="TERMINUS_CACHE_DIR" value="${TERMINUS_CACHE_DIR}" />
     </php>
 </phpunit>

--- a/tests/Functional/TerminusTestBase.php
+++ b/tests/Functional/TerminusTestBase.php
@@ -38,7 +38,7 @@ abstract class TerminusTestBase extends TestCase
         string $command,
         ?string $pipeInput = null
     ): array {
-        $procCommand = sprintf('%s %s', TERMINUS_BIN_FILE, $command);
+        $procCommand = sprintf('TERMINUS_HOST=%s %s %s', getEnv("TERMINUS_HOST"), TERMINUS_BIN_FILE, $command);
         if (null !== $pipeInput) {
             $procCommand = sprintf('%s | %s', $pipeInput, $procCommand);
         }

--- a/tests/Functional/TerminusTestBase.php
+++ b/tests/Functional/TerminusTestBase.php
@@ -38,8 +38,21 @@ abstract class TerminusTestBase extends TestCase
         string $command,
         ?string $pipeInput = null
     ): array {
-        $terminusHost = isset($_ENV['TERMINUS_HOST']) ? "TERMINUS_HOST=" . $_ENV['TERMINUS_HOST'] : "";
-        $procCommand = sprintf('%s %s %s', $terminusHost, TERMINUS_BIN_FILE, $command);
+        $preamble = '';
+        foreach (
+            [
+                'TERMINUS_HOST',
+                'TERMINUS_PORT',
+                'TERMINUS_VERIFY_HOST_CERT',
+                'TERMINUS_CACHE_DIR',
+                'PANTHEON_CERT'
+            ] as $envVar
+        ) {
+            if (false !== getenv($envVar)) {
+                $preamble .= sprintf('%s=%s ', $envVar, getenv($envVar));
+            }
+        }
+        $procCommand = sprintf('%s %s %s', $preamble, TERMINUS_BIN_FILE, $command);
         if (null !== $pipeInput) {
             $procCommand = sprintf('%s | %s', $pipeInput, $procCommand);
         }
@@ -212,7 +225,7 @@ abstract class TerminusTestBase extends TestCase
         int $attempts = 3
     ): void {
         $this->assertTerminusCommandResultEqualsInAttempts(
-            fn () => static::callTerminus(sprintf('%s --yes', $command))[1],
+            fn() => static::callTerminus(sprintf('%s --yes', $command))[1],
             0,
             $attempts
         );

--- a/tests/Functional/TerminusTestBase.php
+++ b/tests/Functional/TerminusTestBase.php
@@ -38,7 +38,8 @@ abstract class TerminusTestBase extends TestCase
         string $command,
         ?string $pipeInput = null
     ): array {
-        $procCommand = sprintf('TERMINUS_HOST=%s %s %s', getEnv("TERMINUS_HOST"), TERMINUS_BIN_FILE, $command);
+        $terminusHost = isset($_ENV['TERMINUS_HOST']) ? "TERMINUS_HOST=" . $_ENV['TERMINUS_HOST'] : "";
+        $procCommand = sprintf('%s %s %s', $terminusHost, TERMINUS_BIN_FILE, $command);
         if (null !== $pipeInput) {
             $procCommand = sprintf('%s | %s', $pipeInput, $procCommand);
         }


### PR DESCRIPTION
- We still have some questions about the applications of env vars aside from `TERMINUS_HOST` but are ready for some review on our current implementation.