### PR TITLE
BUGS-8304: Restore filter hooks

### DIFF
--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -444,6 +444,9 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Workflow\\WaitCommand',
             'Pantheon\\Terminus\\Commands\\Workflow\\WatchCommand'
         ];
+
+        // Add in any static additions not handled by 'composer update-class-lists'
+        $this->commands[] = 'Consolidation\\Filter\\Hooks\\FilterHooks';
     }
 
     /**

--- a/tests/Functional/SiteCommandsTest.php
+++ b/tests/Functional/SiteCommandsTest.php
@@ -61,6 +61,19 @@ class SiteCommandsTest extends TerminusTestBase
     }
 
     /**
+     * @test
+     * @covers \Consolidation\Filter\Hooks\FilterHooks
+     *
+     * @group site
+     * @group short
+     */
+    public function testSiteListFilterOption()
+    {
+        $siteListHelpOutput = $this->terminus('help site:list');
+        $this->assertStringContainsString('--filter[=FILTER]', $siteListHelpOutput);
+    }
+
+    /**
      * Test site:create command.
      *
      * @test


### PR DESCRIPTION
Automation that manages the list of Terminus commands and filters removes the filter hooks every time it runs. We need to restore the filter hooks in a way that is not prone to regression.

Starting work with a failing test, as the tests do not catch the lack of the filter hooks, which allowed a bad release to go out.