### PR TITLE
Fix connection:info MySQL Command formatting.

### DIFF
--- a/src/Models/Environment.php
+++ b/src/Models/Environment.php
@@ -334,7 +334,7 @@ class Environment extends TerminusModel implements
         $username = $env_vars['DB_USER'] ?? null;
         $database = $env_vars['DB_NAME'] ?? null;
         $url = "mysql://$username:$password@$domain:$port/$database";
-        $command = "mysql -u $username -p$password -h $domain -P $port $database";
+        $command = "mysql -u $username -p $password -h $domain -P $port $database";
 
         if (is_null($domain)) {
             return [];


### PR DESCRIPTION
Incorrect formatting was causing the output mysql command to fail due to missing password. Due to missing -p definition, as the option had turned into -pas;dflkjasdfj;kajsdf. lol