### PR TITLE
feat(DEVX-6928): use server-side repo name validation for EVCS site creation

### DIFF
--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -437,8 +437,6 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         $repo_name = $options['repository-name'] ?? $site_name;
         $create_repo = $options['create-repo'];
 
-        // 0. Validate repo name.
-        $this->validateRepositoryName($repo_name);
         $this->log()->debug('Repository name: {repo_name}', ['repo_name' => $repo_name]);
 
 
@@ -628,14 +626,17 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             }
         }
 
-        // 5. Validate repository exists (or not) depending on create-repo option.
-        $this->validateRepositoryExistsOrNot(
-            $vcs_client,
+        // 5. Validate repository name and existence via VCS service.
+        $validation = $vcs_client->validateRepositoryName(
             $repo_name,
             $pantheon_org->id,
             $installation_id,
-            $create_repo
+            !$create_repo
         );
+        if (!($validation['data']->valid ?? false)) {
+            $errors = (array) ($validation['data']->errors ?? ['Invalid repository name.']);
+            throw new TerminusException(implode(' ', $errors));
+        }
 
         // 6. Use workflow for all sites
         $this->createExternallyHostedSiteViaWorkflow(
@@ -822,40 +823,6 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
     }
 
     /**
-     * Validates repository existence based on create_repo flag.
-     */
-    private function validateRepositoryExistsOrNot($vcs_client, $repo_name, $org_id, $installation_id, $create_repo)
-    {
-        $existing_repos = $vcs_client->searchRepositories($repo_name, $org_id, $installation_id);
-        $repo_exists = false;
-        if ($existing_repos['data']) {
-            foreach ($existing_repos['data'] as $repo) {
-                if (strtolower($repo->name) === strtolower($repo_name)) {
-                    $repo_exists = true;
-                    break;
-                }
-            }
-        }
-
-        // If we are creating the repo, it must not exist.
-        if ($create_repo && $repo_exists) {
-            throw new TerminusException(
-                'Repository "{repo}" already exists in the selected VCS organization.'
-                    . ' Cannot create it. Please choose a different repository name.',
-                ['repo' => $repo_name]
-            );
-        }
-        // If we are linking to an existing repo, it must exist.
-        if (!$create_repo && !$repo_exists) {
-            throw new TerminusException(
-                'Repository "{repo}" does not exist in the selected VCS organization.'
-                    . ' Cannot link it. Please create the repository first.',
-                ['repo' => $repo_name]
-            );
-        }
-    }
-
-    /**
      * Clone the repository using the converted SSH URL.
      */
     private function cloneRepo($repo_url)
@@ -1027,44 +994,6 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         }
 
         return true;
-    }
-
-    /**
-     * Validates repository name according to GitHub naming rules.
-     *
-     * @param string $repo_name Repository name to validate
-     * @throws TerminusException if validation fails
-     */
-    protected function validateRepositoryName(string $repo_name): void
-    {
-        if (empty($repo_name)) {
-            throw new TerminusException('Repository name cannot be empty.');
-        }
-        if (strlen($repo_name) > 100) {
-            throw new TerminusException(
-                'Repository name "{name}" is too long. Maximum length is 100 characters.',
-                ['name' => $repo_name]
-            );
-        }
-        if (preg_match('/[^a-zA-Z0-9\-]/', $repo_name)) {
-            throw new TerminusException(
-                'Repository name "{name}" contains invalid characters.'
-                    . ' Only alphanumeric and dashes are allowed.',
-                ['name' => $repo_name]
-            );
-        }
-        if (!preg_match('/[a-zA-Z0-9]/', $repo_name)) {
-            throw new TerminusException(
-                'Repository name "{name}" must contain at least one alphanumeric character.',
-                ['name' => $repo_name]
-            );
-        }
-        if (preg_match('/^-/', $repo_name)) {
-            throw new TerminusException('Repository name "{name}" cannot begin with a dash.', ['name' => $repo_name]);
-        }
-        if (preg_match('/-$/', $repo_name)) {
-            throw new TerminusException('Repository name "{name}" cannot end with a dash.', ['name' => $repo_name]);
-        }
     }
 
     /**

--- a/src/VcsApi/Client.php
+++ b/src/VcsApi/Client.php
@@ -252,6 +252,30 @@ class Client implements ConfigAwareInterface
     }
 
     /**
+     * Validate a repository name and check existence via the VCS service.
+     */
+    public function validateRepositoryName(
+        string $repo_name,
+        string $org_id,
+        string $installation_id,
+        bool $skip_create = false
+    ): array {
+        $request_options = [
+            'method' => 'GET',
+        ];
+
+        $path = sprintf(
+            'repository/validate-name?name=%s&org_id=%s&installation_id=%s&skip_create=%s',
+            urlencode($repo_name),
+            $org_id,
+            $installation_id,
+            $skip_create ? 'true' : 'false'
+        );
+
+        return $this->requestApi($path, $request_options, "X-Pantheon-Session");
+    }
+
+    /**
      * Performs the request to API path.
      *
      * @param string $path

--- a/tests/Unit/CreateCommandTest.php
+++ b/tests/Unit/CreateCommandTest.php
@@ -4,82 +4,10 @@ namespace Pantheon\Terminus\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Pantheon\Terminus\Commands\Site\CreateCommand;
-use Pantheon\Terminus\Exceptions\TerminusException;
-use ReflectionClass;
 
 /**
- * Test repository name validation in CreateCommand.
+ * Test site creation in CreateCommand.
  */
 class CreateCommandTest extends TestCase
 {
-    /**
-     * @dataProvider invalidRepositoryNameProvider
-     */
-    public function testInvalidRepositoryNames(string $repoName, string $expectedMessage): void
-    {
-        $this->expectException(TerminusException::class);
-        $this->expectExceptionMessage($expectedMessage);
-
-        $this->invokeValidateMethod($repoName);
-    }
-
-    /**
-     * @dataProvider validRepositoryNameProvider
-     */
-    public function testValidRepositoryNames(string $repoName): void
-    {
-        $this->invokeValidateMethod($repoName);
-        $this->assertTrue(true);
-    }
-
-    /**
-     * Data provider for invalid repository names.
-     *
-     * @return array<string, array<int, string>>
-     */
-    public function invalidRepositoryNameProvider(): array
-    {
-        return [
-            'empty name' => ['', 'Repository name cannot be empty'],
-            'too long (101 chars)' => [str_repeat('a', 101), 'is too long. Maximum length is 100 characters'],
-            'with underscore' => ['my_repo_name', 'contains invalid characters'],
-            'with special characters' => ['my-repo!name', 'contains invalid characters'],
-            'with spaces' => ['my repo name', 'contains invalid characters'],
-            'only dashes' => ['---', 'must contain at least one alphanumeric character'],
-            'starts with dash' => ['-my-repo', 'cannot begin with a dash'],
-            'ends with dash' => ['my-repo-', 'cannot end with a dash'],
-        ];
-    }
-
-    /**
-     * Data provider for valid repository names.
-     *
-     * @return array<string, array<int, string>>
-     */
-    public function validRepositoryNameProvider(): array
-    {
-        return [
-            'alphanumeric' => ['myrepo123'],
-            'with dashes' => ['my-repo-name'],
-            'mixed case' => ['MyRepoName'],
-            'starts with number' => ['123-repo'],
-            'ends with number' => ['repo-123'],
-            'exactly 100 chars' => [str_repeat('a', 100)],
-        ];
-    }
-
-    /**
-     * Invoke the protected validateRepositoryName method using reflection.
-     *
-     * @param string $repoName Repository name to validate
-     * @throws TerminusException if validation fails
-     */
-    private function invokeValidateMethod(string $repoName): void
-    {
-        $command = new CreateCommand();
-        $reflection = new ReflectionClass($command);
-        $method = $reflection->getMethod('validateRepositoryName');
-        $method->setAccessible(true);
-        $method->invoke($command, $repoName);
-    }
 }


### PR DESCRIPTION
## Summary

- Replace local `validateRepositoryName()` (regex) and `validateRepositoryExistsOrNot()` (search + filter) with a single call to the new `GET /repository/validate-name` endpoint from DEVX-6926
- Add `validateRepositoryName()` method to `VcsApi\Client` that calls the new endpoint
- Remove ~120 lines of local validation logic; the server now handles name format validation and existence checking in one call
- Server-side validation covers additional rules the local regex missed: consecutive `--`/`__`, underscore support, must start/end with alphanumeric

## Dependencies

- [go-vcs-service PR #536](https://github.com/pantheon-systems/go-vcs-service/pull/536) (DEVX-6926) — adds the endpoint
- [pantheonapi PR](https://github.com/pantheon-systems/pantheonapi/pull/new/devx-6928) — proxies the endpoint through pantheonapi

## Test plan

- [ ] CI unit tests pass
- [ ] E2E: `terminus site:create` with `--vcs-provider=github` and valid new repo name succeeds
- [ ] E2E: invalid name (e.g. `--bad--`) returns server-side validation errors
- [ ] E2E: existing repo with `--create-repo` returns "already taken" error
- [ ] E2E: existing repo with `--no-create-repo` succeeds
- [ ] E2E: non-existing repo with `--no-create-repo` returns "does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)