### PR TITLE
fix(BUGS-11780): Avoid null backup schedule fields to fix TsvFormatter deprecation

### DIFF
--- a/src/Collections/Backups.php
+++ b/src/Collections/Backups.php
@@ -153,9 +153,9 @@ class Backups extends EnvironmentOwnedCollection
         $response      = $this->request->request($path);
         $response_data = (array)$response['data'];
         $data          = [
-            'daily_backup_hour' => null,
-            'expiry' => null,
-            'weekly_backup_day' => null,
+            'daily_backup_hour' => '',
+            'expiry' => '',
+            'weekly_backup_day' => '',
         ];
 
         $schedule_sample = array_shift($response_data);

--- a/src/Commands/Backup/Automatic/InfoCommand.php
+++ b/src/Commands/Backup/Automatic/InfoCommand.php
@@ -40,7 +40,7 @@ class InfoCommand extends TerminusCommand implements SiteAwareInterface
     public function getSchedule($site_env)
     {
         $schedule = $this->getEnv($site_env)->getBackups()->getBackupSchedule();
-        if (is_null($schedule['daily_backup_hour'])) {
+        if (empty($schedule['daily_backup_hour'])) {
             $this->log()->notice('Backups are not currently scheduled to be run.');
         }
         return new PropertyList($schedule);


### PR DESCRIPTION
## Summary
- `Backups::getBackupSchedule()` defaulted `daily_backup_hour`, `expiry`, and `weekly_backup_day` to `null` when an environment has no automatic backup schedule configured.
- Terminus's default output format falls back to `StringFormatter`, which reduces `PropertyList` data via `TsvFormatter::tsvEscape()`. Its `str_replace()` call chokes on a `null` field value, producing a PHP deprecation warning on `terminus backup:automatic:info` for any environment without a schedule.
- Default these fields to empty strings instead of `null`, and updated `InfoCommand::getSchedule()`'s check from `is_null()` to `empty()` to match.

BUGS ticket: https://getpantheon.atlassian.net/browse/BUGS-11780

## Test plan
- [x] `bin/terminus backup:automatic:info <site>.<env>` against an environment with no schedule — no deprecation warning, notice still logged
- [x] Verified `--format=table`, `--format=json`, `--format=yaml` all render cleanly with empty strings instead of nulls
- [x] `composer test:unit` — 99/99 passing