### PR TITLE
feat: expose upstream and upstream_label as optional fields in site:list and org:site:list

### DIFF
--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -37,6 +37,8 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
      *     created: Created
      *     tags: Tags
      *     frozen: Is Frozen?
+     *     upstream: Upstream
+     *     upstream_label: Upstream Label
      * @default-fields name,id,plan_name,framework,owner,created,tags,frozen
      * @return RowsOfFields
      *

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -34,6 +34,8 @@ class ListCommand extends SiteCommand
      *     memberships: Memberships
      *     frozen: Is Frozen?
      *     last_frozen_at: Date frozen
+     *     upstream: Upstream
+     *     upstream_label: Upstream Label
      * @default-fields name,id,plan_name,framework,region,owner,created,memberships,frozen
      *
      * @param array $options


### PR DESCRIPTION
## Summary

- Adds `upstream` (upstream UUID + URL) and `upstream_label` (human-readable name) as opt-in `--fields` values for both `site:list` and `org:site:list`
- Both fields are already emitted by `Site::serialize()` and populated from data already present in the site list API response — no additional API calls are made
- Default output is unchanged; this is a purely additive, non-breaking change

## Usage

```
terminus site:list --fields=name,id,upstream_label
terminus org:site:list myorg --fields=name,id,upstream,upstream_label
```

## Notes

Making either field part of the default output would be a breaking change and is being deferred to a future 5.x major release.
