### PR TITLE
[BUGS-7496] Paging true in workflow:list depending on new all flag.

### DIFF
--- a/src/Commands/Workflow/ListCommand.php
+++ b/src/Commands/Workflow/ListCommand.php
@@ -25,6 +25,8 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @command workflow:list
      * @aliases workflows
      *
+     * @option bool $all Whether to return all available workflows, not just the most recent 100
+     *
      * @field-labels
      *     id: Workflow ID
      *     env: Environment
@@ -40,11 +42,14 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *
      * @usage <site> Displays the list of the workflows for <site>.
      */
-    public function wfList($site_id)
+    public function wfList($site_id, $options = [
+        'all' => false,
+    ])
     {
+        $paging = (bool) $options['all'];
         $site = $this->getSiteById($site_id);
         return $this->getRowsOfFields(
-            $site->getWorkflows()->setPaging(true)->fetch(),
+            $site->getWorkflows()->setPaging($paging)->fetch(),
             [
                 'message' => 'No workflows have been run on {site}.',
                 'message_options' => ['site' => $site->getName()],

--- a/src/Commands/Workflow/ListCommand.php
+++ b/src/Commands/Workflow/ListCommand.php
@@ -44,7 +44,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
     {
         $site = $this->getSiteById($site_id);
         return $this->getRowsOfFields(
-            $site->getWorkflows()->setPaging(false)->fetch(),
+            $site->getWorkflows()->setPaging(true)->fetch(),
             [
                 'message' => 'No workflows have been run on {site}.',
                 'message_options' => ['site' => $site->getName()],

--- a/src/Commands/Workflow/ListCommand.php
+++ b/src/Commands/Workflow/ListCommand.php
@@ -25,7 +25,7 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      * @command workflow:list
      * @aliases workflows
      *
-     * @option bool $all Whether to return all available workflows, not just the most recent 100
+     * @option bool $all Return all of the available workflows, not just the most recent 100
      *
      * @field-labels
      *     id: Workflow ID


### PR DESCRIPTION
Added `--all` option to return all of the available workflows instead of default behavior of only last 100 items.