### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -109,13 +109,6 @@ jobs:
       - name: Functional Tests (arbitrary group)
         if: ${{ github.event.inputs.functional_tests_group != '' && github.event.inputs.functional_tests_group != 'all' }}
         run: composer test:group -- ${{ github.event.inputs.functional_tests_group }}
-      - name: Coverage Report
-        run: composer coverage
-      - name: Save coverage as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: CoverageReport
-          path: docs/TestCoverage.md
       - name: Finish sesssion
         if: ${{ always() && github.event.inputs.tmate_enabled == 1 }}
         run: |

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -84,7 +84,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: gd, mbstring, zip, ssh2-1.3.1, pcov
+          extensions: gd, mbstring, zip, ssh2-1.4.1, pcov
           coverage: pcov
           ini-values: error_reporting=E_ALL
       - name: Download repo content from artifact

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -14,6 +14,11 @@ on:
         required: true
         default: "0"
 
+# Cancel previous runs of this same branch/PR/etc.
+concurrency:
+  group: 'ci-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   # Checkout in separate job because docker image is alpine based and checkout action doesn't work.
   checkout_build:

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [ checkout_build ]
     steps:
       - name: Install SSH key
-        uses: webfactory/ssh-agent@v0.5.3
+        uses: webfactory/ssh-agent@0.9.0
         with:
           ssh-private-key: ${{ secrets.TERMINUS_SITE_OWNER_SSH_PRIVATE_KEY }}
       - run: brew update && brew upgrade icu4c
@@ -112,7 +112,7 @@ jobs:
       - name: Coverage Report
         run: composer coverage
       - name: Save coverage as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CoverageReport
           path: docs/TestCoverage.md

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [ checkout_build ]
     steps:
       - name: Install SSH key
-        uses: webfactory/ssh-agent@latest
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.TERMINUS_SITE_OWNER_SSH_PRIVATE_KEY }}
       - run: brew update && brew upgrade icu4c

--- a/.github/workflows/3x.yml
+++ b/.github/workflows/3x.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [ checkout_build ]
     steps:
       - name: Install SSH key
-        uses: webfactory/ssh-agent@0.9.0
+        uses: webfactory/ssh-agent@latest
         with:
           ssh-private-key: ${{ secrets.TERMINUS_SITE_OWNER_SSH_PRIVATE_KEY }}
       - run: brew update && brew upgrade icu4c


### PR DESCRIPTION
Still getting some "errors" with the versions of GitHub Actions when we do builds. These changes update more of the GitHub Actions to the latest versions and eliminate more of the code coverage stuff we're deprecating. We also prevent a workflow from running twice by stopping a workflow when a new one runs.