### PR TITLE
[BUGS-7228] Remove the concept of change_management in site:team:role commands.

### DIFF
--- a/src/Commands/Site/Team/AddCommand.php
+++ b/src/Commands/Site/Team/AddCommand.php
@@ -41,14 +41,6 @@ class AddCommand extends TerminusCommand implements SiteAwareInterface
         $site = $this->getSiteById($site_id);
         $team = $site->getUserMemberships();
 
-        if ($role !== SiteUserMembership::ROLE_TEAM_MEMBER && !$site->getFeature('change_management')) {
-            $role = SiteUserMembership::ROLE_TEAM_MEMBER;
-            $this->log()->warning(
-                'Site does not have change management enabled, defaulting to user role {role}.',
-                compact('role')
-            );
-        }
-
         $workflow = $team->create($member, $role);
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());

--- a/src/Commands/Site/Team/RoleCommand.php
+++ b/src/Commands/Site/Team/RoleCommand.php
@@ -33,9 +33,6 @@ class RoleCommand extends TerminusCommand implements SiteAwareInterface
     public function role($site_id, $member, $role)
     {
         $site = $this->getSiteById($site_id);
-        if (!(bool)$site->getFeature('change_management')) {
-            throw new TerminusException('This site does not have its change-management option enabled.');
-        }
         $workflow = $site->getUserMemberships()->get($member)->setRole($role);
         $this->processWorkflow($workflow);
         $this->log()->notice($workflow->getMessage());

--- a/tests/Functional/SiteTeamCommandsTest.php
+++ b/tests/Functional/SiteTeamCommandsTest.php
@@ -76,20 +76,13 @@ class SiteTeamCommandsTest extends TerminusTestBase
      * @covers \Pantheon\Terminus\Commands\Site\Team\RoleCommand
      *
      * @group site-team
-     * @group short
+     * @group long
      */
     public function testSiteTeamRoleCommand(): void
     {
-        self::callTerminus(
-            sprintf('site:team:add %s %s', $this->getSiteName(), $this->getUserEmail())
-        );
-
         [$stdout, $exitCode, $stderr] = self::callTerminus(
             sprintf('site:team:role %s %s team_member', $this->getSiteName(), $this->getUserEmail())
         );
-
-        printf("stdout: %s\n", $stdout);
-        printf("stderr: %s\n", $stderr);
 
         $this->assertEquals(0, $exitCode);
     }

--- a/tests/Functional/SiteTeamCommandsTest.php
+++ b/tests/Functional/SiteTeamCommandsTest.php
@@ -84,7 +84,7 @@ class SiteTeamCommandsTest extends TerminusTestBase
             sprintf('site:team:role %s %s team_member', $this->getSiteName(), $this->getUserEmail())
         );
 
-        $this->assertNotFalse(strpos($stderr, 'This site does not have its change-management option enabled.'));
+        $this->assertEquals(0, $exitCode);
     }
 
     /**

--- a/tests/Functional/SiteTeamCommandsTest.php
+++ b/tests/Functional/SiteTeamCommandsTest.php
@@ -84,6 +84,9 @@ class SiteTeamCommandsTest extends TerminusTestBase
             sprintf('site:team:role %s %s team_member', $this->getSiteName(), $this->getUserEmail())
         );
 
+        printf("stdout: %s\n", $stdout);
+        printf("stderr: %s\n", $stderr);
+
         $this->assertEquals(0, $exitCode);
     }
 

--- a/tests/Functional/SiteTeamCommandsTest.php
+++ b/tests/Functional/SiteTeamCommandsTest.php
@@ -80,6 +80,10 @@ class SiteTeamCommandsTest extends TerminusTestBase
      */
     public function testSiteTeamRoleCommand(): void
     {
+        self::callTerminus(
+            sprintf('site:team:add %s %s', $this->getSiteName(), $this->getUserEmail())
+        );
+
         [$stdout, $exitCode, $stderr] = self::callTerminus(
             sprintf('site:team:role %s %s team_member', $this->getSiteName(), $this->getUserEmail())
         );

--- a/tests/Functional/SiteTeamCommandsTest.php
+++ b/tests/Functional/SiteTeamCommandsTest.php
@@ -76,7 +76,7 @@ class SiteTeamCommandsTest extends TerminusTestBase
      * @covers \Pantheon\Terminus\Commands\Site\Team\RoleCommand
      *
      * @group site-team
-     * @group long
+     * @group short
      */
     public function testSiteTeamRoleCommand(): void
     {


### PR DESCRIPTION
To match dashboard functionality and suppress an unused flag.