### PR TITLE
chore: Update version to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org)
 
-## 4.2.3-dev
+## 4.3.0 - 2026-05-26
+
+### Added
+
+- Add `vcs:github-host:add` command for GHES provisioning (#2838)
+- Add `--github-host` option to VCS commands for GHES support (#2840)
+
+### Changed
+
+- Update twig dependency (#2841)
 
 ## 4.2.2 - 2026-05-13
 

--- a/config/constants.yml
+++ b/config/constants.yml
@@ -7,7 +7,7 @@
 ---
 
 # App
-TERMINUS_VERSION: '4.2.3-dev'
+TERMINUS_VERSION: '4.3.0'
 
 # Connectivity
 TERMINUS_HOST:        'terminus.pantheon.io'


### PR DESCRIPTION
## Summary

Release Terminus 4.3.0

### Changes in this release

- Add `vcs:github-host:add` command for GHES provisioning (#2838)
- Add `--github-host` option to VCS commands for GHES support (#2840)
- Update twig dependency (#2841)