### PR TITLE
[NCX-77] Warn when creating sites without --org

### DIFF
--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -28,7 +28,7 @@ class CreateCommand extends SiteCommand
      * @param string $site_name Site name
      * @param string $label Site label
      * @param string $upstream_id Upstream name or UUID
-     * @option org Organization name, label, or ID
+     * @option org Organization name, label, or ID (required starting Q2 2026)
      * @option region Specify the service region where the site should be
      *   created. See documentation for valid regions.
      *
@@ -66,12 +66,28 @@ class CreateCommand extends SiteCommand
         if (!is_null($org_id = $options['org'])) {
             $org = $user->getOrganizationMemberships()->get($org_id)->getOrganization();
             $workflow_options['organization_id'] = $org->id;
+        } else {
+            $this->log()->warning(
+                'Starting in Q2 2026, all new sites will be required to belong to an organization. '
+                . 'Use the --org option to specify an organization when creating a site.'
+            );
         }
 
         // Create the site.
         $this->log()->notice('Creating a new site...');
         $workflow = $this->sites()->create($workflow_options);
-        $this->processWorkflow($workflow);
+        try {
+            $this->processWorkflow($workflow);
+        } catch (TerminusException $e) {
+            if (is_null($options['org']) && stripos($e->getMessage(), 'organization') !== false) {
+                throw new TerminusException(
+                    'Site creation requires an organization. Use the --org option to specify one. '
+                    . 'Example: terminus site:create {site_name} {label} {upstream_id} --org=<org-name>',
+                    compact('site_name', 'label', 'upstream_id')
+                );
+            }
+            throw $e;
+        }
 
         // Deploy the upstream.
         if ($site = $this->getSiteById($workflow->get('waiting_for_task')->site_id)) {


### PR DESCRIPTION
## Summary

- Warns users when `site:create` is called without the `--org` option, ahead of the Q2 2026 requirement that all sites belong to an organization
- Catches backend rejection (when `REQUIRE_ORG_ID_FOR_SITE_CREATION` flag is enabled in Yggdrasil) and provides a clear, actionable error message with example usage
- Updates `--org` help text to indicate the upcoming requirement

## Related

- Yggdrasil feature flag: pantheon-systems/titan-mt#21454
- Terminus notices mechanism: #2785
- Pantheon API middleware: separate PR in pantheon-systems/pantheonapi

## Test plan

- [ ] `terminus site:create mysite "My Site" drupal-recommended` (no --org) shows warning message
- [ ] `terminus site:create mysite "My Site" drupal-recommended --org=my-org` shows no warning
- [ ] When backend rejects (flag enabled), error message includes `--org` usage example
- [ ] `terminus help site:create` shows "(required starting Q2 2026)" on the --org option