### PR TITLE
feat(DEVX-7022): support Node.js dependency updates

### DIFF
--- a/src/Commands/Upstream/Updates/ApplyCommand.php
+++ b/src/Commands/Upstream/Updates/ApplyCommand.php
@@ -44,13 +44,18 @@ class ApplyCommand extends UpdatesCommand
 
         $updates = $this->getUpstreamUpdatesLog($env);
         $composerUpdates = $this->getComposerUpdatesLog($env);
+        $nodeUpdates = $this->getNodeUpdatesLog($env);
 
         $count = count($updates);
         $composerCount = count($composerUpdates);
-        if ($count || $composerCount) {
+        $nodeCount = count($nodeUpdates);
+        if ($count || $composerCount || $nodeCount) {
             $prefix = sprintf("Applying %d upstream update(s)", $count);
             if ($composerCount) {
                 $prefix .= " and any composer update(s)";
+            }
+            if ($nodeCount) {
+                $prefix .= " and any node dependency update(s)";
             }
             $this->log()->notice(
                 '{prefix} to the {env} environment of {site_id}...',

--- a/src/Commands/Upstream/Updates/UpdatesCommand.php
+++ b/src/Commands/Upstream/Updates/UpdatesCommand.php
@@ -92,4 +92,33 @@ abstract class UpdatesCommand extends TerminusCommand implements SiteAwareInterf
         }
         return $deps;
     }
+
+    /**
+     * Get the list of node dependency updates for a site environment
+     *
+     * @param \Pantheon\Terminus\Models\Environment $env
+     *
+     * @return array The list of updates
+     */
+    protected function getNodeUpdatesLog($env)
+    {
+        if (!$env->getSite()->isNodejs()) {
+            return [];
+        }
+        $updates = $env->getUpstreamStatus()->getNodeUpdates();
+        if (empty($updates)) {
+            return [];
+        }
+        $deps = [];
+        if (!empty($updates->added_dependencies)) {
+            $deps = array_merge($deps, $updates->added_dependencies);
+        }
+        if (!empty($updates->updated_dependencies)) {
+            $deps = array_merge($deps, $updates->updated_dependencies);
+        }
+        if (!empty($updates->removed_dependencies)) {
+            $deps = array_merge($deps, $updates->removed_dependencies);
+        }
+        return $deps;
+    }
 }

--- a/src/Models/UpstreamStatus.php
+++ b/src/Models/UpstreamStatus.php
@@ -28,6 +28,11 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
      */
     protected $composerUpdates = null;
 
+    /**
+     * @var object|null
+     */
+    protected $nodeUpdates = null;
+
     public function __construct($attributes, array $options = [])
     {
         parent::__construct($attributes, $options);
@@ -43,8 +48,8 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
      */
     public function getStatus()
     {
-        return $this->hasUpdates() || $this->hasComposerUpdates(
-        ) ? 'outdated' : 'current';
+        return $this->hasUpdates() || $this->hasComposerUpdates() || $this->hasNodeUpdates()
+            ? 'outdated' : 'current';
     }
 
     /**
@@ -81,6 +86,22 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
     }
 
     /**
+     * Retrives node dependency updates
+     *
+     * @return object
+     */
+    public function getNodeUpdates()
+    {
+        if ($this->nodeUpdates === null) {
+            $env = $this->getEnvironment();
+            $this->nodeUpdates = $this->request()->request(
+                "sites/{$env->getSite()->id}/environments/{$env->id}/build/node-updates"
+            )['data'];
+        }
+        return $this->nodeUpdates;
+    }
+
+    /**
      * @return bool
      */
     public function hasCode()
@@ -99,6 +120,22 @@ class UpstreamStatus extends TerminusModel implements EnvironmentInterface
         return !empty($composerUpdates->added_dependencies) ||
             !empty($composerUpdates->updated_dependencies) ||
             !empty($composerUpdates->removed_dependencies);
+    }
+
+    /**
+     * Determines whether there are any node dependency updates to be applied.
+     *
+     * @return bool
+     */
+    public function hasNodeUpdates(): bool
+    {
+        if (!$this->getEnvironment()->getSite()->isNodejs()) {
+            return false;
+        }
+        $nodeUpdates = $this->getNodeUpdates();
+        return !empty($nodeUpdates->added_dependencies) ||
+            !empty($nodeUpdates->updated_dependencies) ||
+            !empty($nodeUpdates->removed_dependencies);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds `getNodeUpdates()` and `hasNodeUpdates()` to `UpstreamStatus` model, calling `build/node-updates` API endpoint
- Adds `getNodeUpdatesLog()` to `UpdatesCommand`, gated on `$env->getSite()->isNodejs()` framework check
- `ApplyCommand` now includes node dependency updates in its update count and log message
- `getStatus()` returns `'outdated'` when node updates are pending

## Related PRs
- composer-updates-proxy: adds the GCS-backed `node-updates` endpoint
- titan-mt: adds the proxy route that forwards to composer-updates-proxy

## Deploy dependency
- composer-updates-proxy and titan-mt must be deployed first

## Test plan
- [ ] Verify unit tests pass in CI
- [ ] Verify `upstream:updates:status` reports `outdated` for Node.js sites with pending updates
- [ ] Verify `upstream:updates:apply` includes node dependency count in its output
- [ ] Verify non-Node.js sites are unaffected (no extra API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)