### PR TITLE
[USERMGMT-2222, LOPS-2220] Remove SFTP password info

### DIFF
--- a/src/Commands/Connection/InfoCommand.php
+++ b/src/Commands/Connection/InfoCommand.php
@@ -27,7 +27,6 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
      *     sftp_command: SFTP Command
      *     sftp_username: SFTP Username
      *     sftp_host: SFTP Host
-     *     sftp_password: SFTP Password
      *     sftp_port: SFTP Port
      *     sftp_url: SFTP URL
      *     git_command: Git Command

--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -981,7 +981,6 @@ class Environment extends TerminusModel implements
             $username = "{$this->id}.{$site->id}";
             $domain = "appserver.{$this->id}.{$site->id}.drush.in";
         }
-        $password = 'Use your account password';
         $port = '2222';
         $url = "sftp://$username@$domain:$port";
         $command = "sftp -o Port=$port $username@$domain";

--- a/tests/unit_tests/Models/EnvironmentTest.php
+++ b/tests/unit_tests/Models/EnvironmentTest.php
@@ -256,7 +256,6 @@ class EnvironmentTest extends ModelTestCase
             'sftp_username' => $sftp_username,
             'sftp_host' => $sftp_domain,
             'sftp_port' => '2222',
-            'sftp_password' => 'Use your account password',
             'sftp_url' => "sftp://$sftp_username@$sftp_domain:$port",
             'sftp_command' => "sftp -o Port=$port $sftp_username@$sftp_domain",
         ];
@@ -854,7 +853,6 @@ class EnvironmentTest extends ModelTestCase
             'username' => 'dev.abc',
             'host' => 'appserver.dev.abc.drush.in',
             'port' => '2222',
-            'password' => 'Use your account password',
             'url' => 'sftp://dev.abc@appserver.dev.abc.drush.in:2222',
             'command' => 'sftp -o Port=2222 dev.abc@appserver.dev.abc.drush.in',
         ];
@@ -869,7 +867,6 @@ class EnvironmentTest extends ModelTestCase
             'username' => 'appserver.dev.abc',
             'host' => 'onebox',
             'port' => '2222',
-            'password' => 'Use your account password',
             'url' => 'sftp://appserver.dev.abc@onebox:2222',
             'command' => 'sftp -o Port=2222 appserver.dev.abc@onebox',
         ];
@@ -884,7 +881,6 @@ class EnvironmentTest extends ModelTestCase
             'username' => 'appserver.dev.abc',
             'host' => 'ssh.example.com',
             'port' => '2222',
-            'password' => 'Use your account password',
             'url' => 'sftp://appserver.dev.abc@ssh.example.com:2222',
             'command' => 'sftp -o Port=2222 appserver.dev.abc@ssh.example.com',
         ];


### PR DESCRIPTION
On April 30st, 2024, we will officially deprecate support for **password-based authentication for SSH connections to sites** (e.g. sftp, Git, scp). This will **not affect** support for regular username/password authentication to Pantheon.

As part of this work, this PR removes some references in the Terminus code and interface that suggested passwords as a valid authentication method.