### PR TITLE
Use workspace-aware dashboard URLs

### DIFF
--- a/src/Commands/Dashboard/ViewCommand.php
+++ b/src/Commands/Dashboard/ViewCommand.php
@@ -41,12 +41,14 @@ class ViewCommand extends TerminusCommand implements SiteAwareInterface
      */
     public function view($site_env = null, array $options = ['print' => false])
     {
+        $dashboard_url = $this->getDashboardUrl($site_env);
         if ($options['print']) {
-            return $this->getDashboardUrl($site_env);
+            return $dashboard_url;
         }
+        $this->log()->notice($dashboard_url);
         $this->getContainer()
             ->get(LocalMachineHelper::class)
-            ->openUrl($this->getDashboardUrl($site_env));
+            ->openUrl($dashboard_url);
 
         return null;
     }

--- a/src/Commands/Site/CreateCommand.php
+++ b/src/Commands/Site/CreateCommand.php
@@ -353,7 +353,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
             // Output final success message
             $this->log()->notice('---');
             $this->log()->notice('Site "{site}" created successfully!', ['site' => $site->getName()]);
-            $dashboard_url = $this->buildDashboardUrl($site, $upstream, $org ? $org->id : null);
+            $dashboard_url = $site->dashboardUrl($org ? $org->id : null);
             $this->log()->notice('Pantheon Dashboard: {url}', ['url' => $dashboard_url]);
         } else {
             // This shouldn't happen if the create workflow succeeded and returned an ID, but good to handle.
@@ -850,7 +850,7 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         if ($target_repo_url) {
             $this->log()->notice('Repository: {url}', ['url' => $target_repo_url]);
         }
-        $dashboard_url = $this->buildDashboardUrl($site, $upstream, $pantheon_org->id);
+        $dashboard_url = $site->dashboardUrl($pantheon_org->id);
         $this->log()->notice('Pantheon Dashboard: {url}', ['url' => $dashboard_url]);
         if ($clone_repo) {
             $this->log()->notice('Code repository cloned successfully to the current directory.');
@@ -1045,30 +1045,5 @@ class CreateCommand extends SiteCommand implements RequestAwareInterface, SiteAw
         $this->getVcsClient()->installWithToken($post_data);
 
         return true;
-    }
-
-    /**
-     * Builds the dashboard URL for a site.
-     *
-     * @param Site $site The site object
-     * @param Upstream $upstream The upstream object to determine framework
-     * @param string|null $org_id Organization ID
-     * @return string Dashboard URL
-     */
-    protected function buildDashboardUrl(Site $site, Upstream $upstream, ?string $org_id = null): string
-    {
-        $site_id = $site->id;
-
-        // Determine site type based on framework
-        $framework = $upstream->get('framework');
-        $site_type = ($framework === 'nodejs') ? 'node-site' : 'cms-site';
-
-        // If org_id is provided, use the new workspace URL format
-        if ($org_id) {
-            return sprintf('https://dashboard.pantheon.io/workspace/%s/%s/%s', $org_id, $site_type, $site_id);
-        }
-
-        // Fallback to default dashboard URL if no org
-        return $site->dashboardUrl();
     }
 }

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -17,6 +17,8 @@ use Pantheon\Terminus\Friends\LocalCopiesTrait;
 use Pantheon\Terminus\Friends\OrganizationsInterface;
 use Pantheon\Terminus\Friends\OrganizationsTrait;
 use Pantheon\Terminus\Helpers\Utility\SiteFramework;
+use Pantheon\Terminus\Session\SessionAwareInterface;
+use Pantheon\Terminus\Session\SessionAwareTrait;
 
 /**
  * Class Site
@@ -25,11 +27,13 @@ use Pantheon\Terminus\Helpers\Utility\SiteFramework;
  */
 class Site extends TerminusModel implements
     ContainerAwareInterface,
-    OrganizationsInterface
+    OrganizationsInterface,
+    SessionAwareInterface
 {
     use ContainerAwareTrait;
     use OrganizationsTrait;
     use LocalCopiesTrait;
+    use SessionAwareTrait;
 
     /**
      *
@@ -165,12 +169,49 @@ class Site extends TerminusModel implements
     /**
      * Provides Pantheon Dashboard URL for this site
      *
+     * @param string|null $org_id Organization ID to use as the workspace. If omitted, it will be resolved
+     *   from the site's owner organization, then its supporting organizations, then the current user.
+     *
      * @return string
      */
-    public function dashboardUrl()
+    public function dashboardUrl(?string $org_id = null)
     {
         $config = $this->getConfig();
-        return "{$config->get('dashboard_protocol')}://{$config->get('dashboard_host')}/sites/{$this->id}";
+        $workspace_id = $org_id ?? $this->getWorkspaceId();
+        $site_type = $this->isNodejs() ? 'node-site' : 'cms-site';
+        return "{$config->get('dashboard_protocol')}://{$config->get('dashboard_host')}"
+            . "/workspace/{$workspace_id}/{$site_type}/{$this->id}";
+    }
+
+    /**
+     * Determines the workspace (organization) ID to use in this site's Dashboard URL.
+     *
+     * Preference order: the site's owner organization, then a supporting organization, then the
+     * current user's own (personal) workspace -- each only if the current user has access to it.
+     *
+     * @return string
+     */
+    private function getWorkspaceId(): string
+    {
+        $user = $this->session()->getUser();
+        $accessible_org_ids = array_map(
+            fn ($membership) => $membership->getOrganization()->id,
+            $user->getOrganizationMemberships()->all()
+        );
+
+        $owner_org_id = $this->get('organization');
+        if (!empty($owner_org_id) && in_array($owner_org_id, $accessible_org_ids, true)) {
+            return $owner_org_id;
+        }
+
+        foreach ($this->getOrganizationMemberships()->all() as $membership) {
+            $supporting_org_id = $membership->getOrganization()->id;
+            if (in_array($supporting_org_id, $accessible_org_ids, true)) {
+                return $supporting_org_id;
+            }
+        }
+
+        return $user->id;
     }
 
     /**

--- a/tests/Unit/SiteTest.php
+++ b/tests/Unit/SiteTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Pantheon\Terminus\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\Terminus\Collections\SiteOrganizationMemberships;
+use Pantheon\Terminus\Config\TerminusConfig;
+use Pantheon\Terminus\Models\Organization;
+use Pantheon\Terminus\Models\Site;
+use Pantheon\Terminus\Models\SiteOrganizationMembership;
+use Pantheon\Terminus\Models\User;
+use Pantheon\Terminus\Models\UserOrganizationMembership;
+use Pantheon\Terminus\Collections\UserOrganizationMemberships;
+use Pantheon\Terminus\Session\Session;
+
+class SiteTest extends TestCase
+{
+    private function createSite(
+        array $attributes,
+        array $userOrgIds,
+        array $siteSupportingOrgIds = []
+    ): Site {
+        $site = $this->getMockBuilder(Site::class)
+            ->setConstructorArgs([(object)array_merge(['id' => 'site-id'], $attributes)])
+            ->onlyMethods(['getOrganizationMemberships'])
+            ->getMock();
+
+        $config = $this->createMock(TerminusConfig::class);
+        $config->method('get')->willReturnMap([
+            ['dashboard_protocol', null, 'https'],
+            ['dashboard_host', null, 'dashboard.pantheon.io'],
+        ]);
+        $site->setConfig($config);
+
+        $user = $this->createMock(User::class);
+        $user->id = 'user-id';
+        $userMemberships = $this->createMock(UserOrganizationMemberships::class);
+        $userMemberships->method('all')->willReturn(array_map(
+            fn ($orgId) => $this->createMembership(UserOrganizationMembership::class, $orgId),
+            $userOrgIds
+        ));
+        $user->method('getOrganizationMemberships')->willReturn($userMemberships);
+
+        $session = $this->createMock(Session::class);
+        $session->method('getUser')->willReturn($user);
+        $site->setSession($session);
+
+        $siteMemberships = $this->createMock(SiteOrganizationMemberships::class);
+        $siteMemberships->method('all')->willReturn(array_map(
+            fn ($orgId) => $this->createMembership(SiteOrganizationMembership::class, $orgId),
+            $siteSupportingOrgIds
+        ));
+        $site->method('getOrganizationMemberships')->willReturn($siteMemberships);
+
+        return $site;
+    }
+
+    private function createMembership(string $class, string $orgId)
+    {
+        $org = $this->createMock(Organization::class);
+        $org->id = $orgId;
+        $membership = $this->createMock($class);
+        $membership->method('getOrganization')->willReturn($org);
+        return $membership;
+    }
+
+    public function testDashboardUrlUsesOwnerOrgWhenAccessible()
+    {
+        $site = $this->createSite(
+            ['organization' => 'owner-org', 'framework' => 'wordpress'],
+            ['owner-org', 'other-org']
+        );
+
+        $this->assertSame(
+            'https://dashboard.pantheon.io/workspace/owner-org/cms-site/site-id',
+            $site->dashboardUrl()
+        );
+    }
+
+    public function testDashboardUrlFallsBackToSupportingOrgWhenOwnerOrgNotAccessible()
+    {
+        $site = $this->createSite(
+            ['organization' => 'inaccessible-org', 'framework' => 'nodejs'],
+            ['user-org'],
+            ['other-supporting-org', 'user-org']
+        );
+
+        $this->assertSame(
+            'https://dashboard.pantheon.io/workspace/user-org/node-site/site-id',
+            $site->dashboardUrl()
+        );
+    }
+
+    public function testDashboardUrlFallsBackToUserIdWhenNoAccessibleOrg()
+    {
+        $site = $this->createSite(
+            ['organization' => null, 'framework' => 'wordpress'],
+            []
+        );
+
+        $this->assertSame(
+            'https://dashboard.pantheon.io/workspace/user-id/cms-site/site-id',
+            $site->dashboardUrl()
+        );
+    }
+
+    public function testDashboardUrlUsesExplicitOrgIdHintWithoutResolution()
+    {
+        $site = $this->createSite(
+            ['organization' => null, 'framework' => 'wordpress'],
+            []
+        );
+
+        $this->assertSame(
+            'https://dashboard.pantheon.io/workspace/hinted-org/cms-site/site-id',
+            $site->dashboardUrl('hinted-org')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `dashboard:view` and site creation now build the new `dashboard.pantheon.io/workspace/{org}/{cms-site|node-site}/{site}` URL format instead of the legacy `/sites/{id}` path.
- The workspace org is resolved from the site's owner org, then a supporting org, then the current user, checking at each step that the current user actually has access to that org.
- `dashboard:view` now also prints the resolved URL before opening it in the browser.
- Removed `CreateCommand::buildDashboardUrl()`, a duplicate of the same URL-building logic, in favor of the shared `Site::dashboardUrl()`.

## Test plan
- [x] `vendor/bin/phpunit --configuration phpunit-unit.xml` passes (103 tests)
- [x] `vendor/bin/phpcs --standard=phpcs_ruleset.xml` clean on changed files
- [x] New unit tests in `tests/Unit/SiteTest.php` cover owner-org, supporting-org fallback, user-id fallback, and explicit-org-hint cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)