### PR TITLE
fix: validate --fields before fetching sites in site:list and org:site:list

### DIFF
--- a/src/Commands/Org/Site/ListCommand.php
+++ b/src/Commands/Org/Site/ListCommand.php
@@ -3,6 +3,7 @@
 namespace Pantheon\Terminus\Commands\Org\Site;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\Transformations\ReorderFields;
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Commands\StructuredListTrait;
 use Pantheon\Terminus\Site\SiteAwareInterface;
@@ -16,6 +17,18 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
 {
     use SiteAwareTrait;
     use StructuredListTrait;
+
+    private const FIELD_LABELS = [
+        'name' => 'Name',
+        'label' => 'Label',
+        'id' => 'ID',
+        'plan_name' => 'Plan',
+        'framework' => 'Framework',
+        'owner' => 'Owner',
+        'created' => 'Created',
+        'tags' => 'Tags',
+        'frozen' => 'Is Frozen?',
+    ];
 
     /**
      * Displays the list of sites associated with an organization.
@@ -56,6 +69,8 @@ class ListCommand extends TerminusCommand implements SiteAwareInterface
         $organization,
         $options = ['plan' => null, 'tag' => null, 'tags' => null, 'upstream' => null,]
     ) {
+        (new ReorderFields())->reorder($this->input()->getOption('fields'), self::FIELD_LABELS, []);
+
         $org = $this->session()->getUser()->getOrganizationMemberships()->get($organization)->getOrganization();
         $this->sites->fetch(['org_id' => $org->id,]);
         if (isset($options['plan']) && !is_null($plan = $options['plan'])) {

--- a/src/Commands/Site/ListCommand.php
+++ b/src/Commands/Site/ListCommand.php
@@ -3,6 +3,7 @@
 namespace Pantheon\Terminus\Commands\Site;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\Transformations\ReorderFields;
 use Pantheon\Terminus\Commands\StructuredListTrait;
 
 class ListCommand extends SiteCommand
@@ -11,6 +12,20 @@ class ListCommand extends SiteCommand
 
     private const OPTION_OWNER_ME = 'me';
     private const OPTION_ORG_ALL = 'all';
+
+    private const FIELD_LABELS = [
+        'name' => 'Name',
+        'label' => 'Label',
+        'id' => 'ID',
+        'plan_name' => 'Plan',
+        'framework' => 'Framework',
+        'region' => 'Region',
+        'owner' => 'Owner',
+        'created' => 'Created',
+        'memberships' => 'Memberships',
+        'frozen' => 'Is Frozen?',
+        'last_frozen_at' => 'Date frozen',
+    ];
 
     /**
      * Displays the list of sites accessible to the currently logged-in user.
@@ -69,6 +84,8 @@ class ListCommand extends SiteCommand
         'upstream' => null,
     ])
     {
+        (new ReorderFields())->reorder($this->input()->getOption('fields'), self::FIELD_LABELS, []);
+
         $user = $this->session()->getUser();
         $this->sites()->fetch(
             [


### PR DESCRIPTION
## Summary

- Field validation for `--fields` currently happens at render time, after all site data is fetched — which for large accounts can mean waiting several minutes before surfacing an invalid field name error
- This moves the validation to the very start of the command, before any API calls are made, using the same `ReorderFields` logic that the renderer uses
- The valid field labels are mirrored as a private `FIELD_LABELS` constant in each command to make them accessible at execution time

## Notes

This only covers `site:list` and `org:site:list`. The same pattern could be applied to other commands with slow fetches, but that's left for follow-up to keep scope small.

🤖