### PR TITLE
DEVX-7434: add rollbackable column to node:builds:list

### DIFF
--- a/src/Commands/Node/BuildsListCommand.php
+++ b/src/Commands/Node/BuildsListCommand.php
@@ -27,6 +27,8 @@ class BuildsListCommand extends SiteCommand implements SiteAwareInterface, Reque
      * The "active" field indicates whether the build is the one currently serving
      * traffic in the environment. After a rollback, the active build may differ
      * from the most recently deployed build.
+     * The "rollbackable" field indicates whether the build may still be rolled
+     * back (a deployed build within the rollback window).
      *
      * @authorize
      * @filter-output
@@ -41,6 +43,7 @@ class BuildsListCommand extends SiteCommand implements SiteAwareInterface, Reque
      *   commit: Commit
      *   deployed: Deployed
      *   active: Active
+     *   rollbackable: Rollbackable
      *   created: Created
      *   completed: Completed
      *

--- a/src/Models/Build.php
+++ b/src/Models/Build.php
@@ -29,6 +29,7 @@ class Build extends TerminusModel
             'commit' => $data->commit ?? '',
             'deployed' => !empty($data->release_id) ? 'true' : 'false',
             'active' => !empty($data->active) ? 'true' : 'false',
+            'rollbackable' => !empty($data->rollbackable) ? 'true' : 'false',
             'created' => $data->created,
         ];
     }


### PR DESCRIPTION
## DEVX-7434 — add `rollbackable` column to `node:builds:list`

Surfaces the tenant-controller `rollbackable` flag in the builds list so users can see which builds are still eligible for rollback. Enforcement stays on the backend — tenant-controller returns 422 for an out-of-window rollback, which `node:builds:rollback` already surfaces via `$data->error`.

### Changes
- `rollbackable` parsed in `Build::parseAttributes`.
- `rollbackable` added to the `node:builds:list` `@field-labels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
