### PR TITLE
fix: undefined command summary

### DIFF
--- a/src/Commands/Remote/SSHBaseCommand.php
+++ b/src/Commands/Remote/SSHBaseCommand.php
@@ -100,13 +100,14 @@ abstract class SSHBaseCommand extends TerminusCommand implements SiteAwareInterf
             // Send the combined command line via SSH
             $ssh_data = $this->sendCommandViaSsh($command_line, $env_vars);
 
+            $command_summary = $this->getCommandSummary($command_args);
             // Log the command execution
             $this->log()->notice(
                 'Command: {site}.{env} -- {command} [Exit: {exit}] (Attempt {attempt}/{max_attempts})',
                 [
                     'site' => $this->site->getName(),
                     'env' => $this->environment->id,
-                    'command' => $this->getCommandSummary($command_args),
+                    'command' => $command_summary,
                     'exit' => $ssh_data['exit_code'],
                     'attempt' => $attempt + 1,
                     'max_attempts' => $max_attempts,


### PR DESCRIPTION
Fixes undefined notice for `$command_summary` during WP-CLI/Drush execution
This was broken in #2589 

> https://github.com/pantheon-systems/terminus/pull/2589/files#diff-0940cda3af08922f69b1bf2e6f64c5c9c291135936a398e5303435a82cd234b5L81-L82