### PR TITLE
[BUGS-11265] Terminus 4.2.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This projec
 
 - Fix premature pagination stop in `org:site:list` when API returns short pages (#2829)
 - Only include `wp_replace_siteurl` if site is WordPress (#2825)
+- Warn when creating sites without `--org` and provide actionable error if creation fails due to missing org (#2786)
 
 ## 4.2.0 - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.2.1-dev
+## 4.2.1 - 2026-04-30
+
+### Fixed
+
+- Fix premature pagination stop in `org:site:list` when API returns short pages (#2829)
+- Only include `wp_replace_siteurl` if site is WordPress (#2825)
 
 ## 4.2.0 - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,41 @@ All notable changes to this project will be documented in this file. This projec
 
 - Update and pin GitHub Actions to latest versions (#2753)
 
+## 4.1.9 - 2026-04-09
+
+### Fixed
+
+- Fix SSH command output formatting when streaming (#2814)
+- Fix `env:wake` by removing X-Pantheon-Styx-Hostname header requirement (#2815)
+
+## 4.1.8 - 2026-03-30
+
+### Changed
+
+- Warn users when creating sites without --org, ahead of Q2 2026 requirement that all sites belong to an organization (#2786)
+
+## 4.1.7 - 2026-03-24
+
+### Fixed
+
+- Fix `domain:verify` to display DNS challenge details when unverified and poll for verification status (#2797)
+
+## 4.1.6 - 2026-03-18
+
+### Added
+
+- Add `search:enable` and `search:disable` commands for managing search indexing (#2783, #2784)
+  - Coming soon to WordPress - these commands are currently non-functional for WP sites until Elasticsearch platform compatibility is added
+- Add `domain:verify` command for domain ownership verification (#2790)
+
+### Deprecated
+
+- `solr:enable` and `solr:disable` commands are deprecated in favor of `search:enable` and `search:disable`
+
+### Fixed
+
+- Empty body should be object, not array (#2780)
+
 ## 4.1.4 - 2026-02-02
 
 ### Added

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.2.1-dev'
+TERMINUS_VERSION: '4.2.1'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -61,7 +61,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
      * @param string $site_name Site name (machine name)
      * @param string $label Site label (human-readable name)
      * @param string $upstream_id Upstream name or UUID (e.g., wordpress, drupal-composer-managed)
-     * @option org Organization name, label, or ID. Required if --vcs-provider=github is used.
+     * @option org Organization name, label, or ID (required starting Q2 2026). Required if --vcs-provider=github is used.
      * @option region Specify the service region where the site should be created. See documentation for valid regions.
      * @option vcs-provider VCS provider for the site repository (e.g., github, pantheon). Default is pantheon.
      * @option vcs-org Name of the Github organization containing the repository. Required if --vcs-provider=github is used.
@@ -291,13 +291,27 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
                 );
             }
         } else {
-             $this->log()->notice('Site will be owned by the current user: {email}', ['email' => $user->get('email')]);
+            $this->log()->warning(
+                'Starting in Q2 2026, all new sites will be required to belong to an organization. '
+                . 'Use the --org option to specify an organization when creating a site.'
+            );
         }
 
         // Create the site record via Pantheon API
         $this->log()->notice('Submitting site creation request to Pantheon API...');
         $workflow = $this->sites()->create($workflow_options);
-        $this->processWorkflow($workflow);
+        try {
+            $this->processWorkflow($workflow);
+        } catch (TerminusException $e) {
+            if (is_null($options['org']) && stripos($e->getMessage(), 'organization') !== false) {
+                throw new TerminusException(
+                    'Site creation requires an organization. Use the --org option to specify one. '
+                    . 'Example: terminus site:create {site_name} {label} {upstream_id} --org=<org-name>',
+                    compact('site_name', 'label', 'upstream_id')
+                );
+            }
+            throw $e;
+        }
         $this->log()->notice('Pantheon site record created successfully.');
 
         // Deploy the upstream CMS code

--- a/tests/config/bootstrap.php
+++ b/tests/config/bootstrap.php
@@ -103,6 +103,37 @@ if (!getenv('TERMINUS_TESTING_RUNTIME_ENV')) {
     // Create a testing runtime multidev environment.
     $sitename = TerminusTestBase::getSiteName();
 
+    // Clean up orphaned test-* multidev environments before creating a new one.
+    $log->info('Checking for orphaned test-* multidev environments...');
+    $listOutput = [];
+    exec(
+        sprintf('%s multidev:list %s --format=json', TERMINUS_BIN_FILE, $sitename),
+        $listOutput,
+        $listCode
+    );
+    if (0 === $listCode && !empty($listOutput)) {
+        $multidevs = json_decode(implode('', $listOutput), true);
+        if (is_array($multidevs)) {
+            $testEnvs = array_filter($multidevs, function ($env, $id) {
+                return str_starts_with($id, 'test-');
+            }, ARRAY_FILTER_USE_BOTH);
+            if (!empty($testEnvs)) {
+                $log->info(sprintf('Found %d orphaned test-* multidev(s), deleting...', count($testEnvs)));
+                foreach ($testEnvs as $id => $env) {
+                    $log->info(sprintf('Deleting orphaned multidev: %s', $id));
+                    exec(
+                        sprintf('%s multidev:delete %s.%s --delete-branch --yes', TERMINUS_BIN_FILE, $sitename, $id),
+                        $delOutput,
+                        $delCode
+                    );
+                    if (0 !== $delCode) {
+                        $log->warning(sprintf('Failed to delete orphaned multidev %s (exit code %d)', $id, $delCode));
+                    }
+                }
+            }
+        }
+    }
+
     $multidev = sprintf('test-%s', substr(uniqid(), -6, 6));
     $createMdCommand = sprintf('multidev:create %s.dev %s', $sitename, $multidev);
 


### PR DESCRIPTION
## Summary

Release Terminus 4.2.1

### Changes since 4.2.0

- **Fix premature pagination stop in `org:site:list`** — API can return short pages when FGA results contain mixed tuple types, causing `pagedRequest()` to terminate early and return incomplete site listings (#2829)
- **Only include `wp_replace_siteurl` if site is WordPress** (#2825)

### Links

- BUGS ticket: https://getpantheon.atlassian.net/browse/BUGS-11265
- Pre-release: https://github.com/pantheon-systems/terminus/releases/tag/4.2.1-rc.1

🤖