### PR TITLE
Terminus 4.2.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.2.2-dev
+## 4.2.2 - 2026-05-13
 
 ### Added
 
 - Add Object Cache and Search status rows to `site:info` output (#2812)
+- Expose `upstream` and `upstream_label` as optional fields in `site:list` and `org:site:list` (#2835)
+- Support Node.js dependency updates in `upstream:updates` commands (#2828)
+- Use server-side repo name validation for EVCS site creation (#2831)
+
+### Fixed
+
+- Fix PHP 8.2 deprecation warnings for dynamic property creation in Site model (#2813)
 
 ## 4.2.1 - 2026-04-30
 
@@ -14,10 +21,6 @@ All notable changes to this project will be documented in this file. This projec
 - Fix premature pagination stop in `org:site:list` when API returns short pages (#2829)
 - Only include `wp_replace_siteurl` if site is WordPress (#2825)
 - Warn when creating sites without `--org` and provide actionable error if creation fails due to missing org (#2786)
-
-### Fixed
-
-- Fix PHP 8.2 deprecation warnings for dynamic property creation in Site model (#2813)
 
 ## 4.2.0 - 2026-04-13
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.2.2-dev'
+TERMINUS_VERSION: '4.2.2'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
Release Terminus 4.2.2

## Changes

### Added
- Add Object Cache and Search status rows to `site:info` output (#2812)
- Expose `upstream` and `upstream_label` as optional fields in `site:list` and `org:site:list` (#2835)
- Support Node.js dependency updates in `upstream:updates` commands (#2828)
- Use server-side repo name validation for EVCS site creation (#2831)

### Fixed
- Fix PHP 8.2 deprecation warnings for dynamic property creation in Site model (#2813)