### PR TITLE
feat(DEVX-7053): add vcs:github-host:add command for GHES provisioning

### DIFF
--- a/src/Commands/Ghes/RegisterCommand.php
+++ b/src/Commands/Ghes/RegisterCommand.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Pantheon\Terminus\Commands\Ghes;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Helpers\LocalMachineHelper;
+use Pantheon\Terminus\Request\RequestAwareInterface;
+use Pantheon\Terminus\VcsApi\VcsClientAwareTrait;
+use Symfony\Component\Process\Process;
+
+/**
+ * Registers a GitHub Enterprise Server instance with Pantheon EVCS
+ * via the GitHub App manifest flow.
+ */
+class RegisterCommand extends TerminusCommand implements RequestAwareInterface
+{
+    use VcsClientAwareTrait;
+
+    protected const CALLBACK_TIMEOUT = 300;
+
+    protected ?Process $serverProcess = null;
+
+    public function __destruct()
+    {
+        $this->stopServer();
+    }
+
+    /**
+     * Register a GitHub Enterprise Server instance with Pantheon.
+     *
+     * Creates a GitHub App on the GHES instance via the manifest flow
+     * and provisions it with the Pantheon EVCS service.
+     *
+     * @authorize
+     *
+     * @command ghes:register
+     * @aliases ghes-register
+     *
+     * @option hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     *
+     * @usage --hostname=ghes.example.com Registers a GHES instance with Pantheon.
+     */
+    public function register(array $options = ['hostname' => null])
+    {
+        $hostname = $options['hostname'] ?? null;
+        if (empty($hostname)) {
+            throw new TerminusException('The --hostname option is required.');
+        }
+
+        $hostname = $this->sanitizeHostname($hostname);
+        $ghesBaseUrl = "https://{$hostname}";
+
+        $this->log()->notice('Fetching app manifest for {hostname}...', ['hostname' => $hostname]);
+        $manifestResponse = $this->getVcsClient()->getProvisionManifest($hostname);
+        $manifest = $manifestResponse['data'] ?? $manifestResponse;
+
+        $port = $this->findAvailablePort();
+        $localBaseUrl = "http://127.0.0.1:{$port}";
+        $manifest['redirect_url'] = "{$localBaseUrl}/callback";
+
+        $manifestJson = json_encode($manifest, JSON_UNESCAPED_SLASHES);
+        $token = bin2hex(random_bytes(16));
+        $flagFile = sys_get_temp_dir() . "/terminus_ghes_register_{$token}";
+
+        $serverScript = $this->createServerScript($ghesBaseUrl, $manifestJson, $flagFile);
+        $this->startServer($port, $serverScript);
+
+        $this->log()->notice('Opening browser to start GitHub App registration...');
+        $this->log()->notice('If your browser does not open, visit: {url}', ['url' => $localBaseUrl]);
+
+        try {
+            $this->getContainer()
+                ->get(LocalMachineHelper::class)
+                ->openUrl($localBaseUrl);
+        } catch (\Exception $e) {
+            $this->log()->warning('Could not open browser automatically: ' . $e->getMessage());
+        }
+
+        $this->log()->notice('Waiting for GHES callback (up to {minutes} minutes)...', [
+            'minutes' => (int) (self::CALLBACK_TIMEOUT / 60),
+        ]);
+
+        if (!$this->waitForFlagFile($flagFile, self::CALLBACK_TIMEOUT)) {
+            throw new TerminusException(
+                'GHES callback was not received within {timeout} seconds. Please try again.',
+                ['timeout' => self::CALLBACK_TIMEOUT]
+            );
+        }
+
+        $this->log()->notice('Callback received from GHES.');
+        $this->log()->notice('');
+        $this->log()->notice('A JSON response should now be visible in your browser.');
+        $this->log()->notice('Copy the entire JSON and paste it below.');
+        $this->log()->notice('');
+
+        $credentialsJson = $this->promptForJson();
+        $credentials = json_decode($credentialsJson, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new TerminusException('Invalid JSON: ' . json_last_error_msg());
+        }
+
+        $this->validateCredentials($credentials);
+
+        $provisionPayload = [
+            'hostname' => $hostname,
+            'app_id' => (string) ($credentials['id'] ?? ''),
+            'slug' => $credentials['slug'] ?? '',
+            'name' => $credentials['name'] ?? '',
+            'client_id' => $credentials['client_id'] ?? '',
+            'client_secret' => $credentials['client_secret'] ?? '',
+            'webhook_secret' => $credentials['webhook_secret'] ?? '',
+            'pem' => $credentials['pem'] ?? '',
+        ];
+
+        $this->log()->notice('Provisioning GHES instance...');
+        $result = $this->getVcsClient()->provision($provisionPayload);
+
+        $this->stopServer();
+        @unlink($serverScript);
+
+        $vcsHostId = $result['vcs_host_id'] ?? $result['data']->vcs_host_id ?? 'unknown';
+        $slug = $provisionPayload['slug'];
+
+        $this->log()->notice('');
+        $this->log()->notice('========================================');
+        $this->log()->notice(' GHES Instance Registered Successfully!');
+        $this->log()->notice('========================================');
+        $this->log()->notice(' VCS Host ID:  {id}', ['id' => $vcsHostId]);
+        $this->log()->notice(' App Name:     {name}', ['name' => $provisionPayload['name']]);
+        $this->log()->notice(' App ID:       {id}', ['id' => $provisionPayload['app_id']]);
+        $this->log()->notice(' Slug:         {slug}', ['slug' => $slug]);
+        $this->log()->notice(' Settings URL: {url}', ['url' => "{$ghesBaseUrl}/settings/apps/{$slug}"]);
+        $this->log()->notice('========================================');
+    }
+
+    private function sanitizeHostname(string $hostname): string
+    {
+        $hostname = preg_replace('#^https?://#', '', $hostname);
+        $hostname = rtrim($hostname, '/');
+
+        if (empty($hostname) || !preg_match('/^[a-zA-Z0-9]([a-zA-Z0-9\-\.]*[a-zA-Z0-9])?$/', $hostname)) {
+            throw new TerminusException(
+                'Invalid hostname: {hostname}. Provide a valid GHES hostname (e.g. ghes.example.com).',
+                ['hostname' => $hostname]
+            );
+        }
+
+        return $hostname;
+    }
+
+    private function findAvailablePort(): int
+    {
+        $socket = stream_socket_server("tcp://127.0.0.1:0");
+        if ($socket === false) {
+            throw new TerminusException('Cannot find an available port on localhost.');
+        }
+        $address = stream_socket_get_name($socket, false);
+        fclose($socket);
+        return (int) substr(strrchr($address, ':'), 1);
+    }
+
+    private function createServerScript(string $ghesBaseUrl, string $manifestJson, string $flagFile): string
+    {
+        $escapedManifest = htmlspecialchars($manifestJson, ENT_QUOTES, 'UTF-8');
+        $escapedGhesUrl = htmlspecialchars($ghesBaseUrl, ENT_QUOTES, 'UTF-8');
+
+        $scriptPath = sys_get_temp_dir() . '/terminus_ghes_server_' . bin2hex(random_bytes(8)) . '.php';
+
+        $formAction = "{$ghesBaseUrl}/settings/apps/new";
+
+        $php = <<<'SERVERSCRIPT'
+<?php
+$requestUri = $_SERVER['REQUEST_URI'] ?? '/';
+$path = parse_url($requestUri, PHP_URL_PATH);
+
+if ($path === '/callback') {
+    parse_str($_SERVER['QUERY_STRING'] ?? '', $query);
+    $code = $query['code'] ?? '';
+    if (empty($code)) {
+        http_response_code(400);
+        echo 'Missing code parameter.';
+        exit;
+    }
+    file_put_contents('FLAG_FILE', 'done');
+
+    $convUrl = htmlspecialchars('GHES_BASE_URL' . '/api/v3/app-manifests/' . $code . '/conversions', ENT_QUOTES, 'UTF-8');
+    echo <<<HTML
+<!DOCTYPE html>
+<html><head><title>GHES Registration</title></head><body>
+<h2>Exchanging code for app credentials...</h2>
+<p>This page will submit to your GHES instance. After it responds, <strong>copy the entire JSON</strong> and paste it into your terminal.</p>
+<form id="conv" method="post" action="{$convUrl}">
+  <input type="submit" value="Exchange Code Now" style="font-size:1.2em;padding:10px 20px;">
+</form>
+<script>setTimeout(function(){document.getElementById("conv").submit();},2000);</script>
+</body></html>
+HTML;
+    exit;
+}
+
+echo <<<'HTML'
+<!DOCTYPE html>
+<html><head><title>GHES Registration</title></head><body>
+<h2>Registering GitHub App</h2>
+<p>Redirecting to your GHES instance...</p>
+<form id="manifest-form" method="post" action="FORM_ACTION">
+  <input type="hidden" name="manifest" value="ESCAPED_MANIFEST">
+  <input type="submit" value="Create GitHub App" style="font-size:1.2em;padding:10px 20px;">
+</form>
+<script>document.getElementById("manifest-form").submit();</script>
+</body></html>
+HTML;
+SERVERSCRIPT;
+
+        $php = str_replace('FLAG_FILE', addcslashes($flagFile, "'\\"), $php);
+        $php = str_replace("'GHES_BASE_URL'", "'" . addcslashes($ghesBaseUrl, "'\\") . "'", $php);
+        $php = str_replace('FORM_ACTION', htmlspecialchars($formAction, ENT_QUOTES, 'UTF-8'), $php);
+        $php = str_replace('ESCAPED_MANIFEST', $escapedManifest, $php);
+
+        file_put_contents($scriptPath, $php);
+
+        return $scriptPath;
+    }
+
+    private function startServer(int $port, string $scriptPath): void
+    {
+        $this->serverProcess = new Process(['php', '-S', "127.0.0.1:{$port}", $scriptPath]);
+        $this->serverProcess->start();
+
+        usleep(300000);
+
+        if (!$this->serverProcess->isRunning()) {
+            throw new TerminusException('Failed to start local HTTP server.');
+        }
+
+        $this->log()->debug('Local server started on port {port}', ['port' => $port]);
+    }
+
+    private function stopServer(): void
+    {
+        if (isset($this->serverProcess) && $this->serverProcess !== null && $this->serverProcess->isRunning()) {
+            $this->serverProcess->stop(0);
+        }
+        $this->serverProcess = null;
+    }
+
+    private function waitForFlagFile(string $flagFile, int $timeout): bool
+    {
+        $start = time();
+        while (true) {
+            if (file_exists($flagFile)) {
+                @unlink($flagFile);
+                return true;
+            }
+            if ((time() - $start) > $timeout) {
+                return false;
+            }
+            usleep(500000);
+        }
+    }
+
+    private function promptForJson(): string
+    {
+        $handle = fopen('php://stdin', 'r');
+        if ($handle === false) {
+            throw new TerminusException('Unable to read from stdin.');
+        }
+
+        $this->output()->write('Paste JSON credentials: ');
+
+        $lines = [];
+        $braceDepth = 0;
+        $started = false;
+
+        while (($line = fgets($handle)) !== false) {
+            $trimmed = trim($line);
+            if (!$started && $trimmed === '') {
+                continue;
+            }
+
+            $lines[] = $line;
+            $braceDepth += substr_count($line, '{') - substr_count($line, '}');
+
+            if (!$started && str_contains($trimmed, '{')) {
+                $started = true;
+            }
+
+            if ($started && $braceDepth <= 0) {
+                break;
+            }
+        }
+
+        return implode('', $lines);
+    }
+
+    private function validateCredentials(array $credentials): void
+    {
+        $required = ['id', 'slug', 'client_id', 'client_secret', 'webhook_secret', 'pem'];
+        $missing = [];
+        foreach ($required as $field) {
+            if (empty($credentials[$field])) {
+                $missing[] = $field;
+            }
+        }
+        if (!empty($missing)) {
+            throw new TerminusException(
+                'Missing required fields in credentials: {fields}',
+                ['fields' => implode(', ', $missing)]
+            );
+        }
+    }
+}

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -51,7 +51,7 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
 
         $this->log()->notice('Fetching app manifest for {hostname}...', ['hostname' => $hostname]);
         $manifestResponse = $this->getVcsClient()->getProvisionManifest($hostname);
-        $manifest = (array) ($manifestResponse->data ?? $manifestResponse);
+        $manifest = (array) ($manifestResponse['data'] ?? $manifestResponse);
 
         $port = $this->findAvailablePort();
         $localBaseUrl = "http://127.0.0.1:{$port}";

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -37,18 +37,14 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
      * @command vcs:github-host:add
      * @aliases vcs-github-host-add
      *
-     * @option hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
+     * @param string $hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
-     * @usage --hostname=ghes.example.com Registers a GHES instance with Pantheon.
+     * @usage ghes.example.com Registers a GHES instance with Pantheon.
      */
-    public function add(array $options = ['hostname' => null])
+    public function add(string $hostname)
     {
-        $hostname = $options['hostname'] ?? null;
-        if (empty($hostname)) {
-            throw new TerminusException('The --hostname option is required.');
-        }
 
         $hostname = $this->sanitizeHostname($hostname);
         $ghesBaseUrl = "https://{$hostname}";

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -38,15 +38,17 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
      * @aliases vcs-github-host-add
      *
      * @param string $hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
-     * @param string $credentials_file Path to save/read the JSON credentials file
+     *
+     * @option credentials-file Path to save/read the JSON credentials file (default: creds.json)
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
      * @usage ghes.example.com Registers a GHES instance with Pantheon.
-     * @usage ghes.example.com /tmp/ghes-creds.json Registers using a custom credentials file path.
+     * @usage ghes.example.com --credentials-file=/tmp/ghes-creds.json Registers using a custom credentials file path.
      */
-    public function add(string $hostname, string $credentials_file = 'creds.json')
+    public function add(string $hostname, array $options = ['credentials-file' => 'creds.json'])
     {
+        $credentials_file = $options['credentials-file'];
 
         $hostname = $this->sanitizeHostname($hostname);
         $ghesBaseUrl = "https://{$hostname}";

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -38,12 +38,14 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
      * @aliases vcs-github-host-add
      *
      * @param string $hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
+     * @param string $credentials_file Path to save/read the JSON credentials file
      *
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      *
      * @usage ghes.example.com Registers a GHES instance with Pantheon.
+     * @usage ghes.example.com /tmp/ghes-creds.json Registers using a custom credentials file path.
      */
-    public function add(string $hostname)
+    public function add(string $hostname, string $credentials_file = 'creds.json')
     {
 
         $hostname = $this->sanitizeHostname($hostname);
@@ -89,13 +91,30 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
         $this->log()->notice('Callback received from GHES.');
         $this->log()->notice('');
         $this->log()->notice('A JSON response should now be visible in your browser.');
-        $this->log()->notice('Copy the entire JSON and paste it below.');
+        $this->log()->notice('Save the entire JSON to: {file}', ['file' => realpath('.') . '/' . $credentials_file]);
+        $this->log()->notice('Then press Enter to continue, or wait 5 minutes to auto-proceed.');
         $this->log()->notice('');
 
-        $credentialsJson = $this->promptForJson();
+        $this->waitForConfirmation(self::CALLBACK_TIMEOUT);
+
+        if (!file_exists($credentials_file)) {
+            throw new TerminusException(
+                'Credentials file not found: {file}',
+                ['file' => $credentials_file]
+            );
+        }
+
+        $credentialsJson = file_get_contents($credentials_file);
+        if ($credentialsJson === false) {
+            throw new TerminusException(
+                'Unable to read credentials file: {file}',
+                ['file' => $credentials_file]
+            );
+        }
+
         $credentials = json_decode($credentialsJson, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new TerminusException('Invalid JSON: ' . json_last_error_msg());
+            throw new TerminusException('Invalid JSON in {file}: ' . json_last_error_msg(), ['file' => $credentials_file]);
         }
 
         $this->validateCredentials($credentials);
@@ -258,38 +277,23 @@ SERVERSCRIPT;
         }
     }
 
-    private function promptForJson(): string
+    private function waitForConfirmation(int $timeout): void
     {
         $handle = fopen('php://stdin', 'r');
         if ($handle === false) {
-            throw new TerminusException('Unable to read from stdin.');
+            return;
         }
 
-        $this->output()->write('Paste JSON credentials: ');
+        stream_set_blocking($handle, false);
+        $start = time();
 
-        $lines = [];
-        $braceDepth = 0;
-        $started = false;
-
-        while (($line = fgets($handle)) !== false) {
-            $trimmed = trim($line);
-            if (!$started && $trimmed === '') {
-                continue;
+        while ((time() - $start) < $timeout) {
+            $line = fgets($handle);
+            if ($line !== false) {
+                return;
             }
-
-            $lines[] = $line;
-            $braceDepth += substr_count($line, '{') - substr_count($line, '}');
-
-            if (!$started && str_contains($trimmed, '{')) {
-                $started = true;
-            }
-
-            if ($started && $braceDepth <= 0) {
-                break;
-            }
+            usleep(500000);
         }
-
-        return implode('', $lines);
     }
 
     private function validateCredentials(array $credentials): void

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -116,7 +116,10 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
 
         $credentials = json_decode($credentialsJson, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new TerminusException('Invalid JSON in {file}: ' . json_last_error_msg(), ['file' => $credentials_file]);
+            throw new TerminusException(
+                'Invalid JSON in {file}: ' . json_last_error_msg(),
+                ['file' => $credentials_file]
+            );
         }
 
         $this->validateCredentials($credentials);
@@ -201,12 +204,14 @@ if ($path === '/callback') {
     }
     file_put_contents('FLAG_FILE', 'done');
 
-    $convUrl = htmlspecialchars('GHES_BASE_URL' . '/api/v3/app-manifests/' . $code . '/conversions', ENT_QUOTES, 'UTF-8');
+    $apiPath = '/api/v3/app-manifests/' . $code . '/conversions';
+    $convUrl = htmlspecialchars('GHES_BASE_URL' . $apiPath, ENT_QUOTES, 'UTF-8');
     echo <<<HTML
 <!DOCTYPE html>
 <html><head><title>GHES Registration</title></head><body>
 <h2>Exchanging code for app credentials...</h2>
-<p>This page will submit to your GHES instance. After it responds, <strong>copy the entire JSON</strong> and paste it into your terminal.</p>
+<p>This page will submit to your GHES instance.
+After it responds, <strong>save the JSON</strong> to the credentials file.</p>
 <form id="conv" method="post" action="{$convUrl}">
   <input type="submit" value="Exchange Code Now" style="font-size:1.2em;padding:10px 20px;">
 </form>

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pantheon\Terminus\Commands\Ghes;
+namespace Pantheon\Terminus\Commands\Vcs\GithubHost;
 
 use Pantheon\Terminus\Commands\TerminusCommand;
 use Pantheon\Terminus\Exceptions\TerminusException;
@@ -13,7 +13,7 @@ use Symfony\Component\Process\Process;
  * Registers a GitHub Enterprise Server instance with Pantheon EVCS
  * via the GitHub App manifest flow.
  */
-class RegisterCommand extends TerminusCommand implements RequestAwareInterface
+class AddCommand extends TerminusCommand implements RequestAwareInterface
 {
     use VcsClientAwareTrait;
 
@@ -34,8 +34,8 @@ class RegisterCommand extends TerminusCommand implements RequestAwareInterface
      *
      * @authorize
      *
-     * @command ghes:register
-     * @aliases ghes-register
+     * @command vcs:github-host:add
+     * @aliases vcs-github-host-add
      *
      * @option hostname GitHub Enterprise Server hostname (e.g. ghes.example.com)
      *
@@ -43,7 +43,7 @@ class RegisterCommand extends TerminusCommand implements RequestAwareInterface
      *
      * @usage --hostname=ghes.example.com Registers a GHES instance with Pantheon.
      */
-    public function register(array $options = ['hostname' => null])
+    public function add(array $options = ['hostname' => null])
     {
         $hostname = $options['hostname'] ?? null;
         if (empty($hostname)) {

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -51,7 +51,7 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
 
         $this->log()->notice('Fetching app manifest for {hostname}...', ['hostname' => $hostname]);
         $manifestResponse = $this->getVcsClient()->getProvisionManifest($hostname);
-        $manifest = $manifestResponse['data'] ?? $manifestResponse;
+        $manifest = (array) ($manifestResponse->data ?? $manifestResponse);
 
         $port = $this->findAvailablePort();
         $localBaseUrl = "http://127.0.0.1:{$port}";

--- a/src/Commands/Vcs/GithubHost/AddCommand.php
+++ b/src/Commands/Vcs/GithubHost/AddCommand.php
@@ -138,14 +138,12 @@ class AddCommand extends TerminusCommand implements RequestAwareInterface
         $this->stopServer();
         @unlink($serverScript);
 
-        $vcsHostId = $result['vcs_host_id'] ?? $result['data']->vcs_host_id ?? 'unknown';
         $slug = $provisionPayload['slug'];
 
         $this->log()->notice('');
         $this->log()->notice('========================================');
         $this->log()->notice(' GHES Instance Registered Successfully!');
         $this->log()->notice('========================================');
-        $this->log()->notice(' VCS Host ID:  {id}', ['id' => $vcsHostId]);
         $this->log()->notice(' App Name:     {name}', ['name' => $provisionPayload['name']]);
         $this->log()->notice(' App ID:       {id}', ['id' => $provisionPayload['app_id']]);
         $this->log()->notice(' Slug:         {slug}', ['slug' => $slug]);

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -383,6 +383,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Env\\ViewCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
+            'Pantheon\\Terminus\\Commands\\Ghes\\RegisterCommand',
             'Pantheon\\Terminus\\Commands\\Github\\GithubVcsCommand',
             'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\HTTPS\\RemoveCommand',

--- a/src/Terminus.php
+++ b/src/Terminus.php
@@ -383,7 +383,7 @@ EOD;
             'Pantheon\\Terminus\\Commands\\Env\\ViewCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WakeCommand',
             'Pantheon\\Terminus\\Commands\\Env\\WipeCommand',
-            'Pantheon\\Terminus\\Commands\\Ghes\\RegisterCommand',
+            'Pantheon\\Terminus\\Commands\\Vcs\\GithubHost\\AddCommand',
             'Pantheon\\Terminus\\Commands\\Github\\GithubVcsCommand',
             'Pantheon\\Terminus\\Commands\\HTTPS\\InfoCommand',
             'Pantheon\\Terminus\\Commands\\HTTPS\\RemoveCommand',

--- a/src/VcsApi/Client.php
+++ b/src/VcsApi/Client.php
@@ -388,7 +388,7 @@ class Client implements ConfigAwareInterface
         if ($config->get('host') && false !== strpos($config->get('host'), 'hermes.sandbox-')) {
             return str_replace('hermes', 'pantheonapi', $config->get('host'));
         }
-        if (!$host && strpos($config->get('host'), 'sandbox-') !== false) {
+        if ($config->get('host') && strpos($config->get('host'), 'sandbox-') !== false) {
             return $config->get('host');
         }
 

--- a/src/VcsApi/Client.php
+++ b/src/VcsApi/Client.php
@@ -276,6 +276,37 @@ class Client implements ConfigAwareInterface
     }
 
     /**
+     * Get the GHES app manifest for provisioning.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function getProvisionManifest(string $hostname): array
+    {
+        $request_options = [
+            'method' => 'GET',
+        ];
+
+        $path = 'provision/manifest?hostname=' . urlencode($hostname);
+
+        return $this->requestApi($path, $request_options, "X-Pantheon-Session");
+    }
+
+    /**
+     * Provision a GHES instance with app credentials.
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     */
+    public function provision(array $data): array
+    {
+        $request_options = [
+            'method' => 'POST',
+            'json' => $data,
+        ];
+
+        return $this->requestApi('provision', $request_options, "X-Pantheon-Session");
+    }
+
+    /**
      * Performs the request to API path.
      *
      * @param string $path


### PR DESCRIPTION
## Summary

- Add `terminus vcs:github-host:add <hostname>` command that orchestrates the GitHub App manifest flow for registering GHES instances with Pantheon EVCS
- Add `getProvisionManifest()` and `provision()` methods to VcsApi Client
- Register new command in Terminus.php

## How it works

1. Fetches app manifest from pantheonapi (`GET /vcs/v1/provision/manifest`)
2. Starts local HTTP server, opens browser to auto-POST manifest to GHES
3. Catches GHES callback, renders conversions page for code exchange
4. User saves JSON credentials from browser to a file (default: `creds.json`, configurable via `--credentials-file`)
5. User presses Enter (or waits 5 minutes to auto-proceed)
6. Sends credentials to provisioning service (`POST /vcs/v1/provision`)
7. Prints app name, app ID, slug, and GHES settings URL

## Usage

```
terminus vcs:github-host:add ghes.example.com
terminus vcs:github-host:add ghes.example.com --credentials-file=/tmp/ghes-creds.json
```


## Test plan

- [ ] `terminus list | grep vcs:github-host` — command visible
- [ ] `terminus vcs:github-host:add ghes.example.com` — end-to-end test against a GHES instance
- [ ] Verify local server starts and browser opens
- [ ] Verify callback handling and credentials file flow
- [ ] Verify provisioning API call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)