### PR TITLE
LOPS-2119 - Wait for a healthcheck before releasing the command

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -73,3 +73,5 @@ TERMINUS_VCR_MODE:     null
 TERMINUS_CLIENT_OPTIONS:
   debug: false
   http_errors: false
+
+TERMINUS_WAIT_FOR_WAKE_REPEAT: 25

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -73,11 +73,14 @@ class CreateCommand extends SiteCommand
             $this->log()->notice('Deploying CMS...');
             $this->processWorkflow($site->deployProduct($upstream->id));
             $this->log()->notice('Waiting for site availability...');
+            $waits = 0;
             do {
                 sleep(5);
                 $woke = $site->getEnvironments()->get('dev')->wake();
                 // if success is empty, then the site is still waking up.
-            } while (($woke['success'] ?? false) !== true);
+                $waits++;
+                // If we've waited more than 25 seconds, then something is wrong.
+            } while (($woke['success'] ?? false) !== true || $waits < 5);
             $this->log()->notice('Your site has been created successfully!');
         }
     }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -80,11 +80,11 @@ class CreateCommand extends SiteCommand
                 // if success is empty, then the site is still waking up.
                 $waits++;
                 // If we've waited more than 25 seconds, then something is wrong.
-            } while (($woke['success'] ?? false) !== true || $waits < 5);
-            if (($woke['success'] ?? false) !== true) {
-                $this->log()->error('There was a problem creating the site.');
-                exit(1);
-            }
+                if ($waits < 5) {
+                    $this->log()->error('There was a problem creating the site.');
+                    exit(1);
+                }
+            } while (($woke['success'] ?? false) !== true);
             $this->log()->notice('Your site has been created successfully!');
         }
     }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -80,7 +80,7 @@ class CreateCommand extends SiteCommand
                 // if success is empty, then the site is still waking up.
                 $waits++;
                 // If we've waited more than 25 seconds, then something is wrong.
-                if ($waits < 5) {
+                if ($waits > 5) {
                     throw new \Exception('Could not confirm that the site is working; there might be a problem.');
                 }
             } while (($woke['success'] ?? false) !== true);

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -81,8 +81,7 @@ class CreateCommand extends SiteCommand
                 $waits++;
                 // If we've waited more than 25 seconds, then something is wrong.
                 if ($waits < 5) {
-                    $this->log()->error('Could not confirm that the site is working; there might be a problem.');
-                    exit(1);
+                    throw new \Exception('Could not confirm that the site is working; there might be a problem.');
                 }
             } while (($woke['success'] ?? false) !== true);
             $this->log()->notice('Your site has been created successfully!');

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -72,8 +72,9 @@ class CreateCommand extends SiteCommand
         if ($site = $this->getSiteById($workflow->get('waiting_for_task')->site_id)) {
             $this->log()->notice('Deploying CMS...');
             $this->processWorkflow($site->deployProduct($upstream->id));
-            $this->log()->notice('Deployed CMS');
+            $this->log()->notice('Waiting for site availability...');
             $site->getEnvironments()->get('dev')->wake();
+            $this->log()->notice('Your site has been created successfully!');
         }
     }
 }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -73,7 +73,11 @@ class CreateCommand extends SiteCommand
             $this->log()->notice('Deploying CMS...');
             $this->processWorkflow($site->deployProduct($upstream->id));
             $this->log()->notice('Waiting for site availability...');
-            $site->getEnvironments()->get('dev')->wake();
+            do {
+                sleep(5);
+                $woke = $site->getEnvironments()->get('dev')->wake();
+                // if success is empty, then the site is still waking up.
+            } while (($woke['success'] ?? false) !== true);
             $this->log()->notice('Your site has been created successfully!');
         }
     }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -73,6 +73,7 @@ class CreateCommand extends SiteCommand
             $this->log()->notice('Deploying CMS...');
             $this->processWorkflow($site->deployProduct($upstream->id));
             $this->log()->notice('Deployed CMS');
+            $site->getEnvironments()->get('dev')->wake();
         }
     }
 }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -81,7 +81,7 @@ class CreateCommand extends SiteCommand
                 $waits++;
                 // If we've waited more than 25 seconds, then something is wrong.
                 if ($waits < 5) {
-                    $this->log()->error('There was a problem creating the site.');
+                    $this->log()->error('Could not confirm that the site is working; there might be a problem.');
                     exit(1);
                 }
             } while (($woke['success'] ?? false) !== true);

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -81,6 +81,10 @@ class CreateCommand extends SiteCommand
                 $waits++;
                 // If we've waited more than 25 seconds, then something is wrong.
             } while (($woke['success'] ?? false) !== true || $waits < 5);
+            if (($woke['success'] ?? false) !== true) {
+                $this->log()->error('There was a problem creating the site.');
+                exit(1);
+            }
             $this->log()->notice('Your site has been created successfully!');
         }
     }

--- a/src/Helpers/Traits/WaitForWakeTrait.php
+++ b/src/Helpers/Traits/WaitForWakeTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pantheon\Terminus\Helpers\Traits;
+
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Models\Environment;
+use Psr\Log\LoggerInterface;
+
+trait WaitForWakeTrait
+{
+    /**
+     * Waits for the site to wake up.
+     *
+     * @param Environment $env
+     * @throws \Exception
+     */
+    public function waitForWake(Environment $env, LoggerInterface $logger)
+    {
+        $waits = 0;
+        do {
+            $woke = $env->wake();
+            if (($woke['success'] ?? false) === true) {
+                break;
+            }
+            // if success is empty, then the site is still waking up.
+            // If we've waited more than 25 seconds, then something is wrong.
+            if ($waits > 5) {
+                throw new TerminusException('Could not confirm that the site is working; there might be a problem.');
+            }
+            sleep(1);
+            $waits++;
+        } while (true);
+        $logger->notice('Your site has been created successfully!');
+    }
+}

--- a/src/Helpers/Traits/WaitForWakeTrait.php
+++ b/src/Helpers/Traits/WaitForWakeTrait.php
@@ -2,17 +2,21 @@
 
 namespace Pantheon\Terminus\Helpers\Traits;
 
+use Pantheon\Terminus\Config\ConfigAwareTrait;
 use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Models\Environment;
 use Psr\Log\LoggerInterface;
 
 trait WaitForWakeTrait
 {
+    use ConfigAwareTrait;
+
     /**
      * Waits for the site to wake up.
      *
      * @param Environment $env
-     * @throws \Exception
+     * @param LoggerInterface $logger
+     * @throws TerminusException
      */
     public function waitForWake(Environment $env, LoggerInterface $logger)
     {
@@ -23,8 +27,9 @@ trait WaitForWakeTrait
                 break;
             }
             // if success is empty, then the site is still waking up.
-            // If we've waited more than 25 seconds, then something is wrong.
-            if ($waits > 5) {
+            // Allow user to set the number of retries if the site is still waking up.
+            // Default should be 25 times, once per second.
+            if ($waits > $this->getConfig()->get("wait_for_wake_repeat", 25)) {
                 throw new TerminusException('Could not confirm that the site is working; there might be a problem.');
             }
             sleep(1);

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -10,10 +10,10 @@ use Pantheon\Terminus\Collections\Commits;
 use Pantheon\Terminus\Collections\Domains;
 use Pantheon\Terminus\Collections\EnvironmentMetrics;
 use Pantheon\Terminus\Collections\Workflows;
-use Pantheon\Terminus\Helpers\LocalMachineHelper;
+use Pantheon\Terminus\Exceptions\TerminusException;
 use Pantheon\Terminus\Friends\SiteInterface;
 use Pantheon\Terminus\Friends\SiteTrait;
-use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Helpers\LocalMachineHelper;
 
 /**
  * Class Environment
@@ -1000,7 +1000,7 @@ class Environment extends TerminusModel implements
      *
      * @return array
      */
-    public function wake()
+    public function wake(): array
     {
         $domains = array_filter(
             $this->getDomains()->all(),


### PR DESCRIPTION
Tested with a local build against production PAPI. Seems to satisfy done-whens.