### PR TITLE
fix(BUGS-11502): Guard null labels in Commit::serialize()

### DIFF
--- a/src/Models/Commit.php
+++ b/src/Models/Commit.php
@@ -16,7 +16,7 @@ class Commit extends TerminusModel
         return [
             'datetime' => $this->get('datetime'),
             'author' => $this->get('author'),
-            'labels' => implode(', ', $this->get('labels')),
+            'labels' => implode(', ', $this->get('labels') ?? []),
             'hash' => $this->get('hash'),
             'message' => substr(
                 strtr(

--- a/tests/Unit/CommitTest.php
+++ b/tests/Unit/CommitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Models\Commit;
+
+class CommitTest extends TestCase
+{
+    public function testSerializeWithNullLabels()
+    {
+        $commit = new Commit((object) [
+            'datetime' => '2026-08-19T14:26:01Z',
+            'author' => 'Kevin Porras',
+            'labels' => null,
+            'hash' => '85df13055962be862ef5ffc691cfedb76af63a8c',
+            'message' => 'Update README.md',
+        ]);
+
+        $serialized = $commit->serialize();
+
+        $this->assertSame('', $serialized['labels']);
+    }
+
+    public function testSerializeWithLabels()
+    {
+        $commit = new Commit((object) [
+            'datetime' => '2026-08-19T14:26:01Z',
+            'author' => 'Kevin Porras',
+            'labels' => ['dev', 'test'],
+            'hash' => '85df13055962be862ef5ffc691cfedb76af63a8c',
+            'message' => 'Update README.md',
+        ]);
+
+        $serialized = $commit->serialize();
+
+        $this->assertSame('dev, test', $serialized['labels']);
+    }
+}


### PR DESCRIPTION
## Summary
- `terminus env:code-log` crashed with a PHP Fatal `TypeError` on eVCS sites because the code-log API returns `labels: null` (instead of `[]`) for commits, and `Commit::serialize()` called `implode(', ', $this->get('labels'))` directly on it.
- Fix guards the value with `?? []`, matching the null-guard convention used elsewhere in the codebase.

## Test plan
- [x] Reproduced the crash locally against a real eVCS site (`terminus env:code-log <evcs-site>.dev -v`)
- [x] Confirmed the fix resolves it — command now returns a normal table with an empty Labels column
- [x] Added `tests/Unit/CommitTest.php` covering `serialize()` with null labels and with populated labels
- [x] Full unit suite passes: `composer test:unit` (99 tests, 148 assertions)
- [x] Confirmed `composer test:unit` runs in CI (`.github/workflows/4.x.yml`) and will pick up the new test

Fixes BUGS-11502

🤖 Generated with [Claude Code](https://claude.com/claude-code)