### PR TITLE
Roll-forward: increase release container image to php-ci:v7.4

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Release
     container:
-      image: quay.io/pantheon-public/php-ci:1.x
+      image: quay.io/pantheon-public/php-ci:v7.4
     needs: [ functional ]
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
     steps:

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -134,7 +134,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/')  && github.repository == 'pantheon-systems/terminus' }}
     steps:
       - name: Download terminus.phar as artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: terminus-phar
       - name: Release


### PR DESCRIPTION
Retain the new github action versions, and increase the release stage `php-ci` image to v7.4.  

Tested rolling back an earlier stage to the 1.x version and confirmed it encountered the same error, which implies that increasing the version to php-ci:v7.4 should resolve the issue we encountered with releasing on Thursday.