### PR TITLE
[BUGS-7938] Non interactive commands should also exit with error if the workflow failed.

### DIFF
--- a/src/Commands/WorkflowProcessingTrait.php
+++ b/src/Commands/WorkflowProcessingTrait.php
@@ -4,6 +4,7 @@ namespace Pantheon\Terminus\Commands;
 
 use Pantheon\Terminus\Models\Workflow;
 use Pantheon\Terminus\ProgressBars\WorkflowProgressBar;
+use Pantheon\Terminus\Exceptions\TerminusException;
 
 /**
  * Class WorkflowTrait
@@ -33,6 +34,9 @@ trait WorkflowProcessingTrait
             $workflow->fetch();
             usleep($retry_interval * 1000);
         } while (!$workflow->isFinished());
+        if (!$workflow->isSuccessful()) {
+            throw new TerminusException($workflow->getMessage());
+        }
         return $workflow;
     }
 }


### PR DESCRIPTION
Before, only interactive commands were exiting with the right exit code in case of errors.