### PR TITLE
Fixing broken tests: Adding update to homebrew before testing

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -72,6 +72,8 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.TERMINUS_SITE_OWNER_SSH_PRIVATE_KEY }}
+      - run: brew update && brew upgrade icu4c
+        if: runner.os == 'macOS'
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Monday morning 2/28/2024 tests just magically started breaking that were working on friday. This fixes issues with broken home-brew library in the testing cycle. 