### PR TITLE
[USERMGMT-2222] Fix undefined notice from sftp password cleanup

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -988,7 +988,6 @@ class Environment extends TerminusModel implements
             'username' => $username,
             'host' => $domain,
             'port' => $port,
-            'password' => $password,
             'url' => $url,
             'command' => $command,
         ];


### PR DESCRIPTION
I upgraded to 3.5.1 today and started getting undefined notices when running `terminus wp`

```
terminus remote:wp "${SITE}.dev" -- plugin list
 [warning] This environment is in read-only Git mode. If you want to make changes to the codebase of this site (e.g. updating modules or plugins), you will need to toggle into read/write SFTP mode first.
PHP Notice:  Undefined variable: password in phar:///opt/homebrew/Cellar/terminus/3.5.1/bin/terminus/src/Models/Environment.php on line 991
Notice: Undefined variable: password in phar:///opt/homebrew/Cellar/terminus/3.5.1/bin/terminus/src/Models/Environment.php on line 991
+--------------+----------+-----------+---------+--------------+---------------+
| name         | status   | update    | version | update_versi | auto_update   |
|              |          |           |         | on           |               |
+--------------+----------+-----------+---------+--------------+---------------+
......
+--------------+----------+-----------+---------+--------------+---------------+
 [notice] Command: SITE.dev -- wp plugin list [Exit: 0] (Attempt 1/1)
```

Looks like this field was missed in #2572.
